### PR TITLE
Make facets optional in the morphology endpoint

### DIFF
--- a/app/routers/morphology.py
+++ b/app/routers/morphology.py
@@ -144,7 +144,7 @@ def morphology_query(
     pagination_request: PaginationQuery,
     morphology_filter: Annotated[MorphologyFilter, FilterDepends(MorphologyFilter)],
     search: str | None = None,
-    with_facets: bool = True,
+    with_facets: bool = False,
 ) -> ListResponse[ReconstructionMorphologyRead]:
     agent_alias = aliased(Agent, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = {

--- a/app/routers/morphology.py
+++ b/app/routers/morphology.py
@@ -138,11 +138,13 @@ def _get_facets(
 
 @router.get("")
 def morphology_query(
+    *,
     db: SessionDep,
     project_context: VerifiedProjectContextHeader,
     pagination_request: PaginationQuery,
     morphology_filter: Annotated[MorphologyFilter, FilterDepends(MorphologyFilter)],
     search: str | None = None,
+    with_facets: bool = True,
 ) -> ListResponse[ReconstructionMorphologyRead]:
     agent_alias = aliased(Agent, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = {
@@ -177,12 +179,16 @@ def morphology_query(
 
     filter_query = morphology_filter.filter(filter_query, aliases={Agent: agent_alias})
 
-    facets = _get_facets(
-        db,
-        filter_query,
-        name_to_facet_query_params=name_to_facet_query_params,
-        count_distinct_field=ReconstructionMorphology.id,
-    )
+    if with_facets:
+        facets = _get_facets(
+            db,
+            filter_query,
+            name_to_facet_query_params=name_to_facet_query_params,
+            count_distinct_field=ReconstructionMorphology.id,
+        )
+    else:
+        facets = None
+
     distinct_ids_subquery = (
         morphology_filter.sort(filter_query)
         .with_only_columns(ReconstructionMorphology)

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -107,6 +107,7 @@ def test_create_contribution(
 
     response = client.get(
         ROUTE_MORPH,
+        params={"with_facets": True},
         headers=BEARER_TOKEN | PROJECT_HEADERS,
     )
     response.raise_for_status()
@@ -277,7 +278,7 @@ def test_contribution_facets(
 
     response = client.get(
         ROUTE_MORPH,
-        params={"page_size": 10},
+        params={"with_facets": True, "page_size": 10},
         headers=BEARER_TOKEN | PROJECT_HEADERS,
     )
     data = response.json()
@@ -301,7 +302,8 @@ def test_contribution_facets(
     assert [len(item["contributions"]) for item in data["data"]] == expected_contribution_sizes
 
     response = client.get(
-        f"{ROUTE_MORPH}?contribution__pref_label=person_pref_label",
+        f"{ROUTE_MORPH}",
+        params={"with_facets": True, "contribution__pref_label": "person_pref_label"},
         headers=BEARER_TOKEN | PROJECT_HEADERS,
     )
     data = response.json()

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -146,26 +146,11 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):
     assert len(data) == 3
     assert [row["id"] for row in data] == [1, 2, 3]
 
-    response = client.get(ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS)
-    assert response.status_code == 200
-    data = response.json()
-
-    assert "facets" in data
-    facets = data["facets"]
-    assert facets == {
-        "contributions": [],
-        "mtype": [],
-        "species": [
-            {"id": 1, "label": "TestSpecies1", "count": 6, "type": "species"},
-            {"id": 2, "label": "TestSpecies2", "count": 5, "type": "species"},
-        ],
-        "strain": [
-            {"id": 1, "label": "TestStrain1", "count": 6, "type": "strain"},
-            {"id": 2, "label": "TestStrain2", "count": 5, "type": "strain"},
-        ],
-    }
-
-    response = client.get(f"{ROUTE}?search=Test", headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(
+        ROUTE,
+        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"with_facets": True},
+    )
     assert response.status_code == 200
     data = response.json()
 
@@ -185,7 +170,32 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):
     }
 
     response = client.get(
-        f"{ROUTE}?species__name=TestSpecies1", headers=BEARER_TOKEN | PROJECT_HEADERS
+        ROUTE,
+        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"search": "Test", "with_facets": True},
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "facets" in data
+    facets = data["facets"]
+    assert facets == {
+        "contributions": [],
+        "mtype": [],
+        "species": [
+            {"id": 1, "label": "TestSpecies1", "count": 6, "type": "species"},
+            {"id": 2, "label": "TestSpecies2", "count": 5, "type": "species"},
+        ],
+        "strain": [
+            {"id": 1, "label": "TestStrain1", "count": 6, "type": "strain"},
+            {"id": 2, "label": "TestStrain2", "count": 5, "type": "strain"},
+        ],
+    }
+
+    response = client.get(
+        ROUTE,
+        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"species__name": "TestSpecies1", "with_facets": True},
     )
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -66,7 +66,7 @@ def test_missing(client):
 
 
 @pytest.mark.usefixtures("skip_project_check")
-def test_query_reconstruction_morphology(db, client, brain_region_id):
+def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: PLR0915
     species1 = add_db(db, Species(name="TestSpecies1", taxonomy_id="0"))
     species2 = add_db(db, Species(name="TestSpecies2", taxonomy_id="1"))
 
@@ -103,8 +103,11 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):
         headers=BEARER_TOKEN | PROJECT_HEADERS,
     )
     assert response.status_code == 200
-    data = response.json()["data"]
-    assert len(data) == 10
+    response_json = response.json()
+    assert "facets" in response_json
+    assert "data" in response_json
+    assert response_json["facets"] is None
+    assert len(response_json["data"]) == 10
 
     response = client.get(
         ROUTE,
@@ -233,7 +236,11 @@ def test_query_reconstruction_morphology_species_join(db, client, brain_region_i
         ),
     )
 
-    response = client.get(ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(
+        ROUTE,
+        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"with_facets": True},
+    )
     data = response.json()
     assert len(data["data"]) == data["pagination"]["total_items"]
     assert "facets" in data

--- a/tests/test_morphology_feature_annotation.py
+++ b/tests/test_morphology_feature_annotation.py
@@ -91,8 +91,9 @@ def test_create_annotation(client, species_id, strain_id, brain_region_id):
     assert "morphology_feature_annotation" not in response.json()
 
     response = client.get(
-        f"{MORPHOLOGY_ROUTE}/{reconstruction_morphology_id}?expand=morphology_feature_annotation",
+        f"{MORPHOLOGY_ROUTE}/{reconstruction_morphology_id}",
         headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"expand": "morphology_feature_annotation"},
     )
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_mtype.py
+++ b/tests/test_mtype.py
@@ -122,7 +122,7 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
     ]
 
     response = client.get(
-        f"{ROUTE_MORPH}?mtype__pref_label=m1", headers=BEARER_TOKEN | PROJECT_HEADERS
+        ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS, params={"mtype__pref_label": "m1"}
     )
     assert response.status_code == 200
     facets = response.json()["facets"]

--- a/tests/test_mtype.py
+++ b/tests/test_mtype.py
@@ -87,7 +87,11 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
     add_db(db, MTypeClassification(entity_id=morph_id, mtype_class_id=mtype1.id))
     add_db(db, MTypeClassification(entity_id=morph_id, mtype_class_id=mtype2.id))
 
-    response = client.get(ROUTE_MORPH, headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(
+        ROUTE_MORPH,
+        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"with_facets": True},
+    )
     assert response.status_code == 200
     facets = response.json()["facets"]
     assert facets["mtype"] == [
@@ -122,7 +126,9 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
     ]
 
     response = client.get(
-        ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS, params={"mtype__pref_label": "m1"}
+        ROUTE_MORPH,
+        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        params={"with_facets": True, "mtype__pref_label": "m1"},
     )
     assert response.status_code == 200
     facets = response.json()["facets"]

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -27,7 +27,7 @@ def test_create_species(client):
     assert data == items
 
     # test filter
-    response = client.get(f"{ROUTE}", params={"name": "Test Species 1"})
+    response = client.get(ROUTE, params={"name": "Test Species 1"})
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 1

--- a/tests/test_strain.py
+++ b/tests/test_strain.py
@@ -34,21 +34,21 @@ def test_create_strain(client, species_id):
     assert data == items
 
     # test filter
-    response = client.get(f"{ROUTE}", params={"name": "Test Strain 1"})
+    response = client.get(ROUTE, params={"name": "Test Strain 1"})
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 1
     assert data == [items[1]]
 
     # test pagination
-    response = client.get(f"{ROUTE}", params={"page": 1, "page_size": 2})
+    response = client.get(ROUTE, params={"page": 1, "page_size": 2})
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 2
     assert data == [items[0], items[1]]
 
     # test pagination (page validation error)
-    response = client.get(f"{ROUTE}", params={"page": 0, "page_size": 2})
+    response = client.get(ROUTE, params={"page": 0, "page_size": 2})
     assert response.status_code == 422
     assert response.json() == {
         "details": [


### PR DESCRIPTION
Some clients don't need the facets (for example entitysdk), so we can avoid N quite complex queries (one for each facet) in those cases.
We could decide what can be the default value for the parameter `with_facets`.
By setting `with_facets=False` by default, we should be more confident that the facets are requested only when needed.
However, this PR has `with_facets=True` for backward compatibility.

This PR doesn't need to be merged yet, because I don't see a big difference in response times when the search is executed locally, but it can be used for simple benchmarks:
- ~360 ms for http://127.0.0.1:8000/reconstruction-morphology?page_size=1000&with_facets=true
- ~310 ms for http://127.0.0.1:8000/reconstruction-morphology?page_size=1000&with_facets=false