### PR TITLE
Rename endpoints to use dash instead of underscore, and cleanup

### DIFF
--- a/app/routers/brain_region.py
+++ b/app/routers/brain_region.py
@@ -57,7 +57,7 @@ def get(db: SessionDep, flat: bool = False) -> Response:  # noqa: FBT001, FBT002
 
 
 @router.get("/{id_}", response_model=BrainRegionRead)
-def read_reconstruction_morphology(db: SessionDep, id_: int):
+def read_brain_region(db: SessionDep, id_: int):
     with ensure_result(error_message="License not found"):
         row = db.query(BrainRegion).filter(BrainRegion.id == id_).one()
     return row

--- a/app/routers/brain_region.py
+++ b/app/routers/brain_region.py
@@ -53,7 +53,7 @@ def get(db: SessionDep, flat: bool = False) -> Response:  # noqa: FBT001, FBT002
 
 @router.get("/{id_}", response_model=BrainRegionRead)
 def read_brain_region(db: SessionDep, id_: int):
-    with ensure_result(error_message="License not found"):
+    with ensure_result(error_message="Brain region not found"):
         row = db.query(BrainRegion).filter(BrainRegion.id == id_).one()
     return BrainRegionRead.model_validate(row)
 

--- a/app/routers/brain_region.py
+++ b/app/routers/brain_region.py
@@ -7,12 +7,7 @@ from sqlalchemy import text
 from app.db.model import BrainRegion
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
-from app.schemas.base import (
-    BrainRegionCreate,
-)
-from app.schemas.morphology import (
-    BrainRegionRead,
-)
+from app.schemas.base import BrainRegionCreate, BrainRegionRead
 
 HIERARCHY = (Path(__file__).parent.parent / "static/brain-regions-tree.json").open().read()
 
@@ -60,13 +55,13 @@ def get(db: SessionDep, flat: bool = False) -> Response:  # noqa: FBT001, FBT002
 def read_brain_region(db: SessionDep, id_: int):
     with ensure_result(error_message="License not found"):
         row = db.query(BrainRegion).filter(BrainRegion.id == id_).one()
-    return row
+    return BrainRegionRead.model_validate(row)
 
 
 @router.post("/", response_model=BrainRegionRead)
 def create_brain_region(brain_region: BrainRegionCreate, db: SessionDep):
-    db_brain_region = BrainRegion(**brain_region.model_dump())
-    db.add(db_brain_region)
+    row = BrainRegion(**brain_region.model_dump())
+    db.add(row)
     db.commit()
-    db.refresh(db_brain_region)
-    return db_brain_region
+    db.refresh(row)
+    return row

--- a/app/routers/contribution.py
+++ b/app/routers/contribution.py
@@ -28,18 +28,11 @@ def read_contributions(
     )
 
 
-@router.get(
-    "/{contribution_id}",
-    response_model=ContributionRead,
-)
-def read_contribution(
-    contribution_id: int, project_context: VerifiedProjectContextHeader, db: SessionDep
-):
+@router.get("/{id_}", response_model=ContributionRead)
+def read_contribution(id_: int, project_context: VerifiedProjectContextHeader, db: SessionDep):
     with ensure_result(error_message="Contribution not found"):
         row = constrain_to_accessible_entities(
-            db.query(Contribution)
-            .filter(Contribution.id == contribution_id)
-            .join(Contribution.entity),
+            db.query(Contribution).filter(Contribution.id == id_).join(Contribution.entity),
             project_context.project_id,
         ).one()
 

--- a/app/routers/contribution.py
+++ b/app/routers/contribution.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, HTTPException
-from sqlalchemy.orm import contains_eager
 
 from app.db.auth import constrain_entity_query_to_project, constrain_to_accessible_entities
 from app.db.model import Contribution, Entity
@@ -15,6 +14,20 @@ router = APIRouter(
 )
 
 
