### PR TITLE
Normalize singular/plural attributes

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -376,7 +376,7 @@ class EModel(DistributionMixin, SpeciesMixin, LocationMixin, Entity):
     __mapper_args__ = {"polymorphic_identity": "emodel"}  # noqa: RUF012
 
 
-class Mesh(DistributionMixin, LocationMixin, Entity):
+class Mesh(DistributionMixin, Entity):
     __tablename__ = "mesh"
     id: Mapped[int] = mapped_column(
         ForeignKey("entity.id"),
@@ -386,6 +386,10 @@ class Mesh(DistributionMixin, LocationMixin, Entity):
         nullable=False,
         autoincrement=True,
     )
+    brain_region_id: Mapped[int] = mapped_column(
+        ForeignKey("brain_region.id"), index=True, nullable=False
+    )
+    brain_region = relationship("BrainRegion", uselist=False)
     __mapper_args__ = {"polymorphic_identity": "mesh"}  # noqa: RUF012
 
 

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -376,7 +376,7 @@ class EModel(DistributionMixin, SpeciesMixin, LocationMixin, Entity):
     __mapper_args__ = {"polymorphic_identity": "emodel"}  # noqa: RUF012
 
 
-class Mesh(DistributionMixin, Entity):
+class Mesh(DistributionMixin, LocationMixin, Entity):
     __tablename__ = "mesh"
     id: Mapped[int] = mapped_column(
         ForeignKey("entity.id"),
@@ -386,10 +386,6 @@ class Mesh(DistributionMixin, Entity):
         nullable=False,
         autoincrement=True,
     )
-    brain_region_id: Mapped[int] = mapped_column(
-        ForeignKey("brain_region.id"), index=True, nullable=False
-    )
-    brain_region = relationship("BrainRegion", uselist=False)
     __mapper_args__ = {"polymorphic_identity": "mesh"}  # noqa: RUF012
 
 
@@ -423,7 +419,7 @@ class ReconstructionMorphology(LicensedMixin, LocationMixin, SpeciesMixin, Entit
 
     location: Mapped[PointLocation] = mapped_column(nullable=True)
 
-    mtype: Mapped[list["MTypeClass"]] = relationship(
+    mtypes: Mapped[list["MTypeClass"]] = relationship(
         primaryjoin="ReconstructionMorphology.id == MTypeClassification.entity_id",
         secondary="join(mtype_classification, mtype_class)",
         uselist=True,

--- a/app/routers/morphology.py
+++ b/app/routers/morphology.py
@@ -151,7 +151,7 @@ def morphology_query(
         "mtype": {"id": MTypeClass.id, "label": MTypeClass.pref_label},
         "species": {"id": Species.id, "label": Species.name},
         "strain": {"id": Strain.id, "label": Strain.name},
-        "contributions": {
+        "contribution": {
             "id": agent_alias.id,
             "label": agent_alias.pref_label,
             "type": agent_alias.type,
@@ -205,7 +205,7 @@ def morphology_query(
         .options(joinedload(ReconstructionMorphology.strain))
         .options(joinedload(ReconstructionMorphology.contributions).joinedload(Contribution.agent))
         .options(joinedload(ReconstructionMorphology.contributions).joinedload(Contribution.role))
-        .options(joinedload(ReconstructionMorphology.mtype))
+        .options(joinedload(ReconstructionMorphology.mtypes))
         .options(joinedload(ReconstructionMorphology.brain_region))
         .options(joinedload(ReconstructionMorphology.license))
         .options(raiseload("*"))

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -57,7 +57,7 @@ class ReconstructionMorphologyRead(
     strain: StrainRead | None
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
-    mtype: list[MTypeClassRead] | None
+    mtypes: list[MTypeClassRead] | None
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -116,8 +116,8 @@ def test_create_contribution(
     assert len(data[0]["contributions"]) == 2
 
     facets = response.json()["facets"]
-    assert len(facets["contributions"]) == 2
-    assert facets["contributions"] == [
+    assert len(facets["contribution"]) == 2
+    assert facets["contribution"] == [
         {"id": 2, "label": "ACME", "type": "organization", "count": 1},
         {"id": 1, "label": "jd courcol", "type": "person", "count": 1},
     ]
@@ -284,7 +284,7 @@ def test_contribution_facets(
     data = response.json()
     facets = data["facets"]
     assert facets == {
-        "contributions": [
+        "contribution": [
             {"count": 6, "id": 2, "label": "org_pref_label", "type": "organization"},
             {"count": 9, "id": 1, "label": "person_pref_label", "type": "person"},
         ],
@@ -309,7 +309,7 @@ def test_contribution_facets(
     data = response.json()
     facets = data["facets"]
     assert facets == {
-        "contributions": [{"count": 9, "id": 1, "label": "person_pref_label", "type": "person"}],
+        "contribution": [{"count": 9, "id": 1, "label": "person_pref_label", "type": "person"}],
         "mtype": [],
         "species": [{"count": 9, "id": 1, "label": "Test Species", "type": "species"}],
         "strain": [{"count": 9, "id": 1, "label": "Test Strain", "type": "strain"}],

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -160,7 +160,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "facets" in data
     facets = data["facets"]
     assert facets == {
-        "contributions": [],
+        "contribution": [],
         "mtype": [],
         "species": [
             {"id": 1, "label": "TestSpecies1", "count": 6, "type": "species"},
@@ -183,7 +183,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "facets" in data
     facets = data["facets"]
     assert facets == {
-        "contributions": [],
+        "contribution": [],
         "mtype": [],
         "species": [
             {"id": 1, "label": "TestSpecies1", "count": 6, "type": "species"},
@@ -207,7 +207,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "facets" in data
     facets = data["facets"]
     assert facets == {
-        "contributions": [],
+        "contribution": [],
         "mtype": [],
         "species": [{"id": 1, "label": "TestSpecies1", "count": 6, "type": "species"}],
         "strain": [{"id": 1, "label": "TestStrain1", "count": 6, "type": "strain"}],
@@ -245,7 +245,7 @@ def test_query_reconstruction_morphology_species_join(db, client, brain_region_i
     assert len(data["data"]) == data["pagination"]["total_items"]
     assert "facets" in data
     assert data["facets"] == {
-        "contributions": [],
+        "contribution": [],
         "mtype": [],
         "species": [{"id": 1, "label": "TestSpecies0", "count": 1, "type": "species"}],
         "strain": [{"id": 1, "label": "Strain0", "count": 1, "type": "strain"}],

--- a/tests/test_mtype.py
+++ b/tests/test_mtype.py
@@ -102,11 +102,11 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
     response = client.get(f"{ROUTE_MORPH}/{morph_id}", headers=BEARER_TOKEN | PROJECT_HEADERS)
     assert response.status_code == 200
     data = response.json()
-    assert "mtype" in data
-    mtype = data["mtype"]
-    assert len(mtype) == 2
+    assert "mtypes" in data
+    mtypes = data["mtypes"]
+    assert len(mtypes) == 2
 
-    assert mtype == [
+    assert mtypes == [
         {
             "id": 1,
             "pref_label": "m1",


### PR DESCRIPTION
Trying to be consistent and more intuitive on the user side.

- db model:
  - plural for relationships that are lists: contributions, mtypes, measurement_serie (although it should be series since serie doesn't exist)
  - singular in other cases
- api model (same as db model):
  - plural for attributes that are lists: contributions, mtypes, measurement_serie
  - singular in other cases
- filter model:
  - singular for the filter key: mtype, contribution (no changes needed)
- facets:
  - singular for the facets key: mtype, contribution
