### PR TITLE
Return allowed query params

### DIFF
--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -20,9 +20,15 @@ def forbid_extra_query_params(
     but this option is intended for internal use, and it might be removed in the future.
     """
 
-    def traverse(dependant: Dependant, params: set) -> set:
-        """Update params from the query_params of all the dependencies."""
-        params.update(param.alias for param in dependant.query_params)
+    def traverse(dependant: Dependant, params: dict[str, bool]) -> dict[str, bool]:
+        """Update params from the query_params of all the dependencies.
+
+        Return a dict of all the known params and the boolean values of `include_in_schema`.
+        """
+        params.update(
+            (param.alias, getattr(param.field_info, "include_in_schema", True))
+            for param in dependant.query_params
+        )
         for dependency in dependant.dependencies:
             traverse(dependency, params)
         return params
@@ -30,17 +36,21 @@ def forbid_extra_query_params(
     if allow_extra_params:
         return
 
-    # allowed_params could be cached by (request.scope["method"], request.scope["path"])
-    allowed_params = traverse(request.scope["route"].dependant, params=set())
+    # possible improvement: cache allowed_params by request.scope["method"], request.scope["path"]
+    allowed_params = traverse(request.scope["route"].dependant, params={})
     query_params = set(request.query_params.keys())
-    if unknown_params := query_params - allowed_params:
+    if unknown_params := query_params.difference(allowed_params):
         raise ApiError(
             message="Unknown query parameters",
             error_code=ApiErrorCode.INVALID_REQUEST,
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             details={
                 "unknown_params": sorted(unknown_params),
-                "allowed_params": sorted(allowed_params - {"allow_extra_params"}),
+                "allowed_params": sorted(
+                    param
+                    for param, include_in_schema in allowed_params.items()
+                    if include_in_schema
+                ),
             },
         )
 

--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -38,7 +38,10 @@ def forbid_extra_query_params(
             message="Unknown query parameters",
             error_code=ApiErrorCode.INVALID_REQUEST,
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            details={"unknown_params": sorted(unknown_params)},
+            details={
+                "unknown_params": sorted(unknown_params),
+                "allowed_params": sorted(allowed_params - {"allow_extra_params"}),
+            },
         )
 
 

--- a/tests/routers/test_root.py
+++ b/tests/routers/test_root.py
@@ -44,7 +44,7 @@ def test_extra_query_params(client):
     assert response.json() == {
         "error_code": "INVALID_REQUEST",
         "message": "Unknown query parameters",
-        "details": {"unknown_params": ["foo"]},
+        "details": {"unknown_params": ["foo"], "allowed_params": []},
     }
 
 


### PR DESCRIPTION
Note that the params that are excluded from the json schema are intentionally not mentioned in the error response, assuming that they are internal or hidden for a reason.