+@router.get("/", response_model=list[ContributionRead])
+def read_contributions(
+    project_context: VerifiedProjectContextHeader, db: SessionDep, skip: int = 0, limit: int = 10
+):
+    return (
+        constrain_to_accessible_entities(
+            db.query(Contribution).join(Entity), project_context.project_id
+        )
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
 @router.get(
     "/{contribution_id}",
     response_model=ContributionRead,
@@ -23,24 +36,12 @@ def read_contribution(
     contribution_id: int, project_context: VerifiedProjectContextHeader, db: SessionDep
 ):
     with ensure_result(error_message="Contribution not found"):
-        row = (
+        row = constrain_to_accessible_entities(
             db.query(Contribution)
             .filter(Contribution.id == contribution_id)
-            .join(Contribution.entity)
-            .options(
-                contains_eager(Contribution.entity).load_only(
-                    Entity.authorized_project_id, Entity.authorized_public
-                )
-            )
-            .one()
-        )
-
-    if (
-        not row.entity.authorized_public
-        and row.entity.authorized_project_id != project_context.project_id
-    ):
-        L.warning("Attempting to get an annotation for an entity the user does not have access to")
-        raise HTTPException(status_code=404, detail="contribution not found")
+            .join(Contribution.entity),
+            project_context.project_id,
+        ).one()
 
     return ContributionRead.model_validate(row)
 
@@ -67,17 +68,3 @@ def create_contribution(
     db.refresh(row)
 
     return row
-
-
-@router.get("/", response_model=list[ContributionRead])
-def read_contributions(
-    project_context: VerifiedProjectContextHeader, db: SessionDep, skip: int = 0, limit: int = 10
-):
-    return (
-        constrain_to_accessible_entities(
-            db.query(Contribution).join(Entity), project_context.project_id
-        )
-        .offset(skip)
-        .limit(limit)
-        .all()
-    )

--- a/app/routers/experimental_bouton_density.py
+++ b/app/routers/experimental_bouton_density.py
@@ -54,7 +54,7 @@ def read_experimental_bouton_density(
             .one()
         )
 
-    return ExperimentalBoutonDensityRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=ExperimentalBoutonDensityRead)

--- a/app/routers/experimental_bouton_density.py
+++ b/app/routers/experimental_bouton_density.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from app.db.auth import constrain_to_accessible_entities
 from app.db.model import (
@@ -7,14 +7,15 @@ from app.db.model import (
 )
 from app.dependencies.auth import VerifiedProjectContextHeader
 from app.dependencies.db import SessionDep
+from app.errors import ensure_result
 from app.schemas.density import (
     ExperimentalBoutonDensityCreate,
     ExperimentalBoutonDensityRead,
 )
 
 router = APIRouter(
-    prefix="/experimental_bouton_density",
-    tags=["experimental_bouton_density"],
+    prefix="/experimental-bouton-density",
+    tags=["experimental-bouton-density"],
 )
 
 
@@ -44,18 +45,16 @@ def read_experimental_bouton_density(
     experimental_bouton_density_id: int,
     db: SessionDep,
 ):
-    experimental_bouton_density = (
-        constrain_to_accessible_entities(
-            db.query(ExperimentalBoutonDensity), project_context.project_id
+    with ensure_result(error_message="ExperimentalBoutonDensity not found"):
+        row = (
+            constrain_to_accessible_entities(
+                db.query(ExperimentalBoutonDensity), project_context.project_id
+            )
+            .filter(ExperimentalBoutonDensity.id == experimental_bouton_density_id)
+            .one()
         )
-        .filter(ExperimentalBoutonDensity.id == experimental_bouton_density_id)
-        .first()
-    )
 
-    if experimental_bouton_density is None:
-        raise HTTPException(status_code=404, detail="experimental_bouton_density not found")
-
-    return ExperimentalBoutonDensityRead.model_validate(experimental_bouton_density)
+    return ExperimentalBoutonDensityRead.model_validate(row)
 
 
 @router.post("/", response_model=ExperimentalBoutonDensityRead)

--- a/app/routers/experimental_bouton_density.py
+++ b/app/routers/experimental_bouton_density.py
@@ -36,13 +36,10 @@ def read_experimental_bouton_densities(
     )
 
 
-@router.get(
-    "/{experimental_bouton_density_id}",
-    response_model=ExperimentalBoutonDensityRead,
-)
+@router.get("/{id_}", response_model=ExperimentalBoutonDensityRead)
 def read_experimental_bouton_density(
     project_context: VerifiedProjectContextHeader,
-    experimental_bouton_density_id: int,
+    id_: int,
     db: SessionDep,
 ):
     with ensure_result(error_message="ExperimentalBoutonDensity not found"):
@@ -50,11 +47,11 @@ def read_experimental_bouton_density(
             constrain_to_accessible_entities(
                 db.query(ExperimentalBoutonDensity), project_context.project_id
             )
-            .filter(ExperimentalBoutonDensity.id == experimental_bouton_density_id)
+            .filter(ExperimentalBoutonDensity.id == id_)
             .one()
         )
 
-    return row
+    return ExperimentalBoutonDensityRead.model_validate(row)
 
 
 @router.post("/", response_model=ExperimentalBoutonDensityRead)
@@ -68,10 +65,8 @@ def create_experimental_bouton_density(
     if density.brain_location:
         dump["brain_location"] = BrainLocation(**density.brain_location.model_dump())
 
-    db_experimental_bouton_density = ExperimentalBoutonDensity(
-        **dump, authorized_project_id=project_context.project_id
-    )
-    db.add(db_experimental_bouton_density)
+    row = ExperimentalBoutonDensity(**dump, authorized_project_id=project_context.project_id)
+    db.add(row)
     db.commit()
-    db.refresh(db_experimental_bouton_density)
-    return db_experimental_bouton_density
+    db.refresh(row)
+    return row

--- a/app/routers/experimental_neuron_density.py
+++ b/app/routers/experimental_neuron_density.py
@@ -51,7 +51,7 @@ def read_experimental_neuron_density(
             .one()
         )
 
-    return ExperimentalNeuronDensityRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=ExperimentalNeuronDensityRead)

--- a/app/routers/experimental_neuron_density.py
+++ b/app/routers/experimental_neuron_density.py
@@ -33,13 +33,10 @@ def read_experimental_neuron_densities(
     )
 
 
-@router.get(
-    "/{experimental_neuron_density_id}",
-    response_model=ExperimentalNeuronDensityRead,
-)
+@router.get("/{id_}", response_model=ExperimentalNeuronDensityRead)
 def read_experimental_neuron_density(
     project_context: VerifiedProjectContextHeader,
-    experimental_neuron_density_id: int,
+    id_: int,
     db: SessionDep,
 ):
     with ensure_result(error_message="ExperimentalNeuronDensity not found"):
@@ -47,11 +44,11 @@ def read_experimental_neuron_density(
             constrain_to_accessible_entities(
                 db.query(ExperimentalNeuronDensity), project_context.project_id
             )
-            .filter(ExperimentalNeuronDensity.id == experimental_neuron_density_id)
+            .filter(ExperimentalNeuronDensity.id == id_)
             .one()
         )
 
-    return row
+    return ExperimentalNeuronDensityRead.model_validate(row)
 
 
 @router.post("/", response_model=ExperimentalNeuronDensityRead)
@@ -65,10 +62,8 @@ def create_experimental_neuron_density(
     if density.brain_location:
         dump["brain_location"] = BrainLocation(**density.brain_location.model_dump())
 
-    db_experimental_neuron_density = ExperimentalNeuronDensity(
-        **dump, authorized_project_id=project_context.project_id
-    )
-    db.add(db_experimental_neuron_density)
+    row = ExperimentalNeuronDensity(**dump, authorized_project_id=project_context.project_id)
+    db.add(row)
     db.commit()
-    db.refresh(db_experimental_neuron_density)
-    return db_experimental_neuron_density
+    db.refresh(row)
+    return row

--- a/app/routers/experimental_synapses_per_connection.py
+++ b/app/routers/experimental_synapses_per_connection.py
@@ -33,13 +33,10 @@ def get(
     )
 
 
-@router.get(
-    "/{experimental_synapses_per_connection_id}",
-    response_model=ExperimentalSynapsesPerConnectionRead,
-)
+@router.get("/{id_}", response_model=ExperimentalSynapsesPerConnectionRead)
 def read_experimental_synapses_per_connection(
     project_context: VerifiedProjectContextHeader,
-    experimental_synapses_per_connection_id: int,
+    id_: int,
     db: SessionDep,
 ):
     with ensure_result(error_message="ExperimentalSynapsesPerConnection not found"):
@@ -48,11 +45,11 @@ def read_experimental_synapses_per_connection(
                 db.query(ExperimentalSynapsesPerConnection),
                 project_context.project_id,
             )
-            .filter(ExperimentalSynapsesPerConnection.id == experimental_synapses_per_connection_id)
+            .filter(ExperimentalSynapsesPerConnection.id == id_)
             .one()
         )
 
-    return row
+    return ExperimentalSynapsesPerConnectionRead.model_validate(row)
 
 
 @router.post("/", response_model=ExperimentalSynapsesPerConnectionRead)
@@ -65,10 +62,10 @@ def create_experimental_synapses_per_connection(
     if density.brain_location:
         dump["brain_location"] = BrainLocation(**density.brain_location.model_dump())
 
-    db_experimental_neuron_density = ExperimentalSynapsesPerConnection(
+    row = ExperimentalSynapsesPerConnection(
         **dump, authorized_project_id=project_context.project_id
     )
-    db.add(db_experimental_neuron_density)
+    db.add(row)
     db.commit()
-    db.refresh(db_experimental_neuron_density)
-    return db_experimental_neuron_density
+    db.refresh(row)
+    return row

--- a/app/routers/experimental_synapses_per_connection.py
+++ b/app/routers/experimental_synapses_per_connection.py
@@ -17,7 +17,7 @@ router = APIRouter(
 
 
 @router.get("/", response_model=list[ExperimentalSynapsesPerConnectionRead])
-def read_experimental_neuron_densities(
+def get(
     project_context: VerifiedProjectContextHeader,
     db: SessionDep,
     skip: int = 0,
@@ -37,7 +37,7 @@ def read_experimental_neuron_densities(
     "/{experimental_synapses_per_connection_id}",
     response_model=ExperimentalSynapsesPerConnectionRead,
 )
-def read_experimental_neuron_density(
+def read_experimental_synapses_per_connection(
     project_context: VerifiedProjectContextHeader,
     experimental_synapses_per_connection_id: int,
     db: SessionDep,
@@ -56,7 +56,7 @@ def read_experimental_neuron_density(
 
 
 @router.post("/", response_model=ExperimentalSynapsesPerConnectionRead)
-def create_experimental_neuron_density(
+def create_experimental_synapses_per_connection(
     project_context: VerifiedProjectContextHeader,
     density: ExperimentalSynapsesPerConnectionCreate,
     db: SessionDep,

--- a/app/routers/experimental_synapses_per_connection.py
+++ b/app/routers/experimental_synapses_per_connection.py
@@ -52,7 +52,7 @@ def read_experimental_neuron_density(
             .one()
         )
 
-    return ExperimentalSynapsesPerConnectionRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=ExperimentalSynapsesPerConnectionRead)

--- a/app/routers/license.py
+++ b/app/routers/license.py
@@ -1,14 +1,9 @@
 from fastapi import APIRouter
 
-from app.db.model import (
-    License,
-)
+from app.db.model import License
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
-from app.schemas.base import (
-    LicenseCreate,
-    LicenseRead,
-)
+from app.schemas.base import LicenseCreate, LicenseRead
 
 router = APIRouter(
     prefix="/license",
@@ -21,17 +16,17 @@ def read_licenses(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(License).offset(skip).limit(limit).all()
 
 
-@router.get("/{license_id}", response_model=LicenseRead)
-def read_license(license_id: int, db: SessionDep):
+@router.get("/{id_}", response_model=LicenseRead)
+def read_license(id_: int, db: SessionDep):
     with ensure_result(error_message="License not found"):
-        row = db.query(License).filter(License.id == license_id).one()
-    return row
+        row = db.query(License).filter(License.id == id_).one()
+    return LicenseRead.model_validate(row)
 
 
 @router.post("/", response_model=LicenseRead)
 def create_license(license: LicenseCreate, db: SessionDep):
-    db_license = License(name=license.name, description=license.description, label=license.label)
-    db.add(db_license)
+    row = License(name=license.name, description=license.description, label=license.label)
+    db.add(row)
     db.commit()
-    db.refresh(db_license)
-    return db_license
+    db.refresh(row)
+    return row

--- a/app/routers/license.py
+++ b/app/routers/license.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from app.db.model import (
     License,
 )
 from app.dependencies.db import SessionDep
+from app.errors import ensure_result
 from app.schemas.base import (
     LicenseCreate,
     LicenseRead,
@@ -22,10 +23,9 @@ def read_licenses(db: SessionDep, skip: int = 0, limit: int = 10):
 
 @router.get("/{license_id}", response_model=LicenseRead)
 def read_license(license_id: int, db: SessionDep):
-    license = db.query(License).filter(License.id == license_id).first()
-    if license is None:
-        raise HTTPException(status_code=404, detail="License not found")
-    return license
+    with ensure_result(error_message="License not found"):
+        row = db.query(License).filter(License.id == license_id).one()
+    return row
 
 
 @router.post("/", response_model=LicenseRead)

--- a/app/routers/morphology.py
+++ b/app/routers/morphology.py
@@ -26,8 +26,8 @@ from app.schemas.morphology import (
 )
 
 router = APIRouter(
-    prefix="/reconstruction_morphology",
-    tags=["reconstruction_morphology"],
+    prefix="/reconstruction-morphology",
+    tags=["reconstruction-morphology"],
 )
 
 

--- a/app/routers/morphology.py
+++ b/app/routers/morphology.py
@@ -44,19 +44,19 @@ class FacetQueryParams(TypedDict):
 
 
 @router.get(
-    "/{rm_id}",
+    "/{id_}",
     response_model=ReconstructionMorphologyRead | ReconstructionMorphologyAnnotationExpandedRead,
 )
 def read_reconstruction_morphology(
     db: SessionDep,
-    rm_id: int,
+    id_: int,
     project_context: VerifiedProjectContextHeader,
     expand: str | None = None,
 ):
     with ensure_result(error_message="ReconstructionMorphology not found"):
         query = constrain_to_accessible_entities(
             db.query(ReconstructionMorphology), project_context.project_id
-        ).filter(ReconstructionMorphology.id == rm_id)
+        ).filter(ReconstructionMorphology.id == id_)
 
         if expand and "morphology_feature_annotation" in expand:
             query = query.options(

--- a/app/routers/morphology_feature_annotation.py
+++ b/app/routers/morphology_feature_annotation.py
@@ -48,22 +48,15 @@ def read_morphology_feature_annotation_id(
     db: SessionDep,
 ):
     with ensure_result(error_message="MorphologyFeatureAnnotation not found"):
-        row = (
+        row = constrain_to_accessible_entities(
             db.query(MorphologyFeatureAnnotation)
             .filter(
                 MorphologyFeatureAnnotation.reconstruction_morphology_id
                 == morphology_feature_annotation_id
             )
-            .join(ReconstructionMorphology)
-            .one()
-        )
-
-    if (
-        not row.reconstruction_morphology.authorized_public
-        and row.reconstruction_morphology.authorized_project_id != project_context.project_id
-    ):
-        L.warning("Attempting to get an annotation for an entity the user does not have access to")
-        raise HTTPException(status_code=404, detail="Morphology annotation not found")
+            .join(ReconstructionMorphology),
+            project_context.project_id,
+        ).one()
 
     return row
 

--- a/app/routers/morphology_feature_annotation.py
+++ b/app/routers/morphology_feature_annotation.py
@@ -65,7 +65,7 @@ def read_morphology_feature_annotation_id(
         L.warning("Attempting to get an annotation for an entity the user does not have access to")
         raise HTTPException(status_code=404, detail="Morphology annotation not found")
 
-    return MorphologyFeatureAnnotationRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=MorphologyFeatureAnnotationRead)

--- a/app/routers/morphology_feature_annotation.py
+++ b/app/routers/morphology_feature_annotation.py
@@ -38,27 +38,21 @@ def read_morphology_feature_annotations(
     )
 
 
-@router.get(
-    "/{morphology_feature_annotation_id}",
-    response_model=MorphologyFeatureAnnotationRead,
-)
+@router.get("/{id_}", response_model=MorphologyFeatureAnnotationRead)
 def read_morphology_feature_annotation_id(
-    morphology_feature_annotation_id: int,
+    id_: int,
     project_context: VerifiedProjectContextHeader,
     db: SessionDep,
 ):
     with ensure_result(error_message="MorphologyFeatureAnnotation not found"):
         row = constrain_to_accessible_entities(
             db.query(MorphologyFeatureAnnotation)
-            .filter(
-                MorphologyFeatureAnnotation.reconstruction_morphology_id
-                == morphology_feature_annotation_id
-            )
+            .filter(MorphologyFeatureAnnotation.reconstruction_morphology_id == id_)
             .join(ReconstructionMorphology),
             project_context.project_id,
         ).one()
 
-    return row
+    return MorphologyFeatureAnnotationRead.model_validate(row)
 
 
 @router.post("/", response_model=MorphologyFeatureAnnotationRead)
@@ -84,13 +78,11 @@ def create_morphology_feature_annotation(
             detail=f"Cannot access entity {reconstruction_morphology_id}",
         )
 
-    db_morphology_feature_annotation = MorphologyFeatureAnnotation(
-        reconstruction_morphology_id=reconstruction_morphology_id
-    )
+    row = MorphologyFeatureAnnotation(reconstruction_morphology_id=reconstruction_morphology_id)
 
     for measurement in morphology_feature_annotation.measurements:
         db_measurement = MorphologyMeasurement()
-        db_morphology_feature_annotation.measurements.append(db_measurement)
+        row.measurements.append(db_measurement)
         db_measurement.measurement_of = measurement.measurement_of
 
         for serie in measurement.measurement_serie:
@@ -98,7 +90,7 @@ def create_morphology_feature_annotation(
                 MorphologyMeasurementSerieElement(**serie.model_dump())
             )
 
-    db.add(db_morphology_feature_annotation)
+    db.add(row)
     db.commit()
-    db.refresh(db_morphology_feature_annotation)
-    return db_morphology_feature_annotation
+    db.refresh(row)
+    return row

--- a/app/routers/organization.py
+++ b/app/routers/organization.py
@@ -20,7 +20,7 @@ def read_organizations(db: SessionDep, skip: int = 0, limit: int = 10):
 def read_organization(organization_id: int, db: SessionDep):
     with ensure_result(error_message="Organization not found"):
         row = db.query(Organization).filter(Organization.id == organization_id).one()
-    return OrganizationRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=OrganizationRead)

--- a/app/routers/organization.py
+++ b/app/routers/organization.py
@@ -16,17 +16,17 @@ def read_organizations(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Organization).offset(skip).limit(limit).all()
 
 
-@router.get("/{organization_id}", response_model=OrganizationRead)
-def read_organization(organization_id: int, db: SessionDep):
+@router.get("/{id_}", response_model=OrganizationRead)
+def read_organization(id_: int, db: SessionDep):
     with ensure_result(error_message="Organization not found"):
-        row = db.query(Organization).filter(Organization.id == organization_id).one()
-    return row
+        row = db.query(Organization).filter(Organization.id == id_).one()
+    return OrganizationRead.model_validate(row)
 
 
 @router.post("/", response_model=OrganizationRead)
 def create_organization(organization: OrganizationCreate, db: SessionDep):
-    db_organization = Organization(**organization.model_dump())
-    db.add(db_organization)
+    row = Organization(**organization.model_dump())
+    db.add(row)
     db.commit()
-    db.refresh(db_organization)
-    return db_organization
+    db.refresh(row)
+    return row

--- a/app/routers/person.py
+++ b/app/routers/person.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from app.db.model import Person
 from app.dependencies.db import SessionDep
+from app.errors import ensure_result
 from app.schemas.agent import PersonCreate, PersonRead
 
 router = APIRouter(
@@ -10,13 +11,17 @@ router = APIRouter(
 )
 
 
+@router.get("/", response_model=list[PersonRead])
+def read_persons(db: SessionDep, skip: int = 0, limit: int = 10):
+    return db.query(Person).offset(skip).limit(limit).all()
+
+
 @router.get("/{person_id}", response_model=PersonRead)
 def read_person(person_id: int, db: SessionDep):
-    person = db.query(Person).filter(Person.id == person_id).first()
+    with ensure_result(error_message="Person not found"):
+        row = db.query(Person).filter(Person.id == person_id).one()
 
-    if person is None:
-        raise HTTPException(status_code=404, detail="person not found")
-    return PersonRead.model_validate(person)
+    return row
 
 
 @router.post("/", response_model=PersonRead)
@@ -26,8 +31,3 @@ def create_person(person: PersonCreate, db: SessionDep):
     db.commit()
     db.refresh(db_person)
     return db_person
-
-
-@router.get("/", response_model=list[PersonRead])
-def read_persons(db: SessionDep, skip: int = 0, limit: int = 10):
-    return db.query(Person).offset(skip).limit(limit).all()

--- a/app/routers/person.py
+++ b/app/routers/person.py
@@ -16,18 +16,18 @@ def read_persons(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Person).offset(skip).limit(limit).all()
 
 
-@router.get("/{person_id}", response_model=PersonRead)
-def read_person(person_id: int, db: SessionDep):
+@router.get("/{id_}", response_model=PersonRead)
+def read_person(id_: int, db: SessionDep):
     with ensure_result(error_message="Person not found"):
-        row = db.query(Person).filter(Person.id == person_id).one()
+        row = db.query(Person).filter(Person.id == id_).one()
 
-    return row
+    return PersonRead.model_validate(row)
 
 
 @router.post("/", response_model=PersonRead)
 def create_person(person: PersonCreate, db: SessionDep):
-    db_person = Person(**person.model_dump())
-    db.add(db_person)
+    row = Person(**person.model_dump())
+    db.add(row)
     db.commit()
-    db.refresh(db_person)
-    return db_person
+    db.refresh(row)
+    return row

--- a/app/routers/role.py
+++ b/app/routers/role.py
@@ -16,20 +16,17 @@ def read_roles(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Role).offset(skip).limit(limit).all()
 
 
-@router.get("/{role_id}", response_model=RoleRead)
-def read_role(role_id: int, db: SessionDep):
+@router.get("/{id_}", response_model=RoleRead)
+def read_role(id_: int, db: SessionDep):
     with ensure_result(error_message="Role not found"):
-        row = db.query(Role).filter(Role.id == role_id).one()
-    return row
+        row = db.query(Role).filter(Role.id == id_).one()
+    return RoleRead.model_validate(row)
 
 
 @router.post("/", response_model=RoleRead)
 def create_role(role: RoleCreate, db: SessionDep):
-    db_role = Role(
-        name=role.name,
-        role_id=role.role_id,
-    )
-    db.add(db_role)
+    row = Role(name=role.name, role_id=role.role_id)
+    db.add(row)
     db.commit()
-    db.refresh(db_role)
-    return db_role
+    db.refresh(row)
+    return row

--- a/app/routers/role.py
+++ b/app/routers/role.py
@@ -12,12 +12,12 @@ router = APIRouter(
 
 
 @router.get("/", response_model=list[RoleRead])
-def read_role(db: SessionDep, skip: int = 0, limit: int = 10):
+def read_roles(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Role).offset(skip).limit(limit).all()
 
 
 @router.get("/{role_id}", response_model=RoleRead)
-def read_person(role_id: int, db: SessionDep):
+def read_role(role_id: int, db: SessionDep):
     with ensure_result(error_message="Role not found"):
         row = db.query(Role).filter(Role.id == role_id).one()
     return row

--- a/app/routers/species.py
+++ b/app/routers/species.py
@@ -17,12 +17,12 @@ router = APIRouter(
 
 
 @router.get("/", response_model=list[SpeciesRead])
-def read_role(db: SessionDep, skip: int = 0, limit: int = 10):
+def get(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Species).offset(skip).limit(limit).all()
 
 
 @router.get("/{role_id}", response_model=SpeciesRead)
-def read_person(role_id: int, db: SessionDep):
+def read_species(role_id: int, db: SessionDep):
     with ensure_result(error_message="Species not found"):
         row = db.query(Species).filter(Species.id == role_id).one()
     return row

--- a/app/routers/species.py
+++ b/app/routers/species.py
@@ -3,12 +3,7 @@ from fastapi import APIRouter
 from app.db.model import Species
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
-from app.schemas.base import (
-    SpeciesCreate,
-)
-from app.schemas.morphology import (
-    SpeciesRead,
-)
+from app.schemas.base import SpeciesCreate, SpeciesRead
 
 router = APIRouter(
     prefix="/species",
@@ -21,17 +16,17 @@ def get(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Species).offset(skip).limit(limit).all()
 
 
-@router.get("/{role_id}", response_model=SpeciesRead)
-def read_species(role_id: int, db: SessionDep):
+@router.get("/{id_}", response_model=SpeciesRead)
+def read_species(id_: int, db: SessionDep):
     with ensure_result(error_message="Species not found"):
-        row = db.query(Species).filter(Species.id == role_id).one()
-    return row
+        row = db.query(Species).filter(Species.id == id_).one()
+    return SpeciesRead.model_validate(row)
 
 
 @router.post("/", response_model=SpeciesRead)
 def create_species(species: SpeciesCreate, db: SessionDep):
-    db_species = Species(name=species.name, taxonomy_id=species.taxonomy_id)
-    db.add(db_species)
+    row = Species(name=species.name, taxonomy_id=species.taxonomy_id)
+    db.add(row)
     db.commit()
-    db.refresh(db_species)
-    return db_species
+    db.refresh(row)
+    return row

--- a/app/routers/species.py
+++ b/app/routers/species.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.db.model import Species
 from app.dependencies.db import SessionDep
+from app.errors import ensure_result
 from app.schemas.base import (
     SpeciesCreate,
 )
@@ -13,6 +14,18 @@ router = APIRouter(
     prefix="/species",
     tags=["species"],
 )
+
+
+@router.get("/", response_model=list[SpeciesRead])
+def read_role(db: SessionDep, skip: int = 0, limit: int = 10):
+    return db.query(Species).offset(skip).limit(limit).all()
+
+
+@router.get("/{role_id}", response_model=SpeciesRead)
+def read_person(role_id: int, db: SessionDep):
+    with ensure_result(error_message="Species not found"):
+        row = db.query(Species).filter(Species.id == role_id).one()
+    return SpeciesRead.model_validate(row)
 
 
 @router.post("/", response_model=SpeciesRead)

--- a/app/routers/species.py
+++ b/app/routers/species.py
@@ -25,7 +25,7 @@ def read_role(db: SessionDep, skip: int = 0, limit: int = 10):
 def read_person(role_id: int, db: SessionDep):
     with ensure_result(error_message="Species not found"):
         row = db.query(Species).filter(Species.id == role_id).one()
-    return SpeciesRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=SpeciesRead)

--- a/app/routers/strain.py
+++ b/app/routers/strain.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.db.model import Strain
 from app.dependencies.db import SessionDep
+from app.errors import ensure_result
 from app.schemas.base import (
     StrainCreate,
 )
@@ -13,6 +14,18 @@ router = APIRouter(
     prefix="/strain",
     tags=["strain"],
 )
+
+
+@router.get("/", response_model=list[StrainRead])
+def read_organizations(db: SessionDep, skip: int = 0, limit: int = 10):
+    return db.query(Strain).offset(skip).limit(limit).all()
+
+
+@router.get("/{organization_id}", response_model=StrainRead)
+def read_organization(organization_id: int, db: SessionDep):
+    with ensure_result(error_message="Strain not found"):
+        row = db.query(Strain).filter(Strain.id == organization_id).one()
+    return StrainRead.model_validate(row)
 
 
 @router.post("/", response_model=StrainRead)

--- a/app/routers/strain.py
+++ b/app/routers/strain.py
@@ -17,12 +17,12 @@ router = APIRouter(
 
 
 @router.get("/", response_model=list[StrainRead])
-def read_organizations(db: SessionDep, skip: int = 0, limit: int = 10):
+def read_strains(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Strain).offset(skip).limit(limit).all()
 
 
 @router.get("/{organization_id}", response_model=StrainRead)
-def read_organization(organization_id: int, db: SessionDep):
+def read_strain(organization_id: int, db: SessionDep):
     with ensure_result(error_message="Strain not found"):
         row = db.query(Strain).filter(Strain.id == organization_id).one()
     return row

--- a/app/routers/strain.py
+++ b/app/routers/strain.py
@@ -25,7 +25,7 @@ def read_organizations(db: SessionDep, skip: int = 0, limit: int = 10):
 def read_organization(organization_id: int, db: SessionDep):
     with ensure_result(error_message="Strain not found"):
         row = db.query(Strain).filter(Strain.id == organization_id).one()
-    return StrainRead.model_validate(row)
+    return row
 
 
 @router.post("/", response_model=StrainRead)

--- a/app/routers/strain.py
+++ b/app/routers/strain.py
@@ -3,12 +3,7 @@ from fastapi import APIRouter
 from app.db.model import Strain
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
-from app.schemas.base import (
-    StrainCreate,
-)
-from app.schemas.morphology import (
-    StrainRead,
-)
+from app.schemas.base import StrainCreate, StrainRead
 
 router = APIRouter(
     prefix="/strain",
@@ -21,19 +16,17 @@ def read_strains(db: SessionDep, skip: int = 0, limit: int = 10):
     return db.query(Strain).offset(skip).limit(limit).all()
 
 
-@router.get("/{organization_id}", response_model=StrainRead)
-def read_strain(organization_id: int, db: SessionDep):
+@router.get("/{id_}", response_model=StrainRead)
+def read_strain(id_: int, db: SessionDep):
     with ensure_result(error_message="Strain not found"):
-        row = db.query(Strain).filter(Strain.id == organization_id).one()
-    return row
+        row = db.query(Strain).filter(Strain.id == id_).one()
+    return StrainRead.model_validate(row)
 
 
 @router.post("/", response_model=StrainRead)
 def create_strain(strain: StrainCreate, db: SessionDep):
-    db_strain = Strain(
-        name=strain.name, taxonomy_id=strain.taxonomy_id, species_id=strain.species_id
-    )
-    db.add(db_strain)
+    row = Strain(name=strain.name, taxonomy_id=strain.taxonomy_id, species_id=strain.species_id)
+    db.add(row)
     db.commit()
-    db.refresh(db_strain)
-    return db_strain
+    db.refresh(row)
+    return row

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -165,6 +165,7 @@ def test_authorization(client, brain_region_id, species_id, strain_id, person_id
     )
     assert response.status_code == 200
     inaccessible_annotation_id = response.json()["id"]
+
     response = client.get(
         f"{ROUTE}{inaccessible_annotation_id}",
         headers=BEARER_TOKEN | PROJECT_HEADERS,

--- a/tests/test_experimental_bouton_density.py
+++ b/tests/test_experimental_bouton_density.py
@@ -2,7 +2,7 @@ import pytest
 
 from .utils import PROJECT_HEADERS
 
-ROUTE = "/experimental_bouton_density/"
+ROUTE = "/experimental-bouton-density/"
 
 
 @pytest.mark.usefixtures("skip_project_check")

--- a/tests/test_experimental_neuron_density.py
+++ b/tests/test_experimental_neuron_density.py
@@ -2,7 +2,7 @@ import pytest
 
 from .utils import PROJECT_HEADERS
 
-ROUTE = "/experimental_neuron_density/"
+ROUTE = "/experimental-neuron-density/"
 
 
 @pytest.mark.usefixtures("skip_project_check")

--- a/tests/test_experimental_synapses_per_connection.py
+++ b/tests/test_experimental_synapses_per_connection.py
@@ -2,7 +2,7 @@ import pytest
 
 from .utils import PROJECT_HEADERS
 
-ROUTE = "/experimental_synapses_per_connection/"
+ROUTE = "/experimental-synapses-per-connection/"
 
 
 @pytest.mark.usefixtures("skip_project_check")

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,6 +1,9 @@
+ROUTE = "/license/"
+
+
 def test_create_license(client):
     response = client.post(
-        "/license/",
+        ROUTE,
         json={
             "name": "Test License",
             "description": "a license description",
@@ -13,18 +16,24 @@ def test_create_license(client):
     assert "id" in data
     assert data["description"] == "a license description"
     id_ = data["id"]
-    response = client.get(f"/license/{id_}")
+
+    response = client.get(f"{ROUTE}{id_}")
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == "Test License"
     assert data["description"] == "a license description"
-    response = client.get("/license/")
+
+    response = client.get(ROUTE)
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
     assert data[0]["name"] == "Test License"
     assert data[0]["description"] == "a license description"
 
-    # non-existant id
-    response = client.get("/license/424242")
+
+def test_missing_role(client):
+    response = client.get(f"{ROUTE}42424242")
     assert response.status_code == 404
+
+    response = client.get(f"{ROUTE}notanumber")
+    assert response.status_code == 422

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -6,7 +6,7 @@ from app.db.model import ReconstructionMorphology, Species, Strain
 
 from .utils import BEARER_TOKEN, PROJECT_HEADERS, add_db, create_reconstruction_morphology_id
 
-ROUTE = "/reconstruction_morphology/"
+ROUTE = "/reconstruction-morphology/"
 
 
 @pytest.mark.usefixtures("skip_project_check")
@@ -133,7 +133,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):
     )
 
     response = client.get(
-        "/reconstruction_morphology/",
+        ROUTE,
         headers=BEARER_TOKEN | PROJECT_HEADERS,
         params={"order_by": "+creation_date", "page": 0, "page_size": 3},
     )

--- a/tests/test_morphology_feature_annotation.py
+++ b/tests/test_morphology_feature_annotation.py
@@ -8,8 +8,8 @@ from .utils import (
     create_reconstruction_morphology_id,
 )
 
-ROUTE = "/morphology_feature_annotation/"
-MORPHOLOGY_ROUTE = "/reconstruction_morphology/"
+ROUTE = "/morphology-feature-annotation/"
+MORPHOLOGY_ROUTE = "/reconstruction-morphology/"
 
 
 @pytest.mark.usefixtures("skip_project_check")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,7 +61,7 @@ def create_reconstruction_morphology_id(
     description="Test Morphology Description",
 ):
     response = client.post(
-        "/reconstruction_morphology/",
+        "/reconstruction-morphology/",
         headers=headers,
         json={
             "name": name,


### PR DESCRIPTION
* Renames:
   experimental_bouton_density -> experimental-bouton-density
   experimental_neuron_density -> experimental-neuron-density
   experimental-synapses-per-connection -> experimental-synapses-per-connection
   reconstruction_morphology -> reconstruction-morphology
   morphology_feature_annotation -> /morphology-feature-annotation

* Added missing GET endpoints for Species and Strain
* Ordered routers as GET /, GET /{id}, POST
* used ensure_result where appropriate