### PR TITLE
Improve and add authentication to all the endpoints

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
 
     KEYCLOAK_URL: str = "https://example.openbluebrain.com/auth/realms/SBO"
     AUTH_CACHE_MAXSIZE: int = 128  # items
-    AUTH_CACHE_MAX_TTL: int = 600  # seconds
+    AUTH_CACHE_MAX_TTL: int = 300  # seconds
     AUTH_CACHE_INFO: bool = False
 
     S3_BUCKET_NAME: str = "entitycore-data-dev"

--- a/app/config.py
+++ b/app/config.py
@@ -35,7 +35,10 @@ class Settings(BaseSettings):
     LOG_CATCH: bool = True
     LOG_STANDARD_LOGGER: dict[str, str] = {"root": "INFO"}
 
-    KEYCLOAK_URL: str = "https://example.openbluebrain.com/auth/realms/SBO/"
+    KEYCLOAK_URL: str = "https://example.openbluebrain.com/auth/realms/SBO"
+    AUTH_CACHE_MAXSIZE: int = 128  # items
+    AUTH_CACHE_MAX_TTL: int = 600  # seconds
+    AUTH_CACHE_INFO: bool = False
 
     S3_BUCKET_NAME: str = "entitycore-data-dev"
     S3_MULTIPART_THRESHOLD: int = 5 * 1024**2  # bytes  # TODO: decide an appropriate value

--- a/app/db/auth.py
+++ b/app/db/auth.py
@@ -7,12 +7,12 @@ from sqlalchemy.orm import Query
 from app.db.model import Entity
 
 
-def constrain_to_accessible_entities(query: Query | Select, project_id: UUID4):
+def constrain_to_accessible_entities(query: Query | Select, project_id: UUID4 | None):
     """Ensure a query is filtered to rows that are viewable by the user."""
     query = query.where(
         or_(
             Entity.authorized_public == true(),
-            Entity.authorized_project_id == project_id,
+            Entity.authorized_project_id == project_id if project_id else true(),
         )
     )
 
@@ -21,10 +21,4 @@ def constrain_to_accessible_entities(query: Query | Select, project_id: UUID4):
 
 def constrain_entity_query_to_project(query: Query | Select, project_id: UUID4):
     """Ensure a query is filtered to rows in the user's project."""
-    query = query.where(
-        or_(
-            Entity.authorized_project_id == project_id,
-        )
-    )
-
-    return query
+    return query.where(Entity.authorized_project_id == project_id)

--- a/app/db/auth.py
+++ b/app/db/auth.py
@@ -1,7 +1,7 @@
 """Helpers to make sure queries are filtered to the allowed members."""
 
 from pydantic import UUID4
-from sqlalchemy import Select, or_, true
+from sqlalchemy import Select, false, or_, true
 from sqlalchemy.orm import Query
 
 from app.db.model import Entity
@@ -12,7 +12,7 @@ def constrain_to_accessible_entities(query: Query | Select, project_id: UUID4 | 
     query = query.where(
         or_(
             Entity.authorized_public == true(),
-            Entity.authorized_project_id == project_id if project_id else true(),
+            Entity.authorized_project_id == project_id if project_id else false(),
         )
     )
 

--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -1,103 +1,236 @@
+import hashlib
+import threading
+import time
+from datetime import UTC, datetime
 from typing import Annotated
+from uuid import UUID
 
+import cachetools
 import httpx
-from fastapi import Depends, Header, HTTPException
-from fastapi.security import (
-    HTTPAuthorizationCredentials,
-    HTTPBearer,
-)
+from fastapi import Depends, Header
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette.requests import Request
 
 from app.config import settings
+from app.errors import ApiError, ApiErrorCode, AuthErrorReason
 from app.logger import L
-from app.schemas.base import ProjectContext
+from app.schemas.auth import (
+    CacheKey,
+    DecodedToken,
+    UserContext,
+    UserContextWithProjectId,
+    UserInfoResponse,
+)
+from app.schemas.base import OptionalProjectContext
+from app.utils.http import deserialize_response, make_http_request
 
-AuthHeader: HTTPBearer = HTTPBearer(auto_error=True)
+# auto_error=False because of https://github.com/fastapi/fastapi/issues/10177
+AuthHeader: HTTPBearer = HTTPBearer(auto_error=False)
 
-KEYCLOAK_GROUPS_URL = settings.KEYCLOAK_URL + "protocol/openid-connect/userinfo"
-
-
-def _split_out_vlab_and_projects(groups: list[str]) -> list[ProjectContext]:
-    # "/proj/03ecd74b-a19e-4b3d-b737-5286a5fbea2d/6f945641-bc92-4e30-aa32-63be8eb9ca49/admin",
-    result = []
-    for group in groups:
-        if not group.startswith("/proj/"):
-            continue
-        parts = group[6:].split("/")
-        if len(parts) >= 3:  # noqa: PLR2004
-            # pydantic checks to make sure that the IDs are UUID4
-            result.append(ProjectContext(virtual_lab_id=parts[0], project_id=parts[1]))  # type: ignore[arg-type]
-    return result
+KEYCLOAK_GROUPS_URL = f"{settings.KEYCLOAK_URL}/protocol/openid-connect/userinfo"
 
 
-def _check_user_info(
-    project_context: ProjectContext,
+def _get_cache_key(
+    *,
+    project_context: OptionalProjectContext,
     token: HTTPAuthorizationCredentials,
-) -> bool:
-    with httpx.Client() as client:
-        tok = f"{token.scheme} {token.credentials}"
-        response = client.get(
-            KEYCLOAK_GROUPS_URL,
-            headers={"Authorization": tok},
+    **_,
+) -> CacheKey:
+    """Return the cache key for the given parameters.
+
+    The cache key includes also virtual-lab-id and project-id to force a new request to KeyCloak
+    when they change. This should avoid using a stale cache when a new project is created or
+    assigned to the user, and the user switches to that project.
+    """
+    return CacheKey(
+        virtual_lab_id=project_context.virtual_lab_id,
+        project_id=project_context.project_id,
+        scheme=token.scheme.lower(),
+        token_digest=hashlib.sha256(token.credentials.encode()).hexdigest(),
+    )
+
+
+def _get_cache_ttu(_key: CacheKey, value: UserContext, now: float) -> float:
+    """Calculate the expiration time of an item at the time of insertion into the cache.
+
+    Args:
+        _key: cache key.
+        value: cache value.
+        now: current value of the timer function.
+    """
+    expiration = now + settings.AUTH_CACHE_MAX_TTL
+    if value.is_authorized and value.expiration and value.expiration > now:
+        # consider the token expiration only if the UserContext si authorized
+        expiration = min(expiration, value.expiration)
+    L.opt(lazy=True).debug(
+        "Setting cache expiration to {} for {}",
+        lambda: datetime.fromtimestamp(expiration, tz=UTC).isoformat(),
+        value.model_dump_json,
+    )
+    return expiration
+
+
+@cachetools.cached(
+    cache=cachetools.TLRUCache(
+        maxsize=settings.AUTH_CACHE_MAXSIZE,
+        ttu=_get_cache_ttu,
+        timer=time.time,
+    ),
+    key=_get_cache_key,
+    lock=threading.Lock(),
+    info=settings.AUTH_CACHE_INFO,
+)
+def _check_user_info(
+    *,
+    project_context: OptionalProjectContext,
+    token: HTTPAuthorizationCredentials,
+    http_client: httpx.Client,
+) -> UserContext:
+    """Retrieve the user info from KeyCloak and check the correctness of ProjectContext.
+
+    Note that the result is cached, but exceptions are NOT cached.
+    """
+    decoded = DecodedToken.from_jwt(token)
+    if decoded and decoded.exp and decoded.exp < time.time():
+        # expired token, no need to call KeyCloak
+        return UserContext(
+            subject=decoded.sub,
+            email=decoded.email,
+            expiration=decoded.exp,
+            is_authorized=False,
+            virtual_lab_id=project_context.virtual_lab_id,
+            project_id=project_context.project_id,
+            auth_error_reason=AuthErrorReason.AUTH_TOKEN_EXPIRED,
         )
 
-        # response should look like:
-        # {
-        #  "email": "michael.gevaert@epfl.ch",
-        #  "email_verified": false,
-        #  "family_name": "Gevaert",
-        #  "given_name": "Mike",
-        #  "groups": [
-        #      "/BBP-USERS",
-        #      "/proj/$vlab_id/$project_id/admin",
-        #      [...]
-        #      "/vlab/$vlab_id/admin",
-        #      [...]
-        #  ],
-        #  "name": "Mike Gevaert",
-        #  "preferred_username": "mgeplf",
-        #  "sub": "9856a4d6-005d-4cf9-b272-00b34661ef73"
-        # }
+    http_status_errors = {
+        401: AuthErrorReason.NOT_AUTHENTICATED,
+        403: AuthErrorReason.NOT_AUTHORIZED,
+    }
+    response = make_http_request(
+        KEYCLOAK_GROUPS_URL,
+        method="GET",
+        headers={"Authorization": f"{token.scheme} {token.credentials}"},
+        http_client=http_client,
+        ignored_errors=set(http_status_errors),
+    )
 
-        if response.status_code != 200:  # noqa: PLR2004
-            L.warning("Keycloak returned an error: `{}`", response.text)
-            raise HTTPException(status_code=404, detail="Project not found")
-
-        data = response.json()
-        if "groups" not in data:
-            L.warning("Keycloak returned no `groups`: `{}`", response.text)
-            raise HTTPException(status_code=404, detail="Project not found")
-
-        project_contexts = _split_out_vlab_and_projects(data["groups"])
-
-        if any(ctx == project_context for ctx in project_contexts):
-            return True
-
-        L.warning(
-            "User attempted to use virtual_lab_id {} and project_id {}, but is only a member of {}",
-            project_context.virtual_lab_id,
-            project_context.project_id,
-            [f"{ctx.virtual_lab_id}/{ctx.project_id}" for ctx in project_contexts],
+    if response.status_code in http_status_errors:
+        return UserContext(
+            subject=decoded.sub if decoded else None,
+            email=decoded.email if decoded else None,
+            expiration=decoded.exp if decoded else None,
+            is_authorized=False,
+            virtual_lab_id=project_context.virtual_lab_id,
+            project_id=project_context.project_id,
+            auth_error_reason=http_status_errors[response.status_code],
         )
 
-    return False
+    user_info_response = deserialize_response(response, model_class=UserInfoResponse)
+    user_context = UserContext(
+        subject=user_info_response.sub,
+        email=user_info_response.email,
+        expiration=decoded.exp if decoded else None,
+        is_authorized=user_info_response.is_authorized_for(
+            virtual_lab_id=project_context.virtual_lab_id,
+            project_id=project_context.project_id,
+        ),
+        is_service_admin=user_info_response.is_service_admin(settings.APP_NAME),
+        virtual_lab_id=project_context.virtual_lab_id,
+        project_id=project_context.project_id,
+    )
+
+    if not user_context.is_authorized:
+        L.opt(lazy=True).info(
+            "User {sub} <{email}> attempted to use {virtual_lab_id=} {project_id=}, "
+            "but they're only a member of {groups}",
+            lambda: {
+                "sub": user_context.subject,
+                "email": user_context.email,
+                "virtual_lab_id": project_context.virtual_lab_id,
+                "project_id": project_context.project_id,
+                "groups": sorted(user_info_response.groups),
+            },
+        )
+
+    return user_context
 
 
-def verify_project_context(
-    project_context: Annotated[ProjectContext, Header()],
-    token: Annotated[HTTPAuthorizationCredentials, Depends(AuthHeader)],
-) -> ProjectContext:
-    """Ensures that the user is authenticated and authorized.
+def user_verified(
+    project_context: Annotated[OptionalProjectContext, Header()],
+    token: Annotated[HTTPAuthorizationCredentials | None, Depends(AuthHeader)],
+    request: Request,
+) -> UserContext:
+    """Ensure that the user is authenticated and authorized.
 
-    ie: as a member of the virtual_lab_id and project_id claimed in the header
+    The user must be a member of the virtual_lab_id and project_id claimed in the headers.
+    If only the virtual_lab_id specified, the user must be a member of the virtual_lab_id.
+    If neither is specified, it's enough that the auth token is valid.
     """
     if settings.APP_DISABLE_AUTH:
-        L.warning("Authentication is disabled")
-        return project_context
+        L.warning("Authentication is disabled: admin role granted, vlab and proj not verified")
+        return UserContext(
+            subject=UUID(int=0),
+            email=None,
+            expiration=None,
+            is_authorized=True,
+            is_service_admin=True,
+            virtual_lab_id=project_context.virtual_lab_id,
+            project_id=project_context.project_id,
+        )
 
-    if not _check_user_info(project_context=project_context, token=token):
-        raise HTTPException(status_code=404, detail="Project not found")
+    if not token:
+        raise ApiError(
+            message=AuthErrorReason.AUTH_TOKEN_MISSING,
+            error_code=ApiErrorCode.NOT_AUTHENTICATED,
+            http_status_code=401,
+        )
 
-    return project_context
+    user_context = _check_user_info(
+        project_context=project_context,
+        token=token,
+        http_client=request.state.http_client,
+    )
+
+    if not user_context.is_authorized:
+        match user_context.auth_error_reason:
+            case AuthErrorReason.NOT_AUTHORIZED:
+                raise ApiError(
+                    message=user_context.auth_error_reason,
+                    error_code=ApiErrorCode.NOT_AUTHORIZED,
+                    http_status_code=403,
+                )
+            case _:
+                raise ApiError(
+                    message=user_context.auth_error_reason or "",
+                    error_code=ApiErrorCode.NOT_AUTHENTICATED,
+                    http_status_code=401,
+                )
+
+    return user_context
 
 
-VerifiedProjectContextHeader = Annotated[ProjectContext, Depends(verify_project_context)]
+def user_with_project_id(user_context: "UserContextDep") -> UserContextWithProjectId:
+    """Ensure that the authenticated user has valid virtual_lab_id and project_id."""
+    if not user_context.virtual_lab_id or not user_context.project_id:
+        raise ApiError(
+            message="virtual-lab-id and project-id are required",
+            error_code=ApiErrorCode.NOT_AUTHORIZED,
+            http_status_code=403,
+        )
+    return UserContextWithProjectId.model_validate(user_context, from_attributes=True)
+
+
+def user_with_service_admin_role(user_context: "UserContextDep") -> UserContext:
+    """Ensure that the authenticated user has a service admin role."""
+    if not user_context.is_service_admin:
+        raise ApiError(
+            message="Service admin role required",
+            error_code=ApiErrorCode.NOT_AUTHORIZED,
+            http_status_code=403,
+        )
+    return user_context
+
+
+UserContextDep = Annotated[UserContext, Depends(user_verified)]
+UserContextWithProjectIdDep = Annotated[UserContextWithProjectId, Depends(user_with_project_id)]

--- a/app/errors.py
+++ b/app/errors.py
@@ -13,9 +13,19 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 from app.utils.enum import UpperStrEnum
 
 
+class AuthErrorReason(UpperStrEnum):
+    AUTH_TOKEN_MISSING = auto()
+    AUTH_TOKEN_EXPIRED = auto()
+    NOT_AUTHENTICATED = auto()
+    NOT_AUTHORIZED = auto()
+
+
 class ApiErrorCode(UpperStrEnum):
     """API Error codes."""
 
+    GENERIC_ERROR = auto()
+    NOT_AUTHENTICATED = auto()
+    NOT_AUTHORIZED = auto()
     INVALID_REQUEST = auto()
     ENTITY_NOT_FOUND = auto()
     ENTITY_FORBIDDEN = auto()
@@ -34,7 +44,7 @@ class ApiError(Exception):
 
     message: str
     error_code: ApiErrorCode
-    http_status_code: HTTPStatus = HTTPStatus.BAD_REQUEST
+    http_status_code: HTTPStatus | int = HTTPStatus.BAD_REQUEST
     details: Any = None
 
     def __repr__(self) -> str:

--- a/app/errors.py
+++ b/app/errors.py
@@ -15,6 +15,7 @@ from app.utils.enum import UpperStrEnum
 
 class AuthErrorReason(UpperStrEnum):
     AUTH_TOKEN_MISSING = auto()
+    AUTH_TOKEN_INVALID = auto()
     AUTH_TOKEN_EXPIRED = auto()
     NOT_AUTHENTICATED = auto()
     NOT_AUTHORIZED = auto()

--- a/app/repository/entity.py
+++ b/app/repository/entity.py
@@ -17,7 +17,7 @@ class EntityRepository(BaseRepository):
         self,
         entity_type: EntityType,
         entity_id: uuid.UUID,
-        project_id: uuid.UUID,
+        project_id: uuid.UUID | None,
     ) -> Entity:
         """Return a specific entity by type and id, readable by the given project.
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,7 +1,8 @@
 """Web api."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from app.dependencies.auth import user_verified
 from app.routers import (
     asset,
     brain_region,
@@ -23,31 +24,28 @@ from app.routers import (
     species,
     strain,
 )
-from app.routers.legacy import _search, files, resources, sbo
 
 router = APIRouter()
 router.include_router(root.router)
-router.include_router(asset.router)
-router.include_router(brain_region.router)
-router.include_router(cell_composition.router)
-router.include_router(contribution.router)
-router.include_router(experimental_bouton_density.router)
-router.include_router(experimental_neuron_density.router)
-router.include_router(experimental_synapses_per_connection.router)
-router.include_router(license.router)
-router.include_router(morphology.router)
-router.include_router(emodel.router)
-router.include_router(morphology_feature_annotation.router)
-router.include_router(mtype.router)
-router.include_router(organization.router)
-router.include_router(person.router)
-router.include_router(role.router)
-router.include_router(single_neuron_simulation.router)
-router.include_router(species.router)
-router.include_router(strain.router)
-
-# legacy routes
-router.include_router(_search.router)
-router.include_router(sbo.router)
-router.include_router(resources.router)
-router.include_router(files.router)
+authenticated_routers = [
+    asset.router,
+    brain_region.router,
+    cell_composition.router,
+    contribution.router,
+    experimental_bouton_density.router,
+    experimental_neuron_density.router,
+    experimental_synapses_per_connection.router,
+    license.router,
+    morphology.router,
+    emodel.router,
+    morphology_feature_annotation.router,
+    mtype.router,
+    organization.router,
+    person.router,
+    role.router,
+    single_neuron_simulation.router,
+    species.router,
+    strain.router,
+]
+for r in authenticated_routers:
+    router.include_router(r, dependencies=[Depends(user_verified)])

--- a/app/routers/cell_composition.py
+++ b/app/routers/cell_composition.py
@@ -9,7 +9,7 @@ COMPOSITION_SUMMARY = (
 
 router = APIRouter(
     prefix="/cell-composition",
-    tags=["/cell-composition"],
+    tags=["cell-composition"],
 )
 
 

--- a/app/routers/license.py
+++ b/app/routers/license.py
@@ -1,9 +1,10 @@
 import uuid
 
 import sqlalchemy as sa
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.db.model import License
+from app.dependencies.auth import user_with_service_admin_role
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -50,7 +51,7 @@ def read_license(id_: uuid.UUID, db: SessionDep):
     return LicenseRead.model_validate(row)
 
 
-@router.post("", response_model=LicenseRead)
+@router.post("", dependencies=[Depends(user_with_service_admin_role)], response_model=LicenseRead)
 def create_license(license: LicenseCreate, db: SessionDep):
     row = License(name=license.name, description=license.description, label=license.label)
     db.add(row)

--- a/app/routers/organization.py
+++ b/app/routers/organization.py
@@ -1,9 +1,10 @@
 import uuid
 
 import sqlalchemy as sa
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.db.model import Organization
+from app.dependencies.auth import user_with_service_admin_role
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -50,7 +51,9 @@ def read_organization(id_: uuid.UUID, db: SessionDep):
     return OrganizationRead.model_validate(row)
 
 
-@router.post("", response_model=OrganizationRead)
+@router.post(
+    "", dependencies=[Depends(user_with_service_admin_role)], response_model=OrganizationRead
+)
 def create_organization(organization: OrganizationCreate, db: SessionDep):
     row = Organization(**organization.model_dump())
     db.add(row)

--- a/app/routers/person.py
+++ b/app/routers/person.py
@@ -1,9 +1,10 @@
 import uuid
 
 import sqlalchemy as sa
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.db.model import Person
+from app.dependencies.auth import user_with_service_admin_role
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -47,7 +48,7 @@ def read_person(id_: uuid.UUID, db: SessionDep):
     return PersonRead.model_validate(row)
 
 
-@router.post("", response_model=PersonRead)
+@router.post("", dependencies=[Depends(user_with_service_admin_role)], response_model=PersonRead)
 def create_person(person: PersonCreate, db: SessionDep):
     row = Person(**person.model_dump())
     db.add(row)

--- a/app/routers/role.py
+++ b/app/routers/role.py
@@ -1,9 +1,10 @@
 import uuid
 
 import sqlalchemy as sa
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.db.model import Role
+from app.dependencies.auth import user_with_service_admin_role
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -49,7 +50,7 @@ def read_role(id_: uuid.UUID, db: SessionDep):
     return RoleRead.model_validate(row)
 
 
-@router.post("", response_model=RoleRead)
+@router.post("", dependencies=[Depends(user_with_service_admin_role)], response_model=RoleRead)
 def create_role(role: RoleCreate, db: SessionDep):
     row = Role(name=role.name, role_id=role.role_id)
     db.add(row)

--- a/app/routers/single_neuron_simulation.py
+++ b/app/routers/single_neuron_simulation.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import InstrumentedAttribute, Session, aliased, joinedload, 
 
 from app.db.auth import constrain_to_accessible_entities
 from app.db.model import Agent, Contribution, MEModel, SingleNeuronSimulation
-from app.dependencies.auth import VerifiedProjectContextHeader
+from app.dependencies.auth import UserContextDep, UserContextWithProjectIdDep
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -34,15 +34,15 @@ router = APIRouter(
 
 @router.get("/{id_}")
 def read(
+    user_context: UserContextDep,
     db: SessionDep,
     id_: uuid.UUID,
-    project_context: VerifiedProjectContextHeader,
 ) -> SingleNeuronSimulationRead:
     with ensure_result(error_message="SingleNeuronSimulation not found"):
         query = (
             constrain_to_accessible_entities(
                 sa.select(SingleNeuronSimulation),
-                project_context.project_id,
+                user_context.project_id,
             )
             .filter(SingleNeuronSimulation.id == id_)
             .options(joinedload(SingleNeuronSimulation.me_model))
@@ -59,11 +59,11 @@ def read(
     response_model=SingleNeuronSimulationRead,
 )
 def create(
-    project_context: VerifiedProjectContextHeader,
-    json_model: SingleNeuronSimulationCreate,
+    user_context: UserContextWithProjectIdDep,
     db: SessionDep,
+    json_model: SingleNeuronSimulationCreate,
 ):
-    kwargs = json_model.model_dump() | {"authorized_project_id": project_context.project_id}
+    kwargs = json_model.model_dump() | {"authorized_project_id": user_context.project_id}
 
     db_model = SingleNeuronSimulation(**kwargs)
     db.add(db_model)
@@ -105,8 +105,8 @@ def _get_facets(
 
 @router.get("")
 def query(
+    user_context: UserContextDep,
     db: SessionDep,
-    project_context: VerifiedProjectContextHeader,
     pagination_request: PaginationQuery,
     filter_model: Annotated[
         SingleNeuronSimulationFilter, FilterDepends(SingleNeuronSimulationFilter)
@@ -127,7 +127,7 @@ def query(
     filter_query = (
         constrain_to_accessible_entities(
             sa.select(SingleNeuronSimulation),
-            project_id=project_context.project_id,
+            project_id=user_context.project_id,
         )
         .outerjoin(Contribution, SingleNeuronSimulation.id == Contribution.entity_id)
         .outerjoin(agent_alias, Contribution.agent_id == agent_alias.id)

--- a/app/routers/species.py
+++ b/app/routers/species.py
@@ -2,10 +2,11 @@ import uuid
 from typing import Annotated
 
 import sqlalchemy as sa
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi_filter import FilterDepends
 
 from app.db.model import Species
+from app.dependencies.auth import user_with_service_admin_role
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -55,7 +56,7 @@ def read_species(id_: uuid.UUID, db: SessionDep):
     return SpeciesRead.model_validate(row)
 
 
-@router.post("", response_model=SpeciesRead)
+@router.post("", dependencies=[Depends(user_with_service_admin_role)], response_model=SpeciesRead)
 def create_species(species: SpeciesCreate, db: SessionDep):
     row = Species(name=species.name, taxonomy_id=species.taxonomy_id)
     db.add(row)

--- a/app/routers/strain.py
+++ b/app/routers/strain.py
@@ -2,10 +2,11 @@ import uuid
 from typing import Annotated
 
 import sqlalchemy as sa
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi_filter import FilterDepends
 
 from app.db.model import Strain
+from app.dependencies.auth import user_with_service_admin_role
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.errors import ensure_result
@@ -55,7 +56,7 @@ def read_strain(id_: uuid.UUID, db: SessionDep):
     return StrainRead.model_validate(row)
 
 
-@router.post("", response_model=StrainRead)
+@router.post("", dependencies=[Depends(user_with_service_admin_role)], response_model=StrainRead)
 def create_strain(strain: StrainCreate, db: SessionDep):
     row = Strain(name=strain.name, taxonomy_id=strain.taxonomy_id, species_id=strain.species_id)
     db.add(row)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -91,7 +91,7 @@ class UserInfoResponse(BaseModel):
 
     def is_service_admin(self, service_name: str) -> bool:
         """Return True if admin for the specified service."""
-        return self.groups.isdisjoint(
+        return not self.groups.isdisjoint(
             [
                 f"/service/{service_name}/admin",
                 "/service/*/admin",

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,0 +1,123 @@
+from typing import Self
+from uuid import UUID
+
+import jwt
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel, ConfigDict
+
+from app.errors import AuthErrorReason
+from app.logger import L
+
+
+class CacheKey(BaseModel):
+    """Cache key for UserContext."""
+
+    model_config = ConfigDict(frozen=True)
+    virtual_lab_id: UUID | None
+    project_id: UUID | None
+    scheme: str
+    token_digest: str
+
+
+class UserContext(BaseModel):
+    """User Context."""
+
+    model_config = ConfigDict(frozen=True)
+    subject: UUID | None
+    email: str | None
+    expiration: float | None
+    is_authorized: bool
+    is_service_admin: bool = False
+    virtual_lab_id: UUID | None = None
+    project_id: UUID | None = None
+    auth_error_reason: AuthErrorReason | None = None
+
+
+class UserContextWithProjectId(UserContext):
+    """User Context with valid virtual_lab_id and project_id."""
+
+    virtual_lab_id: UUID
+    project_id: UUID
+
+
+class DecodedToken(BaseModel):
+    """Decoded JWT token.
+
+    Only a subset of the claims is extracted.
+    """
+
+    sub: UUID
+    exp: float | None = None
+    email: str | None = None
+
+    @classmethod
+    def from_jwt(cls, token: HTTPAuthorizationCredentials) -> Self | None:
+        try:
+            # the signature can be ignored because the token will be validated with KeyCloak
+            decoded = jwt.decode(token.credentials, options={"verify_signature": False})
+            return cls.model_validate(decoded)
+        except Exception as e:  # noqa: BLE001
+            L.info("Unable to decode token as JWT [{}]", e)
+        return None
+
+
+class UserInfoResponse(BaseModel):
+    """UserInfoResponse model received from KeyCloak.
+
+    Built from a KeyCloak response that should look like:
+
+    {
+        "email": "john.doe@example.com",
+        "email_verified": false,
+        "family_name": "Doe",
+        "given_name": "John",
+        "groups": [
+            "/BBP-USERS",
+            "/proj/$vlab_id/$project_id/admin",
+            ...
+            "/vlab/$vlab_id/admin",
+            ...
+        ],
+        "name": "John Doe",
+        "preferred_username": "johndoe",
+        "sub": "83e509d1-d579-4d7e-bfe7-a0cf96ac17bf"
+    }
+    """
+
+    sub: UUID
+    name: str
+    email: str
+    groups: set[str] = set()
+
+    def is_service_admin(self, service_name: str) -> bool:
+        """Return True if admin for the specified service."""
+        return self.groups.isdisjoint(
+            [
+                f"/service/{service_name}/admin",
+                "/service/*/admin",
+            ]
+        )
+
+    def is_authorized_for(self, virtual_lab_id: UUID | None, project_id: UUID | None) -> bool:
+        """Return True if authorized for the specified virtual_lab_id and project_id."""
+        match (virtual_lab_id, project_id):
+            case (None, None):
+                # virtual_lab_id and project_id are not specified
+                return True
+            case (None, UUID()):
+                # project_id cannot be specified without virtual_lab_id
+                return False
+            case (UUID(), None):
+                return not self.groups.isdisjoint(
+                    [
+                        f"/vlab/{virtual_lab_id}/admin",
+                        f"/vlab/{virtual_lab_id}/member",
+                    ]
+                )
+            case _:
+                return not self.groups.isdisjoint(
+                    [
+                        f"/proj/{virtual_lab_id}/{project_id}/admin",
+                        f"/proj/{virtual_lab_id}/{project_id}/member",
+                    ]
+                )

--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -18,6 +18,11 @@ class ProjectContext(BaseModel):
     project_id: UUID4
 
 
+class OptionalProjectContext(BaseModel):
+    virtual_lab_id: UUID4 | None = None
+    project_id: UUID4 | None = None
+
+
 class IdentifiableMixin(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: uuid.UUID

--- a/app/service/asset.py
+++ b/app/service/asset.py
@@ -5,21 +5,21 @@ from app.db.types import AssetStatus, EntityType
 from app.errors import ApiErrorCode, ensure_result, ensure_uniqueness
 from app.repository.group import RepositoryGroup
 from app.schemas.asset import AssetCreate, AssetRead
-from app.schemas.base import ProjectContext
+from app.schemas.auth import UserContext, UserContextWithProjectId
 from app.service import entity as entity_service
 from app.utils.s3 import build_s3_path
 
 
 def get_entity_assets(
     repos: RepositoryGroup,
-    project_context: ProjectContext,
+    user_context: UserContext,
     entity_type: EntityType,
     entity_id: uuid.UUID,
 ) -> list[AssetRead]:
     """Return the list of assets associated with a specific entity."""
     _ = entity_service.get_readable_entity(
         repos,
-        project_context=project_context,
+        user_context=user_context,
         entity_type=entity_type,
         entity_id=entity_id,
     )
@@ -31,7 +31,7 @@ def get_entity_assets(
 
 def get_entity_asset(
     repos: RepositoryGroup,
-    project_context: ProjectContext,
+    user_context: UserContext,
     entity_type: EntityType,
     entity_id: uuid.UUID,
     asset_id: uuid.UUID,
@@ -39,7 +39,7 @@ def get_entity_asset(
     """Return an asset associated with a specific entity."""
     _ = entity_service.get_readable_entity(
         repos,
-        project_context=project_context,
+        user_context=user_context,
         entity_type=entity_type,
         entity_id=entity_id,
     )
@@ -52,7 +52,7 @@ def get_entity_asset(
 
 def create_entity_asset(
     repos: RepositoryGroup,
-    project_context: ProjectContext,
+    user_context: UserContextWithProjectId,
     entity_type: EntityType,
     entity_id: uuid.UUID,
     filename: str,
@@ -64,14 +64,14 @@ def create_entity_asset(
     """Create an asset for an entity."""
     entity = entity_service.get_writable_entity(
         repos,
-        project_context=project_context,
+        user_context=user_context,
         entity_type=entity_type,
         entity_id=entity_id,
     )
     bucket_name = settings.S3_BUCKET_NAME
     full_path = build_s3_path(
-        vlab_id=project_context.virtual_lab_id,
-        proj_id=project_context.project_id,
+        vlab_id=user_context.virtual_lab_id,
+        proj_id=user_context.project_id,
         entity_type=entity_type,
         entity_id=entity_id,
         filename=filename,
@@ -100,7 +100,7 @@ def create_entity_asset(
 
 def delete_entity_asset(
     repos: RepositoryGroup,
-    project_context: ProjectContext,
+    user_context: UserContextWithProjectId,
     entity_type: EntityType,
     entity_id: uuid.UUID,
     asset_id: uuid.UUID,
@@ -108,7 +108,7 @@ def delete_entity_asset(
     """Mark an entity asset as deleted."""
     _ = entity_service.get_writable_entity(
         repos,
-        project_context=project_context,
+        user_context=user_context,
         entity_type=entity_type,
         entity_id=entity_id,
     )

--- a/app/service/entity.py
+++ b/app/service/entity.py
@@ -4,12 +4,12 @@ from app.db.model import Entity
 from app.db.types import EntityType
 from app.errors import ensure_result
 from app.repository.group import RepositoryGroup
-from app.schemas.base import ProjectContext
+from app.schemas.auth import UserContext, UserContextWithProjectId
 
 
 def get_readable_entity(
     repos: RepositoryGroup,
-    project_context: ProjectContext,
+    user_context: UserContext,
     entity_type: EntityType,
     entity_id: uuid.UUID,
 ) -> Entity:
@@ -17,13 +17,13 @@ def get_readable_entity(
         return repos.entity.get_readable_entity(
             entity_type=entity_type,
             entity_id=entity_id,
-            project_id=project_context.project_id,
+            project_id=user_context.project_id,
         )
 
 
 def get_writable_entity(
     repos: RepositoryGroup,
-    project_context: ProjectContext,
+    user_context: UserContextWithProjectId,
     entity_type: EntityType,
     entity_id: uuid.UUID,
     *,
@@ -33,6 +33,6 @@ def get_writable_entity(
         return repos.entity.get_writable_entity(
             entity_type=entity_type,
             entity_id=entity_id,
-            project_id=project_context.project_id,
+            project_id=user_context.project_id,
             for_update=for_update,
         )

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,0 +1,7 @@
+def is_ascii(s: str) -> bool:
+    """Return True if a string can be encoded as ASCII."""
+    try:
+        s.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    return True

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -1,0 +1,70 @@
+from http import HTTPStatus
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from app.errors import ApiError, ApiErrorCode
+from app.logger import L
+
+
+def make_http_request(
+    url: str,
+    *,
+    method: str,
+    json: dict | None = None,
+    parameters: dict | None = None,
+    headers: dict | None = None,
+    http_client: httpx.Client,
+    ignored_errors: set[int] | None = None,
+) -> httpx.Response:
+    """Make a HTTP request.
+
+    Args:
+        url: url of the remote endpoint.
+        method: request method.
+        json: json request payload.
+        parameters: query parameters.
+        headers: request headers.
+        http_client: instance of httpx.Client.
+        ignored_errors: status_code errors that should not raise an error.
+
+    Returns:
+        the httpc.Response instance.
+    """
+    try:
+        response = http_client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            json=json,
+            params=parameters,
+            follow_redirects=True,
+        )
+    except httpx.RequestError as e:
+        L.opt(depth=1).warning("HTTP request error in {} {}: {!r}", method, url, e)
+        raise ApiError(
+            message="HTTP request error",
+            error_code=ApiErrorCode.GENERIC_ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        ) from e
+    ignored_errors = ignored_errors or set()
+    if not response.is_success and response.status_code not in ignored_errors:
+        L.opt(depth=1).warning("HTTP status error {} in {} {}", response.status_code, method, url)
+        raise ApiError(
+            message=f"HTTP status error {response.status_code}",
+            error_code=ApiErrorCode.GENERIC_ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+    return response
+
+
+def deserialize_response[T: BaseModel](response: httpx.Response, model_class: type[T]) -> T:
+    """Deserialize the response using a Pydantic model, or raise an error."""
+    try:
+        return model_class.model_validate_json(response.content)
+    except ValidationError as e:
+        raise ApiError(
+            message=f"{model_class.__class__.__name__} validation error",
+            error_code=ApiErrorCode.GENERIC_ERROR,
+            http_status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        ) from e

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,61 @@
+# Authentication
+
+## General Rules
+
+- All endpoints require authentication with a valid token, except for the [unauthenticated endpoints](#unauthenticated-endpoints).
+- For authenticated endpoints:
+  - If `virtual-lab-id` and `project-id` are provided in the request headers, they are validated with Keycloak using the given token.
+  - If `virtual-lab-id` is provided without `project-id`, it is verified.
+  - If `project-id` is provided without `virtual-lab-id`, authentication fails.
+- Endpoints for [global resources](#endpoints-for-global-resources):
+  - Do not require `virtual-lab-id` or `project-id`.
+  - **Read** endpoints are accessible to all authenticated users.
+  - **Write** endpoints require the user to be a member of the [service admin group](#service-admin-group).
+- Endpoints for [project resources](#endpoints-for-project-resources):
+  - **Read** endpoints do not require `virtual-lab-id` or `project-id`, but:
+    - If neither is provided, only public resources are returned.
+    - If both are provided, both public and private resources are returned.
+  - **Write** endpoints require both `virtual-lab-id` and `project-id`.
+
+## Service Admin Group
+
+To call endpoints that modify global resources, the user must belong to a special Keycloak group: `/service/entitycore/admin`.
+
+## Caching
+
+Requests to Keycloak are cached using a Time-aware Least Recently Used (TLRU) cache.
+Similar to a TTL cache, this method assigns an expiration time to each item. However, in a TLRU cache, expiration time is determined individually for each item based on the token's expiration time, capped at the configured maximum TTL.
+
+## Auditing
+
+Auditing is not yet implemented but can be added later using information retrieved from Keycloak and stored in `UserContext`.
+
+## Endpoints for Global Resources
+
+- `/brain-region`
+- `/cell-composition`
+- `/license`
+- `/mtype`
+- `/organization`
+- `/person`
+- `/role`
+- `/species`
+- `/strain`
+
+## Endpoints for Project Resources
+
+- `/assets`
+- `/contribution`
+- `/emodel`
+- `/experimental-bouton-density`
+- `/experimental-neuron-density`
+- `/experimental-synapses-per-connection`
+- `/reconstruction-morphology`
+- `/morphology-feature-annotation`
+- `/single-neuron-simulation`
+
+## Unauthenticated endpoints
+
+- `/health`
+- `/version`
+- `/docs`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,13 @@ build-backend = "setuptools.build_meta"
 include = ["app"]
 
 [tool.uv]
-# Temporarily pin setuptools, see:
+# Use exclude-newer to temporarily pin setuptools, see:
+# https://github.com/pypa/setuptools/issues/4910
 # https://github.com/astral-sh/uv/issues/12434
 # https://github.com/olirice/alembic_utils/issues/153
-build-constraint-dependencies = ["setuptools<78"]
+#build-constraint-dependencies = ["setuptools<78"]
+exclude-newer = "2025-03-24T00:00:00Z"
+
 dev-dependencies = [
     "coverage[toml]",
     "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ build-backend = "setuptools.build_meta"
 include = ["app"]
 
 [tool.uv]
+# Temporarily pin setuptools, see:
+# https://github.com/astral-sh/uv/issues/12434
+# https://github.com/olirice/alembic_utils/issues/153
+build-constraint-dependencies = ["setuptools<78"]
 dev-dependencies = [
     "coverage[toml]",
     "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev-dependencies = [
     "mypy",
     "pytest",
     "pytest-cov",
+    "pytest-freezer>=0.4.9",
     "pytest-httpx>=0.35.0",
     "ruff",
     "types-boto3-lite[essential]>=1.36.11",
@@ -177,6 +178,8 @@ precision = 0
 fail_under = 45
 omit = [
     "__main__.py",
+    "app/cli/*",
+    "app/routers/legacy/*",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "alembic-postgresql-enum>=1.5.0",
     "alembic-utils>=0.8.6",
     "boto3>=1.36.3",
+    "cachetools>=5.5.2",
     "fastapi",
     "fastapi-filter>=2.0.0",
     "loguru>=0.7.3",
@@ -22,8 +23,8 @@ dependencies = [
     "deepdiff",
     "click>=8.1.7",
     "pydantic-settings>=2.7.1",
+    "pyjwt>=2.10.1",
     "python-multipart>=0.0.20",
-    "types-boto3-lite[essential]>=1.36.11",
 ]
 requires-python = "==3.12.*"
 readme = "README.md"
@@ -44,7 +45,10 @@ dev-dependencies = [
     "mypy",
     "pytest",
     "pytest-cov",
+    "pytest-httpx>=0.35.0",
     "ruff",
+    "types-boto3-lite[essential]>=1.36.11",
+    "types-cachetools>=5.5.0.20240820",
     "types-PyYAML",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,6 @@ build-backend = "setuptools.build_meta"
 include = ["app"]
 
 [tool.uv]
-# Use exclude-newer to temporarily pin setuptools, see:
-# https://github.com/pypa/setuptools/issues/4910
-# https://github.com/astral-sh/uv/issues/12434
-# https://github.com/olirice/alembic_utils/issues/153
-#build-constraint-dependencies = ["setuptools<78"]
-exclude-newer = "2025-03-24T00:00:00Z"
-
 dev-dependencies = [
     "coverage[toml]",
     "httpx",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def user_context_no_auth():
 
 
 @pytest.fixture
-def user_context_1():
+def user_context_admin():
     """Admin authenticated user."""
     return UserContext(
         subject=UUID(int=1),
@@ -93,7 +93,7 @@ def user_context_1():
 
 
 @pytest.fixture
-def user_context_2():
+def user_context_user():
     """Regular authenticated user with different project-id."""
     return UserContext(
         subject=UUID(int=2),
@@ -122,13 +122,17 @@ def user_context_no_project():
 
 @pytest.fixture
 def _override_check_user_info(
-    monkeypatch, user_context_no_auth, user_context_1, user_context_2, user_context_no_project
+    monkeypatch,
+    user_context_no_auth,
+    user_context_admin,
+    user_context_user,
+    user_context_no_project,
 ):
     def mock_check_user_info(*, project_context, token, http_client):  # noqa: ARG001
         if project_context.project_id == UUID(PROJECT_ID):
-            return user_context_1
+            return user_context_admin
         if project_context.project_id == UUID(UNRELATED_PROJECT_ID):
-            return user_context_2
+            return user_context_user
         if project_context.project_id is None:
             return user_context_no_project
         return user_context_no_auth

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,9 @@ from .utils import (
 )
 
 
-@pytest.fixture(scope="session")
-def _aws_credentials():
-    """Mocked AWS Credentials for moto."""
+@pytest.fixture(scope="session", autouse=True)
+def _setup_env_variables():
+    # Mock AWS Credentials for moto
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # noqa: S105
     os.environ["AWS_SECURITY_TOKEN"] = "testing"  # noqa: S105
@@ -53,7 +53,7 @@ def _aws_credentials():
 
 
 @pytest.fixture(scope="session")
-def s3(_aws_credentials):
+def s3():
     """Return a mocked S3 client."""
     with mock_aws():
         yield boto3.client("s3")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,13 +153,13 @@ def client_no_auth(session_client, _override_check_user_info):
 
 
 @pytest.fixture
-def client_1(client_no_auth):
-    """Return a web client instance, authenticated as service admin."""
+def client_admin(client_no_auth):
+    """Return a web client instance, authenticated as service admin with a specific project-id."""
     return ClientProxy(client_no_auth, headers=BEARER_TOKEN | PROJECT_HEADERS)
 
 
 @pytest.fixture
-def client_2(client_no_auth):
+def client_user(client_no_auth):
     """Return a web client instance, authenticated as regular user with different project-id."""
     return ClientProxy(client_no_auth, headers=BEARER_TOKEN | UNRELATED_PROJECT_HEADERS)
 
@@ -171,8 +171,8 @@ def client_no_project(client_no_auth):
 
 
 @pytest.fixture
-def client(client_1):
-    return client_1
+def client(client_admin):
+    return client_admin
 
 
 @pytest.fixture(scope="session")

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -12,7 +12,6 @@ from app.utils.s3 import build_s3_path
 
 from tests.utils import (
     MISSING_ID,
-    PROJECT_HEADERS,
     PROJECT_ID,
     TEST_DATA_DIR,
     VIRTUAL_LAB_ID,
@@ -24,15 +23,6 @@ DIFFERENT_ENTITY_TYPE = "experimental_bouton_density"
 FILE_EXAMPLE_PATH = TEST_DATA_DIR / "example.json"
 FILE_EXAMPLE_DIGEST = "a8124f083a58b9a8ff80cb327dd6895a10d0bc92bb918506da0c9c75906d3f91"
 FILE_EXAMPLE_SIZE = 31
-
-# Apply the fixture to all tests in this module
-pytestmark = pytest.mark.usefixtures("skip_project_check")
-
-
-@pytest.fixture
-def client(client):
-    client.headers.update(PROJECT_HEADERS)
-    return client
 
 
 def _route(entity_type: str) -> str:
@@ -64,10 +54,9 @@ def entity(client, species_id, strain_id, brain_region_id) -> Entity:
     entity_type = EntityType.reconstruction_morphology.name
     entity_id = create_reconstruction_morphology_id(
         client,
-        species_id,
-        strain_id,
-        brain_region_id,
-        headers=PROJECT_HEADERS,
+        species_id=species_id,
+        strain_id=strain_id,
+        brain_region_id=brain_region_id,
         authorized_public=False,
     )
     return Entity(id=entity_id, type=entity_type)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,326 @@
+import time
+import uuid
+from unittest.mock import Mock
+
+import httpx
+import jwt
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.config import settings
+from app.dependencies import auth as test_module
+from app.errors import ApiError, ApiErrorCode, AuthErrorReason
+from app.schemas.auth import UserContext, UserContextWithProjectId
+from app.schemas.base import OptionalProjectContext
+
+from tests.utils import PROJECT_ID, UNRELATED_PROJECT_ID, UNRELATED_VIRTUAL_LAB_ID, VIRTUAL_LAB_ID
+
+ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+TEST_USER_SUB = "4e234816-1391-4704-ab96-93f2c0875b42"
+TEST_USER_EMAIL = "test@example.com"
+TEST_USER_NAME = "John Doe"
+
+PROJECT_CONTEXTS = [
+    OptionalProjectContext(virtual_lab_id=None, project_id=None),
+    OptionalProjectContext(virtual_lab_id=VIRTUAL_LAB_ID, project_id=PROJECT_ID),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    yield
+    test_module._check_user_info.cache_clear()
+
+
+@pytest.fixture
+def http_client():
+    with httpx.Client() as client:
+        yield client
+
+
+@pytest.fixture
+def request_mock(http_client):
+    request = Mock()
+    request.state.http_client = http_client
+    return request
+
+
+def _get_token(exp):
+    decoded = {"sub": TEST_USER_SUB, "exp": exp, "email": TEST_USER_EMAIL}
+    encoded = jwt.encode(decoded, "secret", algorithm="HS256")
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=encoded)
+
+
+@pytest.mark.parametrize("project_context", PROJECT_CONTEXTS)
+@pytest.mark.parametrize("is_token_jwt", [True, False])
+@pytest.mark.parametrize("is_admin", [True, False])
+@pytest.mark.usefixtures("freezer")
+def test_user_verified_ok(httpx_mock, request_mock, is_admin, is_token_jwt, project_context):
+    if is_token_jwt:
+        token_expiration = int(time.time() + 3600)
+        token = _get_token(exp=token_expiration)
+    else:
+        token_expiration = None
+        token = HTTPAuthorizationCredentials(scheme="Bearer", credentials="random-ascii-token")
+
+    httpx_mock.add_response(
+        method="GET",
+        url=test_module.KEYCLOAK_GROUPS_URL,
+        match_headers={"Authorization": f"{token.scheme} {token.credentials}"},
+        json={
+            "sub": TEST_USER_SUB,
+            "name": TEST_USER_NAME,
+            "email": TEST_USER_EMAIL,
+            "groups": [
+                "/service/entitycore/admin" if is_admin else "/other",
+                f"/proj/{VIRTUAL_LAB_ID}/{PROJECT_ID}/admin",
+                f"/vlab/{VIRTUAL_LAB_ID}/admin",
+            ],
+        },
+    )
+
+    result = test_module.user_verified(
+        project_context=project_context, token=token, request=request_mock
+    )
+    assert isinstance(result, UserContext)
+    assert result == UserContext(
+        subject=uuid.UUID(TEST_USER_SUB),
+        email=TEST_USER_EMAIL,
+        expiration=token_expiration,
+        is_authorized=True,
+        is_service_admin=is_admin,
+        virtual_lab_id=project_context.virtual_lab_id,
+        project_id=project_context.project_id,
+    )
+
+
+@pytest.mark.parametrize("project_context", PROJECT_CONTEXTS)
+def test_user_verified_ok_when_auth_is_disabled(monkeypatch, request_mock, project_context):
+    monkeypatch.setattr(settings, "APP_DISABLE_AUTH", True)
+    result = test_module.user_verified(
+        project_context=project_context, token=None, request=request_mock
+    )
+    assert isinstance(result, UserContext)
+    assert result == UserContext(
+        subject=uuid.UUID(ZERO_UUID),
+        email=None,
+        expiration=None,
+        is_authorized=True,
+        is_service_admin=True,
+        virtual_lab_id=project_context.virtual_lab_id,
+        project_id=project_context.project_id,
+    )
+
+
+def test_user_verified_without_token(request_mock):
+    project_context = OptionalProjectContext(virtual_lab_id=None, project_id=None)
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_verified(project_context=project_context, token=None, request=request_mock)
+    assert excinfo.value == ApiError(
+        message=AuthErrorReason.AUTH_TOKEN_MISSING,
+        error_code=ApiErrorCode.NOT_AUTHENTICATED,
+        http_status_code=401,
+    )
+
+
+def test_user_verified_with_token_non_ascii(request_mock):
+    project_context = OptionalProjectContext(virtual_lab_id=None, project_id=None)
+    token = HTTPAuthorizationCredentials(scheme="Bearer", credentials="non-ascii-credential-é")
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_verified(
+            project_context=project_context, token=token, request=request_mock
+        )
+    assert excinfo.value == ApiError(
+        message=AuthErrorReason.AUTH_TOKEN_INVALID,
+        error_code=ApiErrorCode.NOT_AUTHENTICATED,
+        http_status_code=401,
+    )
+
+
+@pytest.mark.parametrize("project_context", PROJECT_CONTEXTS)
+@pytest.mark.usefixtures("freezer")
+def test_user_verified_with_expired_token(request_mock, project_context):
+    token_expiration = int(time.time() - 1)
+    token = _get_token(exp=token_expiration)
+
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_verified(
+            project_context=project_context, token=token, request=request_mock
+        )
+    assert excinfo.value == ApiError(
+        message=AuthErrorReason.AUTH_TOKEN_EXPIRED,
+        error_code=ApiErrorCode.NOT_AUTHENTICATED,
+        http_status_code=401,
+    )
+
+
+@pytest.mark.parametrize("project_context", PROJECT_CONTEXTS)
+@pytest.mark.parametrize(
+    ("keycloak_status", "expected_error"),
+    [
+        (
+            401,
+            ApiError(
+                message=ApiErrorCode.NOT_AUTHENTICATED,
+                error_code=ApiErrorCode.NOT_AUTHENTICATED,
+                http_status_code=401,
+            ),
+        ),
+        (
+            403,
+            ApiError(
+                message=ApiErrorCode.NOT_AUTHORIZED,
+                error_code=ApiErrorCode.NOT_AUTHORIZED,
+                http_status_code=403,
+            ),
+        ),
+        (
+            500,
+            ApiError(
+                message="HTTP status error 500",
+                error_code=ApiErrorCode.GENERIC_ERROR,
+                http_status_code=500,
+            ),
+        ),
+    ],
+)
+@pytest.mark.usefixtures("freezer")
+def test_user_verified_keycloak_error(
+    httpx_mock, request_mock, keycloak_status, expected_error, project_context
+):
+    token_expiration = int(time.time() + 3600)
+    token = _get_token(exp=token_expiration)
+
+    httpx_mock.add_response(
+        status_code=keycloak_status,
+        method="GET",
+        url=test_module.KEYCLOAK_GROUPS_URL,
+        match_headers={"Authorization": f"{token.scheme} {token.credentials}"},
+    )
+
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_verified(
+            project_context=project_context, token=token, request=request_mock
+        )
+    assert excinfo.value == expected_error
+
+
+@pytest.mark.parametrize(
+    # ("project_context", "expected_error"),
+    "project_context",
+    [
+        OptionalProjectContext(virtual_lab_id=VIRTUAL_LAB_ID, project_id=PROJECT_ID),
+        OptionalProjectContext(virtual_lab_id=None, project_id=PROJECT_ID),
+        OptionalProjectContext(virtual_lab_id=VIRTUAL_LAB_ID, project_id=None),
+    ],
+)
+@pytest.mark.usefixtures("freezer")
+def test_user_verified_not_authorized_for_project(httpx_mock, request_mock, project_context):
+    token_expiration = int(time.time() + 3600)
+    token = _get_token(exp=token_expiration)
+
+    httpx_mock.add_response(
+        status_code=200,
+        method="GET",
+        url=test_module.KEYCLOAK_GROUPS_URL,
+        match_headers={"Authorization": f"{token.scheme} {token.credentials}"},
+        json={
+            "sub": TEST_USER_SUB,
+            "name": TEST_USER_NAME,
+            "email": TEST_USER_EMAIL,
+            "groups": [
+                "/service/entitycore/admin",
+                f"/proj/{UNRELATED_VIRTUAL_LAB_ID}/{UNRELATED_PROJECT_ID}/admin",
+                f"/vlab/{UNRELATED_VIRTUAL_LAB_ID}/admin",
+            ],
+        },
+    )
+
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_verified(
+            project_context=project_context, token=token, request=request_mock
+        )
+    assert excinfo.value == ApiError(
+        message=ApiErrorCode.NOT_AUTHORIZED,
+        error_code=ApiErrorCode.NOT_AUTHORIZED,
+        http_status_code=403,
+    )
+
+
+def test_user_with_project_id_ok():
+    user_context = UserContext(
+        subject=uuid.UUID(TEST_USER_SUB),
+        email=TEST_USER_EMAIL,
+        expiration=None,
+        is_authorized=True,
+        is_service_admin=True,
+        virtual_lab_id=VIRTUAL_LAB_ID,
+        project_id=PROJECT_ID,
+    )
+
+    result = test_module.user_with_project_id(user_context)
+    assert isinstance(result, UserContextWithProjectId)
+    assert result.virtual_lab_id == uuid.UUID(VIRTUAL_LAB_ID)
+    assert result.project_id == uuid.UUID(PROJECT_ID)
+
+
+@pytest.mark.parametrize(
+    "project_context",
+    [
+        OptionalProjectContext(virtual_lab_id=None, project_id=None),
+        OptionalProjectContext(virtual_lab_id=VIRTUAL_LAB_ID, project_id=None),
+        OptionalProjectContext(virtual_lab_id=None, project_id=PROJECT_ID),
+    ],
+)
+def test_user_with_project_id_raises(project_context):
+    user_context = UserContext(
+        subject=uuid.UUID(TEST_USER_SUB),
+        email=TEST_USER_EMAIL,
+        expiration=None,
+        is_authorized=True,
+        is_service_admin=True,
+        virtual_lab_id=project_context.virtual_lab_id,
+        project_id=project_context.project_id,
+    )
+
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_with_project_id(user_context)
+    assert excinfo.value == ApiError(
+        message="virtual-lab-id and project-id are required",
+        error_code=ApiErrorCode.NOT_AUTHORIZED,
+        http_status_code=403,
+    )
+
+
+def test_user_with_service_admin_role_ok():
+    user_context = UserContext(
+        subject=uuid.UUID(TEST_USER_SUB),
+        email=TEST_USER_EMAIL,
+        expiration=None,
+        is_authorized=True,
+        is_service_admin=True,
+        virtual_lab_id=VIRTUAL_LAB_ID,
+        project_id=PROJECT_ID,
+    )
+    result = test_module.user_with_service_admin_role(user_context)
+    assert isinstance(result, UserContext)
+    assert result.is_service_admin is True
+
+
+def test_user_with_service_admin_role_raises():
+    user_context = UserContext(
+        subject=uuid.UUID(TEST_USER_SUB),
+        email=TEST_USER_EMAIL,
+        expiration=None,
+        is_authorized=True,
+        is_service_admin=False,
+        virtual_lab_id=VIRTUAL_LAB_ID,
+        project_id=PROJECT_ID,
+    )
+    with pytest.raises(ApiError) as excinfo:
+        test_module.user_with_service_admin_role(user_context)
+    assert excinfo.value == ApiError(
+        message="Service admin role required",
+        error_code=ApiErrorCode.NOT_AUTHORIZED,
+        http_status_code=403,
+    )

--- a/tests/test_brain_region.py
+++ b/tests/test_brain_region.py
@@ -39,7 +39,7 @@ hierarchy = {
 }
 
 
-def test_brain_region_id(client):
+def test_brain_region_id(client_admin, client):
     regions = []
 
     def recurse(i):
@@ -53,7 +53,7 @@ def test_brain_region_id(client):
     recurse(hierarchy)
 
     for region in regions:
-        response = client.post(
+        response = client_admin.post(
             ROUTE,
             json=region,
         )

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -116,8 +116,8 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_admin,
-    client_user,
+    client_user_1,
+    client_user_2,
     client_no_project,
     brain_region_id,
     species_id,
@@ -126,14 +126,14 @@ def test_authorization(
     role_id,
 ):
     inaccessible_entity_id = create_reconstruction_morphology_id(
-        client_user,
+        client_user_2,
         species_id=species_id,
         strain_id=strain_id,
         brain_region_id=brain_region_id,
         authorized_public=False,
     )
 
-    response = client_admin.post(
+    response = client_user_1.post(
         ROUTE,
         json={
             "agent_id": str(person_id),
@@ -144,7 +144,7 @@ def test_authorization(
     # can't attach contributions to projects unrelated to us
     assert response.status_code == 404
 
-    response = client_user.post(
+    response = client_user_2.post(
         ROUTE,
         json={
             "agent_id": str(person_id),
@@ -155,17 +155,17 @@ def test_authorization(
     assert response.status_code == 200
     inaccessible_annotation_id = response.json()["id"]
 
-    response = client_admin.get(f"{ROUTE}/{inaccessible_annotation_id}")
+    response = client_user_1.get(f"{ROUTE}/{inaccessible_annotation_id}")
     assert response.status_code == 404
 
     public_entity_id = create_reconstruction_morphology_id(
-        client_user,
+        client_user_2,
         species_id=species_id,
         strain_id=strain_id,
         brain_region_id=brain_region_id,
         authorized_public=True,
     )
-    response = client_admin.post(
+    response = client_user_1.post(
         ROUTE,
         json={
             "agent_id": str(person_id),
@@ -176,7 +176,7 @@ def test_authorization(
     # can't attach contributions to projects unrelated to us, even if public
     assert response.status_code == 404
 
-    public_obj = client_user.post(
+    public_obj = client_user_2.post(
         ROUTE,
         json={
             "agent_id": str(person_id),
@@ -187,11 +187,11 @@ def test_authorization(
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    response = client_admin.get(f"{ROUTE}/{public_obj['id']}")
+    response = client_user_1.get(f"{ROUTE}/{public_obj['id']}")
     # can get the contribution if the entity is public
     assert response.status_code == 200
 
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 1  # only public entity is available

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -116,7 +116,14 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_1, client_2, brain_region_id, species_id, strain_id, person_id, role_id
+    client_1,
+    client_2,
+    client_no_project,
+    brain_region_id,
+    species_id,
+    strain_id,
+    person_id,
+    role_id,
 ):
     inaccessible_entity_id = create_reconstruction_morphology_id(
         client_2,
@@ -191,6 +198,12 @@ def test_authorization(
     assert data[0]["id"] == public_obj["id"]
     assert data[0]["entity"]["id"] == public_entity_id
     assert data[0]["entity"]["authorized_public"]
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_obj["id"]
 
 
 def test_contribution_facets(

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -1,13 +1,8 @@
-import pytest
-
 from app.db.model import Contribution, Organization, Person, Role
 
 from .utils import (
-    BEARER_TOKEN,
     MISSING_ID,
     MISSING_ID_COMPACT,
-    PROJECT_HEADERS,
-    UNRELATED_PROJECT_HEADERS,
     add_db,
     create_reconstruction_morphology_id,
 )
@@ -16,7 +11,6 @@ ROUTE = "/contribution"
 ROUTE_MORPH = "/reconstruction-morphology"
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_create_contribution(
     client,
     person_id,
@@ -28,16 +22,14 @@ def test_create_contribution(
 ):
     reconstruction_morphology_id = create_reconstruction_morphology_id(
         client,
-        species_id,
-        strain_id,
-        brain_region_id,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
+        species_id=species_id,
+        strain_id=strain_id,
+        brain_region_id=brain_region_id,
         authorized_public=False,
     )
 
     response = client.post(
         ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json={
             "agent_id": str(person_id),
             "role_id": str(role_id),
@@ -58,7 +50,7 @@ def test_create_contribution(
 
     contribution_id = data["id"]
 
-    response = client.get(f"{ROUTE}/{contribution_id}", headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/{contribution_id}")
     assert response.status_code == 200
     data = response.json()
     assert data["agent"]["id"] == str(person_id)
@@ -73,7 +65,6 @@ def test_create_contribution(
 
     response = client.post(
         ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json={
             "agent_id": str(organization_id),
             "role_id": str(role_id),
@@ -87,26 +78,16 @@ def test_create_contribution(
     assert data["agent"]["alternative_name"] == "A Company Making Everything"
     assert data["agent"]["type"] == "organization"
 
-    response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client.get(ROUTE)
     assert len(response.json()["data"]) == 2
 
-    response = client.get(
-        f"{ROUTE_MORPH}/{reconstruction_morphology_id}",
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client.get(f"{ROUTE_MORPH}/{reconstruction_morphology_id}")
     response.raise_for_status()
     data = response.json()
     assert "contributions" in data
     assert len(data["contributions"]) == 2
 
-    response = client.get(
-        ROUTE_MORPH,
-        params={"with_facets": True},
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client.get(ROUTE_MORPH, params={"with_facets": True})
     response.raise_for_status()
     data = response.json()["data"]
     assert len(data) == 1
@@ -120,35 +101,33 @@ def test_create_contribution(
     ]
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_missing(client):
-    response = client.get(f"{ROUTE}/{MISSING_ID}", headers=PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/{MISSING_ID}")
     assert response.status_code == 404
 
-    response = client.get(f"{ROUTE}/{MISSING_ID_COMPACT}", headers=PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/{MISSING_ID_COMPACT}")
     assert response.status_code == 404
 
-    response = client.get(f"{ROUTE}/42424242", headers=PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/42424242")
     assert response.status_code == 422
 
-    response = client.get(f"{ROUTE}/notanumber", headers=PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/notanumber")
     assert response.status_code == 422
 
 
-@pytest.mark.usefixtures("skip_project_check")
-def test_authorization(client, brain_region_id, species_id, strain_id, person_id, role_id):
+def test_authorization(
+    client_1, client_2, brain_region_id, species_id, strain_id, person_id, role_id
+):
     inaccessible_entity_id = create_reconstruction_morphology_id(
-        client,
-        species_id,
-        strain_id,
-        brain_region_id,
-        headers=BEARER_TOKEN | UNRELATED_PROJECT_HEADERS,
+        client_2,
+        species_id=species_id,
+        strain_id=strain_id,
+        brain_region_id=brain_region_id,
         authorized_public=False,
     )
 
-    response = client.post(
+    response = client_1.post(
         ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json={
             "agent_id": str(person_id),
             "role_id": str(role_id),
@@ -158,9 +137,8 @@ def test_authorization(client, brain_region_id, species_id, strain_id, person_id
     # can't attach contributions to projects unrelated to us
     assert response.status_code == 404
 
-    response = client.post(
+    response = client_2.post(
         ROUTE,
-        headers=BEARER_TOKEN | UNRELATED_PROJECT_HEADERS,
         json={
             "agent_id": str(person_id),
             "role_id": str(role_id),
@@ -170,23 +148,18 @@ def test_authorization(client, brain_region_id, species_id, strain_id, person_id
     assert response.status_code == 200
     inaccessible_annotation_id = response.json()["id"]
 
-    response = client.get(
-        f"{ROUTE}/{inaccessible_annotation_id}",
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client_1.get(f"{ROUTE}/{inaccessible_annotation_id}")
     assert response.status_code == 404
 
     public_entity_id = create_reconstruction_morphology_id(
-        client,
-        species_id,
-        strain_id,
-        brain_region_id,
-        headers=BEARER_TOKEN | UNRELATED_PROJECT_HEADERS,
+        client_2,
+        species_id=species_id,
+        strain_id=strain_id,
+        brain_region_id=brain_region_id,
         authorized_public=True,
     )
-    response = client.post(
+    response = client_1.post(
         ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json={
             "agent_id": str(person_id),
             "role_id": str(role_id),
@@ -196,9 +169,8 @@ def test_authorization(client, brain_region_id, species_id, strain_id, person_id
     # can't attach contributions to projects unrelated to us, even if public
     assert response.status_code == 404
 
-    public_obj = client.post(
+    public_obj = client_2.post(
         ROUTE,
-        headers=BEARER_TOKEN | UNRELATED_PROJECT_HEADERS,
         json={
             "agent_id": str(person_id),
             "role_id": str(role_id),
@@ -208,17 +180,11 @@ def test_authorization(client, brain_region_id, species_id, strain_id, person_id
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    response = client.get(
-        f"{ROUTE}/{public_obj['id']}",
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client_1.get(f"{ROUTE}/{public_obj['id']}")
     # can get the contribution if the entity is public
     assert response.status_code == 200
 
-    response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client_1.get(ROUTE)
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 1  # only public entity is available
@@ -227,7 +193,6 @@ def test_authorization(client, brain_region_id, species_id, strain_id, person_id
     assert data[0]["entity"]["authorized_public"]
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_contribution_facets(
     db,
     client,
@@ -263,10 +228,9 @@ def test_contribution_facets(
     ):
         reconstruction_morphology_id = create_reconstruction_morphology_id(
             client,
-            species_id,
-            strain_id,
-            brain_region_id,
-            headers=BEARER_TOKEN | PROJECT_HEADERS,
+            species_id=species_id,
+            strain_id=strain_id,
+            brain_region_id=brain_region_id,
             name=f"TestMorphologyName{i}",
             authorized_public=False,
         )
@@ -283,11 +247,7 @@ def test_contribution_facets(
     assert len(morphology_ids) == 12
     assert contribution_sizes == [2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2]
 
-    response = client.get(
-        ROUTE_MORPH,
-        params={"with_facets": True, "page_size": 10},
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client.get(ROUTE_MORPH, params={"with_facets": True, "page_size": 10})
     data = response.json()
     facets = data["facets"]
     assert facets == {
@@ -313,7 +273,6 @@ def test_contribution_facets(
     response = client.get(
         f"{ROUTE_MORPH}",
         params={"with_facets": True, "contribution__pref_label": "person_pref_label"},
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
     )
     data = response.json()
     facets = data["facets"]

--- a/tests/test_emodel.py
+++ b/tests/test_emodel.py
@@ -179,7 +179,13 @@ def test_facets(client: TestClient, create_faceted_emodel_ids: Ids):
 
 
 def test_authorization(
-    client_1, client_2, species_id, strain_id, brain_region_id, exemplar_morphology_id
+    client_1,
+    client_2,
+    client_no_project,
+    species_id,
+    strain_id,
+    brain_region_id,
+    exemplar_morphology_id,
 ):
     emodel_json = {
         "brain_region_id": brain_region_id,
@@ -248,8 +254,13 @@ def test_authorization(
     }
 
     response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
-
     assert response.status_code == 404
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_emodel["id"]
 
 
 def test_pagination(client, create_emodel_ids):

--- a/tests/test_emodel.py
+++ b/tests/test_emodel.py
@@ -2,24 +2,21 @@ import itertools as it
 import uuid
 from collections.abc import Callable
 
-import pytest
 from fastapi.testclient import TestClient
 
 from .conftest import Ids
-from .utils import BEARER_TOKEN, PROJECT_HEADERS, create_reconstruction_morphology_id
+from .utils import create_reconstruction_morphology_id
 
 ROUTE = "/emodel"
 
 CreateEModelIds = Callable[[int], list[uuid.UUID]]
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_create_emodel(
     client: TestClient, species_id, strain_id, brain_region_id, exemplar_morphology_id
 ):
     response = client.post(
         ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json={
             "brain_region_id": brain_region_id,
             "species_id": species_id,
@@ -38,37 +35,30 @@ def test_create_emodel(
     assert data["species"]["id"] == species_id, f"Failed to get species_id for emodel: {data}"
     assert data["strain"]["id"] == strain_id, f"Failed to get strain_id for emodel: {data}"
 
-    response = client.get(ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(ROUTE)
     assert response.status_code == 200, f"Failed to get emodels: {response.text}"
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_get_emodel(client: TestClient, create_emodel_ids: CreateEModelIds):
     emodel_id = str(create_emodel_ids(1)[0])
-    response = client.get(f"{ROUTE}/{emodel_id}", headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/{emodel_id}")
     assert response.status_code == 200
     assert response.json()["id"] == emodel_id
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_missing(client):
-    response = client.get(f"{ROUTE}/{uuid.uuid4()}", headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/{uuid.uuid4()}")
     assert response.status_code == 404
 
-    response = client.get(f"{ROUTE}/notauuid", headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/notauuid")
     assert response.status_code == 422
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_query_emodel(client: TestClient, create_emodel_ids: CreateEModelIds):
     count = 11
     create_emodel_ids(count)
 
-    response = client.get(
-        ROUTE,
-        params={"page_size": 10},
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = client.get(ROUTE, params={"page_size": 10})
     assert response.status_code == 200
     response_json = response.json()
     assert "facets" in response_json
@@ -76,26 +66,17 @@ def test_query_emodel(client: TestClient, create_emodel_ids: CreateEModelIds):
     assert response_json["facets"] is None
     assert len(response_json["data"]) == 10
 
-    response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"page_size": 100},
-    )
+    response = client.get(ROUTE, params={"page_size": 100})
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 11
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_emodels_sorted(client: TestClient, create_emodel_ids: CreateEModelIds):
     count = 11
     emodel_ids = create_emodel_ids(count)
 
-    response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"order_by": "+creation_date", "page_size": 100},
-    )
+    response = client.get(ROUTE, params={"order_by": "+creation_date", "page_size": 100})
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == count
@@ -103,9 +84,7 @@ def test_emodels_sorted(client: TestClient, create_emodel_ids: CreateEModelIds):
         elem["creation_date"] > prev_elem["creation_date"] for prev_elem, elem in it.pairwise(data)
     )
 
-    response = client.get(
-        ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS, params={"order_by": "-creation_date"}
-    )
+    response = client.get(ROUTE, params={"order_by": "-creation_date"})
     assert response.status_code == 200
     data = response.json()["data"]
 
@@ -113,26 +92,17 @@ def test_emodels_sorted(client: TestClient, create_emodel_ids: CreateEModelIds):
         elem["creation_date"] < prev_elem["creation_date"] for prev_elem, elem in it.pairwise(data)
     )
 
-    response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"order_by": "+creation_date", "page": 1, "page_size": 3},
-    )
+    response = client.get(ROUTE, params={"order_by": "+creation_date", "page": 1, "page_size": 3})
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 3
     assert [row["id"] for row in data] == [str(id_) for id_ in emodel_ids][:3]
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_facets(client: TestClient, create_faceted_emodel_ids: Ids):
     ids = create_faceted_emodel_ids
 
-    response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"with_facets": True},
-    )
+    response = client.get(ROUTE, params={"with_facets": True})
     assert response.status_code == 200
     data = response.json()
 
@@ -168,9 +138,7 @@ def test_facets(client: TestClient, create_faceted_emodel_ids: Ids):
     }
 
     response = client.get(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"search": f"species{ids.species_ids[0]}", "with_facets": True},
+        ROUTE, params={"search": f"species{ids.species_ids[0]}", "with_facets": True}
     )
     assert response.status_code == 200
     data = response.json()
@@ -210,8 +178,9 @@ def test_facets(client: TestClient, create_faceted_emodel_ids: Ids):
     }
 
 
-@pytest.mark.usefixtures("skip_project_check")
-def test_authorization(client, species_id, strain_id, brain_region_id, exemplar_morphology_id):
+def test_authorization(
+    client_1, client_2, species_id, strain_id, brain_region_id, exemplar_morphology_id
+):
     emodel_json = {
         "brain_region_id": brain_region_id,
         "description": "morph description",
@@ -225,9 +194,8 @@ def test_authorization(client, species_id, strain_id, brain_region_id, exemplar_
         "seed": 0,
     }
 
-    public_emodel = client.post(
+    public_emodel = client_1.post(
         ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json=emodel_json
         | {
             "name": "public emodel",
@@ -237,38 +205,20 @@ def test_authorization(client, species_id, strain_id, brain_region_id, exemplar_
     assert public_emodel.status_code == 200
     public_emodel = public_emodel.json()
 
-    unauthorized_exemplar_morphology = client.post(
-        ROUTE,
-        headers=BEARER_TOKEN
-        | {
-            "virtual-lab-id": "42424242-4242-4000-9000-424242424242",
-            "project-id": "42424242-4242-4000-9000-424242424242",
-        },
-        json=emodel_json,
-    )
+    unauthorized_exemplar_morphology = client_2.post(ROUTE, json=emodel_json)
 
     assert unauthorized_exemplar_morphology.status_code == 403
 
     exemplar_morphology_id = create_reconstruction_morphology_id(
-        client,
-        species_id,
-        strain_id,
-        brain_region_id,
-        headers=BEARER_TOKEN
-        | {
-            "virtual-lab-id": "42424242-4242-4000-9000-424242424242",
-            "project-id": "42424242-4242-4000-9000-424242424242",
-        },
+        client_2,
+        species_id=species_id,
+        strain_id=strain_id,
+        brain_region_id=brain_region_id,
         authorized_public=False,
     )
 
-    inaccessible_obj = client.post(
+    inaccessible_obj = client_2.post(
         ROUTE,
-        headers=BEARER_TOKEN
-        | {
-            "virtual-lab-id": "42424242-4242-4000-9000-424242424242",
-            "project-id": "42424242-4242-4000-9000-424242424242",
-        },
         json=emodel_json
         | {"name": "inaccessible emodel", "exemplar_morphology_id": exemplar_morphology_id},
     )
@@ -277,27 +227,16 @@ def test_authorization(client, species_id, strain_id, brain_region_id, exemplar_
 
     inaccessible_obj = inaccessible_obj.json()
 
-    private_emodel0 = client.post(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        json=emodel_json | {"name": "private emodel 0"},
-    )
+    private_emodel0 = client_1.post(ROUTE, json=emodel_json | {"name": "private emodel 0"})
     assert private_emodel0.status_code == 200
     private_emodel0 = private_emodel0.json()
 
-    private_emodel1 = client.post(
-        ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        json=emodel_json
-        | {
-            "name": "private emodel 1",
-        },
-    )
+    private_emodel1 = client_1.post(ROUTE, json=emodel_json | {"name": "private emodel 1"})
     assert private_emodel1.status_code == 200
     private_emodel1 = private_emodel1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client.get(ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -308,30 +247,23 @@ def test_authorization(client, species_id, strain_id, brain_region_id, exemplar_
         private_emodel1["id"],
     }
 
-    response = client.get(
-        f"{ROUTE}/{inaccessible_obj['id']}", headers=BEARER_TOKEN | PROJECT_HEADERS
-    )
+    response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
 
     assert response.status_code == 404
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_pagination(client, create_emodel_ids):
     total_items = 29
     create_emodel_ids(total_items)
 
-    response = client.get(
-        ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS, params={"page_size": total_items + 1}
-    )
+    response = client.get(ROUTE, params={"page_size": total_items + 1})
 
     assert response.status_code == 200
     assert len(response.json()["data"]) == total_items
 
     for i in range(1, total_items + 1):
         expected_items = i
-        response = client.get(
-            ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS, params={"page_size": expected_items}
-        )
+        response = client.get(ROUTE, params={"page_size": expected_items})
 
         assert response.status_code == 200
         data = response.json()["data"]
@@ -343,9 +275,7 @@ def test_pagination(client, create_emodel_ids):
 
     items = []
     for i in range(1, total_items + 1):
-        response = client.get(
-            ROUTE, headers=BEARER_TOKEN | PROJECT_HEADERS, params={"page": i, "page_size": 1}
-        )
+        response = client.get(ROUTE, params={"page": i, "page_size": 1})
 
         assert response.status_code == 200
         data = response.json()["data"]

--- a/tests/test_emodel.py
+++ b/tests/test_emodel.py
@@ -179,8 +179,8 @@ def test_facets(client: TestClient, create_faceted_emodel_ids: Ids):
 
 
 def test_authorization(
-    client_admin,
-    client_user,
+    client_user_1,
+    client_user_2,
     client_no_project,
     species_id,
     strain_id,
@@ -200,7 +200,7 @@ def test_authorization(
         "seed": 0,
     }
 
-    public_emodel = client_admin.post(
+    public_emodel = client_user_1.post(
         ROUTE,
         json=emodel_json
         | {
@@ -211,19 +211,19 @@ def test_authorization(
     assert public_emodel.status_code == 200
     public_emodel = public_emodel.json()
 
-    unauthorized_exemplar_morphology = client_user.post(ROUTE, json=emodel_json)
+    unauthorized_exemplar_morphology = client_user_2.post(ROUTE, json=emodel_json)
 
     assert unauthorized_exemplar_morphology.status_code == 403
 
     exemplar_morphology_id = create_reconstruction_morphology_id(
-        client_user,
+        client_user_2,
         species_id=species_id,
         strain_id=strain_id,
         brain_region_id=brain_region_id,
         authorized_public=False,
     )
 
-    inaccessible_obj = client_user.post(
+    inaccessible_obj = client_user_2.post(
         ROUTE,
         json=emodel_json
         | {"name": "inaccessible emodel", "exemplar_morphology_id": exemplar_morphology_id},
@@ -233,16 +233,16 @@ def test_authorization(
 
     inaccessible_obj = inaccessible_obj.json()
 
-    private_emodel0 = client_admin.post(ROUTE, json=emodel_json | {"name": "private emodel 0"})
+    private_emodel0 = client_user_1.post(ROUTE, json=emodel_json | {"name": "private emodel 0"})
     assert private_emodel0.status_code == 200
     private_emodel0 = private_emodel0.json()
 
-    private_emodel1 = client_admin.post(ROUTE, json=emodel_json | {"name": "private emodel 1"})
+    private_emodel1 = client_user_1.post(ROUTE, json=emodel_json | {"name": "private emodel 1"})
     assert private_emodel1.status_code == 200
     private_emodel1 = private_emodel1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -253,7 +253,7 @@ def test_authorization(
         private_emodel1["id"],
     }
 
-    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_user_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_bouton_density.py
+++ b/tests/test_experimental_bouton_density.py
@@ -69,7 +69,9 @@ def test_missing(client):
     assert response.status_code == 422
 
 
-def test_authorization(client_1, client_2, species_id, strain_id, license_id, brain_region_id):
+def test_authorization(
+    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+):
     js = {
         "brain_region_id": brain_region_id,
         "description": "a great description",
@@ -116,3 +118,9 @@ def test_authorization(client_1, client_2, species_id, strain_id, license_id, br
 
     response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_obj["id"]

--- a/tests/test_experimental_bouton_density.py
+++ b/tests/test_experimental_bouton_density.py
@@ -70,7 +70,7 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
 ):
     js = {
         "brain_region_id": brain_region_id,
@@ -81,7 +81,7 @@ def test_authorization(
         "strain_id": str(strain_id),
     }
 
-    public_obj = client_1.post(
+    public_obj = client_admin.post(
         ROUTE,
         json=js
         | {
@@ -92,20 +92,20 @@ def test_authorization(
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
+    inaccessible_obj = client_user.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client_1.post(ROUTE, json=js | {"name": "private obj 0"})
+    private_obj0 = client_admin.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client_1.post(ROUTE, json=js | {"name": "private obj 1"})
+    private_obj1 = client_admin.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_1.get(ROUTE)
+    response = client_admin.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -116,7 +116,7 @@ def test_authorization(
         private_obj1["id"],
     }
 
-    response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_bouton_density.py
+++ b/tests/test_experimental_bouton_density.py
@@ -1,17 +1,13 @@
-import pytest
-
-from .utils import MISSING_ID, MISSING_ID_COMPACT, PROJECT_HEADERS
+from .utils import MISSING_ID, MISSING_ID_COMPACT
 
 ROUTE = "/experimental-bouton-density"
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_experimental_bouton_density(client, species_id, strain_id, license_id, brain_region_id):
     bouton_description = "Test bouton Description"
     bouton_name = "Test bouton Name"
     response = client.post(
         ROUTE,
-        headers=PROJECT_HEADERS,
         json={
             "brain_region_id": brain_region_id,
             "species_id": species_id,
@@ -45,7 +41,7 @@ def test_experimental_bouton_density(client, species_id, strain_id, license_id, 
         f"Failed to get license for  experimental bouton density: {data}"
     )
 
-    response = client.get(f"{ROUTE}/{data['id']}", headers=PROJECT_HEADERS)
+    response = client.get(f"{ROUTE}/{data['id']}")
     assert response.status_code == 200
     data = response.json()
     assert data["brain_region"]["id"] == brain_region_id
@@ -53,13 +49,12 @@ def test_experimental_bouton_density(client, species_id, strain_id, license_id, 
     assert data["strain"]["id"] == strain_id
     assert data["description"] == bouton_description
 
-    response = client.get(ROUTE, headers=PROJECT_HEADERS)
+    response = client.get(ROUTE)
     assert response.status_code == 200
     data = response.json()["data"]
     assert len(data) == 1
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_missing(client):
     response = client.get(f"{ROUTE}/{MISSING_ID}")
     assert response.status_code == 404
@@ -74,8 +69,7 @@ def test_missing(client):
     assert response.status_code == 422
 
 
-@pytest.mark.usefixtures("skip_project_check")
-def test_authorization(client, species_id, strain_id, license_id, brain_region_id):
+def test_authorization(client_1, client_2, species_id, strain_id, license_id, brain_region_id):
     js = {
         "brain_region_id": brain_region_id,
         "description": "a great description",
@@ -85,9 +79,8 @@ def test_authorization(client, species_id, strain_id, license_id, brain_region_i
         "strain_id": str(strain_id),
     }
 
-    public_obj = client.post(
+    public_obj = client_1.post(
         ROUTE,
-        headers=PROJECT_HEADERS,
         json=js
         | {
             "name": "public obj",
@@ -97,34 +90,20 @@ def test_authorization(client, species_id, strain_id, license_id, brain_region_i
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client.post(
-        ROUTE,
-        headers={
-            "virtual-lab-id": "42424242-4242-4000-9000-424242424242",
-            "project-id": "42424242-4242-4000-9000-424242424242",
-        },
-        json=js | {"name": "unaccessable obj"},
-    )
+    inaccessible_obj = client_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client.post(ROUTE, headers=PROJECT_HEADERS, json=js | {"name": "private obj 0"})
+    private_obj0 = client_1.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client.post(
-        ROUTE,
-        headers=PROJECT_HEADERS,
-        json=js
-        | {
-            "name": "private obj 1",
-        },
-    )
+    private_obj1 = client_1.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client.get(ROUTE, headers=PROJECT_HEADERS)
+    response = client_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -135,5 +114,5 @@ def test_authorization(client, species_id, strain_id, license_id, brain_region_i
         private_obj1["id"],
     }
 
-    response = client.get(f"{ROUTE}/{inaccessible_obj['id']}", headers=PROJECT_HEADERS)
+    response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404

--- a/tests/test_experimental_bouton_density.py
+++ b/tests/test_experimental_bouton_density.py
@@ -70,7 +70,13 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_user_1,
+    client_user_2,
+    client_no_project,
+    species_id,
+    strain_id,
+    license_id,
+    brain_region_id,
 ):
     js = {
         "brain_region_id": brain_region_id,
@@ -81,7 +87,7 @@ def test_authorization(
         "strain_id": str(strain_id),
     }
 
-    public_obj = client_admin.post(
+    public_obj = client_user_1.post(
         ROUTE,
         json=js
         | {
@@ -92,20 +98,20 @@ def test_authorization(
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client_user.post(ROUTE, json=js | {"name": "inaccessible obj"})
+    inaccessible_obj = client_user_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client_admin.post(ROUTE, json=js | {"name": "private obj 0"})
+    private_obj0 = client_user_1.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client_admin.post(ROUTE, json=js | {"name": "private obj 1"})
+    private_obj1 = client_user_1.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -116,7 +122,7 @@ def test_authorization(
         private_obj1["id"],
     }
 
-    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_user_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_neuron_density.py
+++ b/tests/test_experimental_neuron_density.py
@@ -69,7 +69,7 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
 ):
     js = {
         "brain_region_id": brain_region_id,
@@ -80,7 +80,7 @@ def test_authorization(
         "license_id": license_id,
     }
 
-    public_obj = client_1.post(
+    public_obj = client_admin.post(
         ROUTE,
         json=js
         | {
@@ -91,20 +91,20 @@ def test_authorization(
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
+    inaccessible_obj = client_user.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client_1.post(ROUTE, json=js | {"name": "private obj 0"})
+    private_obj0 = client_admin.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client_1.post(ROUTE, json=js | {"name": "private obj 1"})
+    private_obj1 = client_admin.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_1.get(ROUTE)
+    response = client_admin.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -115,7 +115,7 @@ def test_authorization(
         private_obj1["id"],
     }
 
-    response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_neuron_density.py
+++ b/tests/test_experimental_neuron_density.py
@@ -68,7 +68,9 @@ def test_missing(client):
     assert response.status_code == 422
 
 
-def test_authorization(client_1, client_2, species_id, strain_id, license_id, brain_region_id):
+def test_authorization(
+    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+):
     js = {
         "brain_region_id": brain_region_id,
         "species_id": species_id,
@@ -115,3 +117,9 @@ def test_authorization(client_1, client_2, species_id, strain_id, license_id, br
 
     response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_obj["id"]

--- a/tests/test_experimental_neuron_density.py
+++ b/tests/test_experimental_neuron_density.py
@@ -1,17 +1,13 @@
-import pytest
-
-from .utils import MISSING_ID, MISSING_ID_COMPACT, PROJECT_HEADERS
+from .utils import MISSING_ID, MISSING_ID_COMPACT
 
 ROUTE = "/experimental-neuron-density"
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_experimental_neuron_density(client, species_id, strain_id, brain_region_id, license_id):
     neuron_description = "Test neuron Description"
     neuron_name = "Test neuron Name"
     response = client.post(
         ROUTE,
-        headers=PROJECT_HEADERS,
         json={
             "brain_region_id": brain_region_id,
             "species_id": species_id,
@@ -45,10 +41,7 @@ def test_experimental_neuron_density(client, species_id, strain_id, brain_region
         f"Failed to get license for  experimental neuron density: {data}"
     )
 
-    response = client.get(
-        f"{ROUTE}/{data['id']}",
-        headers=PROJECT_HEADERS,
-    )
+    response = client.get(f"{ROUTE}/{data['id']}")
     assert response.status_code == 200
     data = response.json()
     assert data["brain_region"]["id"] == brain_region_id
@@ -56,12 +49,11 @@ def test_experimental_neuron_density(client, species_id, strain_id, brain_region
     assert data["strain"]["id"] == strain_id
     assert data["description"] == neuron_description
 
-    response = client.get(ROUTE, headers=PROJECT_HEADERS)
+    response = client.get(ROUTE)
     assert response.status_code == 200
     assert len(response.json()["data"]) == 1
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_missing(client):
     response = client.get(f"{ROUTE}/{MISSING_ID}")
     assert response.status_code == 404
@@ -76,8 +68,7 @@ def test_missing(client):
     assert response.status_code == 422
 
 
-@pytest.mark.usefixtures("skip_project_check")
-def test_authorization(client, species_id, strain_id, license_id, brain_region_id):
+def test_authorization(client_1, client_2, species_id, strain_id, license_id, brain_region_id):
     js = {
         "brain_region_id": brain_region_id,
         "species_id": species_id,
@@ -87,9 +78,8 @@ def test_authorization(client, species_id, strain_id, license_id, brain_region_i
         "license_id": license_id,
     }
 
-    public_obj = client.post(
+    public_obj = client_1.post(
         ROUTE,
-        headers=PROJECT_HEADERS,
         json=js
         | {
             "name": "public obj",
@@ -99,37 +89,20 @@ def test_authorization(client, species_id, strain_id, license_id, brain_region_i
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client.post(
-        ROUTE,
-        headers={
-            "virtual-lab-id": "42424242-4242-4000-9000-424242424242",
-            "project-id": "42424242-4242-4000-9000-424242424242",
-        },
-        json=js
-        | {
-            "name": "unaccessable obj",
-        },
-    )
+    inaccessible_obj = client_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client.post(ROUTE, headers=PROJECT_HEADERS, json=js | {"name": "private obj 0"})
+    private_obj0 = client_1.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client.post(
-        ROUTE,
-        headers=PROJECT_HEADERS,
-        json=js
-        | {
-            "name": "private obj 1",
-        },
-    )
+    private_obj1 = client_1.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client.get(ROUTE, headers=PROJECT_HEADERS)
+    response = client_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -140,5 +113,5 @@ def test_authorization(client, species_id, strain_id, license_id, brain_region_i
         private_obj1["id"],
     }
 
-    response = client.get(f"{ROUTE}/{inaccessible_obj['id']}", headers=PROJECT_HEADERS)
+    response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404

--- a/tests/test_experimental_neuron_density.py
+++ b/tests/test_experimental_neuron_density.py
@@ -69,7 +69,13 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_user_1,
+    client_user_2,
+    client_no_project,
+    species_id,
+    strain_id,
+    license_id,
+    brain_region_id,
 ):
     js = {
         "brain_region_id": brain_region_id,
@@ -80,7 +86,7 @@ def test_authorization(
         "license_id": license_id,
     }
 
-    public_obj = client_admin.post(
+    public_obj = client_user_1.post(
         ROUTE,
         json=js
         | {
@@ -91,20 +97,20 @@ def test_authorization(
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client_user.post(ROUTE, json=js | {"name": "inaccessible obj"})
+    inaccessible_obj = client_user_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client_admin.post(ROUTE, json=js | {"name": "private obj 0"})
+    private_obj0 = client_user_1.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client_admin.post(ROUTE, json=js | {"name": "private obj 1"})
+    private_obj1 = client_user_1.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -115,7 +121,7 @@ def test_authorization(
         private_obj1["id"],
     }
 
-    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_user_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_synapses_per_connection.py
+++ b/tests/test_experimental_synapses_per_connection.py
@@ -71,7 +71,7 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
 ):
     js = {
         "brain_region_id": brain_region_id,
@@ -82,24 +82,26 @@ def test_authorization(
         "license_id": license_id,
     }
 
-    public_obj = client_1.post(ROUTE, json=js | {"name": "public obj", "authorized_public": True})
+    public_obj = client_admin.post(
+        ROUTE, json=js | {"name": "public obj", "authorized_public": True}
+    )
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
+    inaccessible_obj = client_user.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client_1.post(ROUTE, json=js | {"name": "private obj 0"})
+    private_obj0 = client_admin.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client_1.post(ROUTE, json=js | {"name": "private obj 1"})
+    private_obj1 = client_admin.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_1.get(ROUTE)
+    response = client_admin.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -110,7 +112,7 @@ def test_authorization(
         private_obj1["id"],
     }
 
-    response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_synapses_per_connection.py
+++ b/tests/test_experimental_synapses_per_connection.py
@@ -71,7 +71,13 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_user_1,
+    client_user_2,
+    client_no_project,
+    species_id,
+    strain_id,
+    license_id,
+    brain_region_id,
 ):
     js = {
         "brain_region_id": brain_region_id,
@@ -82,26 +88,26 @@ def test_authorization(
         "license_id": license_id,
     }
 
-    public_obj = client_admin.post(
+    public_obj = client_user_1.post(
         ROUTE, json=js | {"name": "public obj", "authorized_public": True}
     )
     assert public_obj.status_code == 200
     public_obj = public_obj.json()
 
-    inaccessible_obj = client_user.post(ROUTE, json=js | {"name": "inaccessible obj"})
+    inaccessible_obj = client_user_2.post(ROUTE, json=js | {"name": "inaccessible obj"})
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_obj0 = client_admin.post(ROUTE, json=js | {"name": "private obj 0"})
+    private_obj0 = client_user_1.post(ROUTE, json=js | {"name": "private obj 0"})
     assert private_obj0.status_code == 200
     private_obj0 = private_obj0.json()
 
-    private_obj1 = client_admin.post(ROUTE, json=js | {"name": "private obj 1"})
+    private_obj1 = client_user_1.post(ROUTE, json=js | {"name": "private obj 1"})
     assert private_obj1.status_code == 200
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -112,7 +118,7 @@ def test_authorization(
         private_obj1["id"],
     }
 
-    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_user_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_experimental_synapses_per_connection.py
+++ b/tests/test_experimental_synapses_per_connection.py
@@ -70,7 +70,9 @@ def test_missing(client):
     assert response.status_code == 422
 
 
-def test_authorization(client_1, client_2, species_id, strain_id, license_id, brain_region_id):
+def test_authorization(
+    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+):
     js = {
         "brain_region_id": brain_region_id,
         "species_id": species_id,
@@ -110,3 +112,9 @@ def test_authorization(client_1, client_2, species_id, strain_id, license_id, br
 
     response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_obj["id"]

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -3,8 +3,8 @@ from tests.utils import MISSING_ID, MISSING_ID_COMPACT
 ROUTE = "/license"
 
 
-def test_create_license(client):
-    response = client.post(
+def test_create_license(client, client_admin):
+    response = client_admin.post(
         ROUTE,
         json={
             "name": "Test License",

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -234,7 +234,13 @@ def test_query_reconstruction_morphology_species_join(db, client, brain_region_i
 
 
 def test_authorization(
-    client_admin, client_user, client_no_project, species_id, strain_id, license_id, brain_region_id
+    client_user_1,
+    client_user_2,
+    client_no_project,
+    species_id,
+    strain_id,
+    license_id,
+    brain_region_id,
 ):
     morph_json = {
         "location": {"x": 10, "y": 20, "z": 30},
@@ -247,28 +253,28 @@ def test_authorization(
         "strain_id": strain_id,
     }
 
-    public_morph = client_admin.post(
+    public_morph = client_user_1.post(
         ROUTE, json=morph_json | {"name": "public morphology", "authorized_public": True}
     )
     assert public_morph.status_code == 200
     public_morph = public_morph.json()
 
-    inaccessible_obj = client_user.post(
+    inaccessible_obj = client_user_2.post(
         ROUTE, json=morph_json | {"name": "inaccessible morphology 1"}
     )
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
 
-    private_morph0 = client_admin.post(ROUTE, json=morph_json | {"name": "private morphology 0"})
+    private_morph0 = client_user_1.post(ROUTE, json=morph_json | {"name": "private morphology 0"})
     assert private_morph0.status_code == 200
     private_morph0 = private_morph0.json()
 
-    private_morph1 = client_admin.post(ROUTE, json=morph_json | {"name": "private morphology 1"})
+    private_morph1 = client_user_1.post(ROUTE, json=morph_json | {"name": "private morphology 1"})
     assert private_morph1.status_code == 200
     private_morph1 = private_morph1.json()
 
     # only return results that matches the desired project, and public ones
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     data = response.json()["data"]
     assert len(data) == 3
 
@@ -279,7 +285,7 @@ def test_authorization(
         private_morph1["id"],
     }
 
-    response = client_admin.get(f"{ROUTE}/{inaccessible_obj['id']}")
+    response = client_user_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
 
     # only return public results

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -233,7 +233,9 @@ def test_query_reconstruction_morphology_species_join(db, client, brain_region_i
     }
 
 
-def test_authorization(client_1, client_2, species_id, strain_id, license_id, brain_region_id):
+def test_authorization(
+    client_1, client_2, client_no_project, species_id, strain_id, license_id, brain_region_id
+):
     morph_json = {
         "location": {"x": 10, "y": 20, "z": 30},
         "brain_region_id": brain_region_id,
@@ -277,6 +279,12 @@ def test_authorization(client_1, client_2, species_id, strain_id, license_id, br
 
     response = client_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
     assert response.status_code == 404
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_morph["id"]
 
 
 def test_pagination(db, client, brain_region_id):

--- a/tests/test_morphology_feature_annotation.py
+++ b/tests/test_morphology_feature_annotation.py
@@ -119,7 +119,7 @@ def test_missing(client):
 
 
 def test_authorization(
-    client_admin, client_user, client_no_project, species_id, strain_id, brain_region_id
+    client_user_1, client_user_2, client_no_project, species_id, strain_id, brain_region_id
 ):
     annotation_js = {
         "measurements": [
@@ -140,14 +140,14 @@ def test_authorization(
     }
 
     reconstruction_morphology_id_public = create_reconstruction_morphology_id(
-        client_admin,
+        client_user_1,
         species_id=species_id,
         strain_id=strain_id,
         brain_region_id=brain_region_id,
         authorized_public=True,
     )
 
-    response = client_admin.post(
+    response = client_user_1.post(
         ROUTE,
         json=annotation_js | {"reconstruction_morphology_id": reconstruction_morphology_id_public},
     )
@@ -155,7 +155,7 @@ def test_authorization(
     morphology_feature_annotation_id_public = response.json()["id"]
 
     reconstruction_morphology_id_inaccessible = create_reconstruction_morphology_id(
-        client_user,
+        client_user_2,
         species_id=species_id,
         strain_id=strain_id,
         brain_region_id=brain_region_id,
@@ -163,7 +163,7 @@ def test_authorization(
     )
 
     # try to add annotation to inaccessible reconstruction
-    response = client_admin.post(
+    response = client_user_1.post(
         ROUTE,
         json=annotation_js
         | {"reconstruction_morphology_id": reconstruction_morphology_id_inaccessible},
@@ -171,31 +171,31 @@ def test_authorization(
     assert response.status_code == 404
 
     # succeed to add annotation to inaccessible reconstruction with a different client
-    response = client_user.post(
+    response = client_user_2.post(
         ROUTE,
         json=annotation_js
         | {"reconstruction_morphology_id": reconstruction_morphology_id_inaccessible},
     )
     assert response.status_code == 200
 
-    response = client_admin.get(f"{ROUTE}/{response.json()['id']}")
+    response = client_user_1.get(f"{ROUTE}/{response.json()['id']}")
     assert response.status_code == 404
 
     reconstruction_morphology_id_public_inaccessible = create_reconstruction_morphology_id(
-        client_user,
+        client_user_2,
         species_id=species_id,
         strain_id=strain_id,
         brain_region_id=brain_region_id,
         authorized_public=True,
     )
-    response = client_admin.post(
+    response = client_user_1.post(
         ROUTE,
         json=annotation_js
         | {"reconstruction_morphology_id": reconstruction_morphology_id_public_inaccessible},
     )
     assert response.status_code == 404
 
-    response = client_admin.get(ROUTE)
+    response = client_user_1.get(ROUTE)
     assert response.status_code == 200
     assert len(response.json()["data"]) == 1
 

--- a/tests/test_mtype.py
+++ b/tests/test_mtype.py
@@ -1,14 +1,10 @@
 from unittest.mock import ANY
 
-import pytest
-
 from app.db.model import MTypeClass, MTypeClassification
 
 from .utils import (
-    BEARER_TOKEN,
     MISSING_ID,
     MISSING_ID_COMPACT,
-    PROJECT_HEADERS,
     add_all_db,
     add_db,
     create_reconstruction_morphology_id,
@@ -84,14 +80,12 @@ def test_missing(client):
     assert response.status_code == 422
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
     morph_id = create_reconstruction_morphology_id(
         client,
         species_id,
         strain_id,
         brain_region_id,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         authorized_public=False,
     )
 
@@ -101,11 +95,7 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
     add_db(db, MTypeClassification(entity_id=morph_id, mtype_class_id=mtype1.id))
     add_db(db, MTypeClassification(entity_id=morph_id, mtype_class_id=mtype2.id))
 
-    response = client.get(
-        ROUTE_MORPH,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"with_facets": True},
-    )
+    response = client.get(ROUTE_MORPH, params={"with_facets": True})
     assert response.status_code == 200
     facets = response.json()["facets"]
     assert facets["mtype"] == [
@@ -113,7 +103,7 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
         {"id": str(mtype2.id), "label": "m2", "count": 1, "type": "mtype"},
     ]
 
-    response = client.get(f"{ROUTE_MORPH}/{morph_id}", headers=BEARER_TOKEN | PROJECT_HEADERS)
+    response = client.get(f"{ROUTE_MORPH}/{morph_id}")
     assert response.status_code == 200
     data = response.json()
     assert "mtypes" in data
@@ -139,11 +129,7 @@ def test_morph_mtypes(db, client, species_id, strain_id, brain_region_id):
         },
     ]
 
-    response = client.get(
-        ROUTE_MORPH,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        params={"with_facets": True, "mtype__pref_label": "m1"},
-    )
+    response = client.get(ROUTE_MORPH, params={"with_facets": True, "mtype__pref_label": "m1"})
     assert response.status_code == 200
     facets = response.json()["facets"]
     assert facets["mtype"] == [

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -3,10 +3,10 @@ from tests.utils import MISSING_ID, MISSING_ID_COMPACT
 ROUTE = "/organization"
 
 
-def test_create_organization(client):
+def test_create_organization(client, client_admin):
     label = "test_organization label"
     alternative_name = "test organization alternative name"
-    response = client.post(
+    response = client_admin.post(
         ROUTE,
         json={"pref_label": label, "alternative_name": alternative_name},
     )

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -3,8 +3,8 @@ from tests.utils import MISSING_ID, MISSING_ID_COMPACT
 ROUTE = "/person"
 
 
-def test_create_person(client):
-    response = client.post(
+def test_create_person(client, client_admin):
+    response = client_admin.post(
         ROUTE,
         json={"givenName": "jd", "familyName": "courcol", "pref_label": "jd courcol"},
     )

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -3,10 +3,10 @@ from tests.utils import MISSING_ID, MISSING_ID_COMPACT
 ROUTE = "/role"
 
 
-def test_create_role(client):
+def test_create_role(client, client_admin):
     name = "important role"
     role_id = "important role id"
-    response = client.post(ROUTE, json={"name": name, "role_id": role_id})
+    response = client_admin.post(ROUTE, json={"name": name, "role_id": role_id})
     assert response.status_code == 200
     data = response.json()
     assert data["name"] == name

--- a/tests/test_single_neuron_simulation.py
+++ b/tests/test_single_neuron_simulation.py
@@ -5,10 +5,8 @@ import pytest
 from app.db.model import MEModel, SingleNeuronSimulation
 
 from .utils import (
-    BEARER_TOKEN,
     MISSING_ID,
     MISSING_ID_COMPACT,
-    PROJECT_HEADERS,
     PROJECT_ID,
     add_db,
     assert_request,
@@ -31,12 +29,10 @@ def me_model_id(db, brain_region_id):
     return row.id
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_single_neuron_simulation(client, brain_region_id, me_model_id):
     response = assert_request(
         client.post,
         url=ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json={
             "name": "foo",
             "description": "my-description",
@@ -60,13 +56,10 @@ def test_single_neuron_simulation(client, brain_region_id, me_model_id):
     assert data["recordingLocation"] == ["soma[0]_0.5"]
     assert data["me_model"]["id"] == str(me_model_id), f"Failed to get id frmo me model; {data}"
     assert data["status"] == "success"
-    assert data["authorized_project_id"] == PROJECT_HEADERS["project-id"]
+    assert data["authorized_project_id"] == PROJECT_ID
 
-    response = assert_request(
-        client.get,
-        url=f"{ROUTE}/{data['id']}",
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = assert_request(client.get, url=f"{ROUTE}/{data['id']}")
+    data = response.json()
     assert data["brain_region"]["id"] == brain_region_id, (
         f"Failed to get id for reconstruction morphology: {data}"
     )
@@ -76,10 +69,9 @@ def test_single_neuron_simulation(client, brain_region_id, me_model_id):
     assert data["recordingLocation"] == ["soma[0]_0.5"]
     assert data["me_model"]["id"] == str(me_model_id), f"Failed to get id frmo me model; {data}"
     assert data["status"] == "success"
-    assert data["authorized_project_id"] == PROJECT_HEADERS["project-id"]
+    assert data["authorized_project_id"] == PROJECT_ID
 
 
-@pytest.mark.usefixtures("skip_project_check")
 @pytest.mark.parametrize(
     ("route_id", "expected_status_code"),
     [
@@ -93,13 +85,11 @@ def test_missing(client, route_id, expected_status_code):
     assert_request(
         client.get,
         url=f"{ROUTE}/{route_id}",
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         expected_status_code=expected_status_code,
     )
 
 
-@pytest.mark.usefixtures("skip_project_check")
-def test_authorization(client, me_model_id, brain_region_id):
+def test_authorization(client_1, client_2, me_model_id, brain_region_id):
     json_data = {
         "name": "foo",
         "description": "my-description",
@@ -112,54 +102,35 @@ def test_authorization(client, me_model_id, brain_region_id):
     }
 
     response = assert_request(
-        client.post,
+        client_1.post,
         url=ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        json=json_data
-        | {
-            "name": "Public Entity",
-            "authorized_public": True,
-        },
+        json=json_data | {"name": "Public Entity", "authorized_public": True},
     )
     public_morph = response.json()
 
     inaccessible_obj = assert_request(
-        client.post,
+        client_2.post,
         url=ROUTE,
-        headers=BEARER_TOKEN
-        | {
-            "virtual-lab-id": "42424242-4242-4000-9000-424242424242",
-            "project-id": "42424242-4242-4000-9000-424242424242",
-        },
-        json=json_data | {"name": "unaccessable morphology 1"},
+        json=json_data | {"name": "inaccessible morphology 1"},
     )
     inaccessible_obj = inaccessible_obj.json()
 
     private_obj0 = assert_request(
-        client.post,
+        client_1.post,
         url=ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         json=json_data | {"name": "private morphology 0"},
     )
     private_obj0 = private_obj0.json()
 
     private_obj1 = assert_request(
-        client.post,
+        client_1.post,
         url=ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-        json=json_data
-        | {
-            "name": "private morphology 1",
-        },
+        json=json_data | {"name": "private morphology 1"},
     )
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = assert_request(
-        client.get,
-        url=ROUTE,
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = assert_request(client_1.get, url=ROUTE)
     data = response.json()["data"]
 
     ids = {row["id"] for row in data}
@@ -170,14 +141,12 @@ def test_authorization(client, me_model_id, brain_region_id):
     }, data
 
     assert_request(
-        client.get,
+        client_1.get,
         url=f"{ROUTE}/{inaccessible_obj['id']}",
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
         expected_status_code=404,
     )
 
 
-@pytest.mark.usefixtures("skip_project_check")
 def test_pagination(db, client, brain_region_id):
     me_model_1 = add_db(
         db,
@@ -223,12 +192,7 @@ def test_pagination(db, client, brain_region_id):
     count = 7
     create(count)
 
-    response = assert_request(
-        client.get,
-        url=ROUTE,
-        params={"page_size": 3},
-        headers=BEARER_TOKEN | PROJECT_HEADERS,
-    )
+    response = assert_request(client.get, url=ROUTE, params={"page_size": 3})
     response_json = response.json()
     assert "facets" in response_json
     assert "data" in response_json

--- a/tests/test_single_neuron_simulation.py
+++ b/tests/test_single_neuron_simulation.py
@@ -89,7 +89,7 @@ def test_missing(client, route_id, expected_status_code):
     )
 
 
-def test_authorization(client_1, client_2, client_no_project, me_model_id, brain_region_id):
+def test_authorization(client_admin, client_user, client_no_project, me_model_id, brain_region_id):
     json_data = {
         "name": "foo",
         "description": "my-description",
@@ -102,35 +102,35 @@ def test_authorization(client_1, client_2, client_no_project, me_model_id, brain
     }
 
     response = assert_request(
-        client_1.post,
+        client_admin.post,
         url=ROUTE,
         json=json_data | {"name": "Public Entity", "authorized_public": True},
     )
     public_morph = response.json()
 
     inaccessible_obj = assert_request(
-        client_2.post,
+        client_user.post,
         url=ROUTE,
         json=json_data | {"name": "inaccessible morphology 1"},
     )
     inaccessible_obj = inaccessible_obj.json()
 
     private_obj0 = assert_request(
-        client_1.post,
+        client_admin.post,
         url=ROUTE,
         json=json_data | {"name": "private morphology 0"},
     )
     private_obj0 = private_obj0.json()
 
     private_obj1 = assert_request(
-        client_1.post,
+        client_admin.post,
         url=ROUTE,
         json=json_data | {"name": "private morphology 1"},
     )
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = assert_request(client_1.get, url=ROUTE)
+    response = assert_request(client_admin.get, url=ROUTE)
     data = response.json()["data"]
 
     ids = {row["id"] for row in data}
@@ -141,7 +141,7 @@ def test_authorization(client_1, client_2, client_no_project, me_model_id, brain
     }, data
 
     assert_request(
-        client_1.get,
+        client_admin.get,
         url=f"{ROUTE}/{inaccessible_obj['id']}",
         expected_status_code=404,
     )

--- a/tests/test_single_neuron_simulation.py
+++ b/tests/test_single_neuron_simulation.py
@@ -89,7 +89,7 @@ def test_missing(client, route_id, expected_status_code):
     )
 
 
-def test_authorization(client_1, client_2, me_model_id, brain_region_id):
+def test_authorization(client_1, client_2, client_no_project, me_model_id, brain_region_id):
     json_data = {
         "name": "foo",
         "description": "my-description",
@@ -145,6 +145,12 @@ def test_authorization(client_1, client_2, me_model_id, brain_region_id):
         url=f"{ROUTE}/{inaccessible_obj['id']}",
         expected_status_code=404,
     )
+
+    # only return public results
+    response = client_no_project.get(ROUTE)
+    data = response.json()["data"]
+    assert len(data) == 1
+    assert data[0]["id"] == public_morph["id"]
 
 
 def test_pagination(db, client, brain_region_id):

--- a/tests/test_single_neuron_simulation.py
+++ b/tests/test_single_neuron_simulation.py
@@ -89,7 +89,9 @@ def test_missing(client, route_id, expected_status_code):
     )
 
 
-def test_authorization(client_admin, client_user, client_no_project, me_model_id, brain_region_id):
+def test_authorization(
+    client_user_1, client_user_2, client_no_project, me_model_id, brain_region_id
+):
     json_data = {
         "name": "foo",
         "description": "my-description",
@@ -102,35 +104,35 @@ def test_authorization(client_admin, client_user, client_no_project, me_model_id
     }
 
     response = assert_request(
-        client_admin.post,
+        client_user_1.post,
         url=ROUTE,
         json=json_data | {"name": "Public Entity", "authorized_public": True},
     )
     public_morph = response.json()
 
     inaccessible_obj = assert_request(
-        client_user.post,
+        client_user_2.post,
         url=ROUTE,
         json=json_data | {"name": "inaccessible morphology 1"},
     )
     inaccessible_obj = inaccessible_obj.json()
 
     private_obj0 = assert_request(
-        client_admin.post,
+        client_user_1.post,
         url=ROUTE,
         json=json_data | {"name": "private morphology 0"},
     )
     private_obj0 = private_obj0.json()
 
     private_obj1 = assert_request(
-        client_admin.post,
+        client_user_1.post,
         url=ROUTE,
         json=json_data | {"name": "private morphology 1"},
     )
     private_obj1 = private_obj1.json()
 
     # only return results that matches the desired project, and public ones
-    response = assert_request(client_admin.get, url=ROUTE)
+    response = assert_request(client_user_1.get, url=ROUTE)
     data = response.json()["data"]
 
     ids = {row["id"] for row in data}
@@ -141,7 +143,7 @@ def test_authorization(client_admin, client_user, client_no_project, me_model_id
     }, data
 
     assert_request(
-        client_admin.get,
+        client_user_1.get,
         url=f"{ROUTE}/{inaccessible_obj['id']}",
         expected_status_code=404,
     )

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -3,13 +3,13 @@ from tests.utils import MISSING_ID, MISSING_ID_COMPACT
 ROUTE = "/species"
 
 
-def test_create_species(client):
+def test_create_species(client, client_admin):
     count = 3
     items = []
     for i in range(count):
         name = f"Test Species {i}"
         taxonomy_id = f"12345_{i}"
-        response = client.post(ROUTE, json={"name": name, "taxonomy_id": taxonomy_id})
+        response = client_admin.post(ROUTE, json={"name": name, "taxonomy_id": taxonomy_id})
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == name

--- a/tests/test_strain.py
+++ b/tests/test_strain.py
@@ -3,13 +3,13 @@ from tests.utils import MISSING_ID, MISSING_ID_COMPACT
 ROUTE = "/strain"
 
 
-def test_create_strain(client, species_id):
+def test_create_strain(client, client_admin, species_id):
     count = 3
     items = []
     for i in range(count):
         name = f"Test Strain {i}"
         taxonomy_id = f"TaxonomyID_{i}"
-        response = client.post(
+        response = client_admin.post(
             ROUTE,
             json={
                 "name": name,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,19 +1,17 @@
-from contextlib import contextmanager
+import functools
 from pathlib import Path
-from typing import Annotated
 
-from fastapi import Depends, Header
-from fastapi.security import HTTPAuthorizationCredentials
-
-from app.application import app
-from app.dependencies.auth import AuthHeader, verify_project_context
-from app.schemas.base import ProjectContext
+from httpx import Headers
+from starlette.testclient import TestClient
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 
 BEARER_TOKEN = {"Authorization": "Bearer this is a fake token"}
+
 VIRTUAL_LAB_ID = "9c6fba01-2c6f-4eac-893f-f0dc665605c5"
 PROJECT_ID = "ee86d4a0-eaca-48ca-9788-ddc450250b15"
+UNRELATED_VIRTUAL_LAB_ID = "99999999-2c6f-4eac-893f-f0dc665605c5"
+UNRELATED_PROJECT_ID = "66666666-eaca-48ca-9788-ddc450250b15"
 
 MISSING_ID = "12345678-1234-5678-1234-567812345678"
 MISSING_ID_COMPACT = MISSING_ID.replace("-", "")
@@ -22,35 +20,35 @@ PROJECT_HEADERS = {
     "virtual-lab-id": VIRTUAL_LAB_ID,
     "project-id": PROJECT_ID,
 }
-
 UNRELATED_PROJECT_HEADERS = {
-    "virtual-lab-id": "99999999-2c6f-4eac-893f-f0dc665605c5",
-    "project-id": "66666666-eaca-48ca-9788-ddc450250b15",
+    "virtual-lab-id": UNRELATED_VIRTUAL_LAB_ID,
+    "project-id": UNRELATED_PROJECT_ID,
 }
 
 
-@contextmanager
-def skip_project_check():
-    """Skip checking if Bearer token has access to the project-id
+class ClientProxy:
+    """Proxy TestClient to pass default headers without creating a new instance.
 
-    Note: Otherwise, the keycloak endpoint is called,
-          depending on the config.py::Settings.KEYCLOAK_URL
+    This can be used to avoid running the lifespan event multiple times.
     """
 
-    def mock_verify_project_context(
-        project_context: Annotated[ProjectContext, Header()],
-        token: Annotated[HTTPAuthorizationCredentials, Depends(AuthHeader)],
-    ) -> ProjectContext:
-        assert f"{token.scheme} {token.credentials}" == BEARER_TOKEN["Authorization"]
-        return project_context
+    def __init__(self, client: TestClient, headers: dict | None = None) -> None:
+        self._client = client
+        self._headers = headers
+        self._methods = {"request", "get", "options", "head", "post", "put", "patch", "delete"}
 
-    orig = dict(app.dependency_overrides)
-    app.dependency_overrides[verify_project_context] = mock_verify_project_context
+    def __getattr__(self, name: str):
+        def decorator(f):
+            @functools.wraps(f)
+            def wrapper(*args, headers=None, **kwargs):
+                merged_headers = Headers(self._headers)
+                merged_headers.update(headers)
+                return f(*args, headers=merged_headers, **kwargs)
 
-    try:
-        yield
-    finally:
-        app.dependency_overrides = orig
+            return wrapper
+
+        method = getattr(self._client, name)
+        return decorator(method) if name in self._methods else method
 
 
 def create_reconstruction_morphology_id(
@@ -58,14 +56,12 @@ def create_reconstruction_morphology_id(
     species_id,
     strain_id,
     brain_region_id,
-    headers,
     authorized_public,
     name="Test Morphology Name",
     description="Test Morphology Description",
 ):
     response = client.post(
         "/reconstruction-morphology",
-        headers=headers,
         json={
             "name": name,
             "description": description,
@@ -99,5 +95,8 @@ def add_all_db(db, rows):
 
 def assert_request(client_method, *, expected_status_code=200, **kwargs):
     response = client_method(**kwargs)
-    assert response.status_code == expected_status_code, response.content
+    assert response.status_code == expected_status_code, (
+        f"expected={expected_status_code}, actual={response.status_code}, "
+        f"content={response.content}"
+    )
     return response

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,11 @@ from starlette.testclient import TestClient
 
 TEST_DATA_DIR = Path(__file__).parent / "data"
 
-BEARER_TOKEN = {"Authorization": "Bearer this is a fake token"}
+TOKEN_ADMIN = "I'm admin"  # noqa: S105
+TOKEN_USER = "I'm user"  # noqa: S105
+
+AUTH_HEADER_ADMIN = {"Authorization": f"Bearer {TOKEN_ADMIN}"}
+AUTH_HEADER_USER = {"Authorization": f"Bearer {TOKEN_USER}"}
 
 VIRTUAL_LAB_ID = "9c6fba01-2c6f-4eac-893f-f0dc665605c5"
 PROJECT_ID = "ee86d4a0-eaca-48ca-9788-ddc450250b15"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,10 +7,12 @@ from starlette.testclient import TestClient
 TEST_DATA_DIR = Path(__file__).parent / "data"
 
 TOKEN_ADMIN = "I'm admin"  # noqa: S105
-TOKEN_USER = "I'm user"  # noqa: S105
+TOKEN_USER_1 = "I'm user 1"  # noqa: S105
+TOKEN_USER_2 = "I'm user 2"  # noqa: S105
 
 AUTH_HEADER_ADMIN = {"Authorization": f"Bearer {TOKEN_ADMIN}"}
-AUTH_HEADER_USER = {"Authorization": f"Bearer {TOKEN_USER}"}
+AUTH_HEADER_USER_1 = {"Authorization": f"Bearer {TOKEN_USER_1}"}
+AUTH_HEADER_USER_2 = {"Authorization": f"Bearer {TOKEN_USER_2}"}
 
 VIRTUAL_LAB_ID = "9c6fba01-2c6f-4eac-893f-f0dc665605c5"
 PROJECT_ID = "ee86d4a0-eaca-48ca-9788-ddc450250b15"

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -264,6 +273,7 @@ dependencies = [
     { name = "alembic-utils" },
     { name = "bidict" },
     { name = "boto3" },
+    { name = "cachetools" },
     { name = "click" },
     { name = "deepdiff" },
     { name = "fastapi" },
@@ -272,10 +282,10 @@ dependencies = [
     { name = "psycopg2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "tqdm" },
-    { name = "types-boto3-lite", extra = ["essential"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -287,7 +297,10 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-httpx" },
     { name = "ruff" },
+    { name = "types-boto3-lite", extra = ["essential"] },
+    { name = "types-cachetools" },
     { name = "types-pyyaml" },
 ]
 
@@ -298,6 +311,7 @@ requires-dist = [
     { name = "alembic-utils", specifier = ">=0.8.6" },
     { name = "bidict" },
     { name = "boto3", specifier = ">=1.36.3" },
+    { name = "cachetools", specifier = ">=5.5.2" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "deepdiff" },
     { name = "fastapi" },
@@ -306,10 +320,10 @@ requires-dist = [
     { name = "psycopg2" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
+    { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sqlalchemy" },
     { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "types-boto3-lite", extras = ["essential"], specifier = ">=1.36.11" },
     { name = "uvicorn", extras = ["standard"] },
 ]
 
@@ -321,7 +335,10 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "ruff" },
+    { name = "types-boto3-lite", extras = ["essential"], specifier = ">=1.36.11" },
+    { name = "types-cachetools", specifier = ">=5.5.0.20240820" },
     { name = "types-pyyaml" },
 ]
 
@@ -683,6 +700,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +734,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/89/5b12b7b29e3d0af3a4b9c071ee92fa25a9017453731a38f08ba01c280f4c/pytest_httpx-0.35.0.tar.gz", hash = "sha256:d619ad5d2e67734abfbb224c3d9025d64795d4b8711116b1a13f72a251ae511f", size = 54146 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ed/026d467c1853dd83102411a78126b4842618e86c895f93528b0528c7a620/pytest_httpx-0.35.0-py3-none-any.whl", hash = "sha256:ee11a00ffcea94a5cbff47af2114d34c5b231c326902458deed73f9c459fd744", size = 19442 },
 ]
 
 [[package]]
@@ -980,6 +1019,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/cf/2d6b90fb0dab9b3200ad357f9851c09de99072bcf3129fa7b89c113bcd54/types_boto3_sqs-1.37.0.tar.gz", hash = "sha256:37bd73d2a0810f9b685a3230aac87543d88e55e92d0b26a142c7d220c375bfd3", size = 23366 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/c1/79ca53904b8452ba2519b3480b0bf9068f46e68776ff7c8299ef18dd1a61/types_boto3_sqs-1.37.0-py3-none-any.whl", hash = "sha256:3de05af6afeb77cefbe816556cec12c46a436f31a63cf2647cb7a09892a0d39b", size = 33410 },
+]
+
+[[package]]
+name = "types-cachetools"
+version = "5.5.0.20240820"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/7e/ad6ba4a56b2a994e0f0a04a61a50466b60ee88a13d10a18c83ac14a66c61/types-cachetools-5.5.0.20240820.tar.gz", hash = "sha256:b888ab5c1a48116f7799cd5004b18474cd82b5463acb5ffb2db2fc9c7b053bc0", size = 4198 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/4d/fd7cc050e2d236d5570c4d92531c0396573a1e14b31735870e849351c717/types_cachetools-5.5.0.20240820-py3-none-any.whl", hash = "sha256:efb2ed8bf27a4b9d3ed70d33849f536362603a90b8090a328acf0cd42fda82e2", size = 4149 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-freezer" },
     { name = "pytest-httpx" },
     { name = "ruff" },
     { name = "types-boto3-lite", extra = ["essential"] },
@@ -335,6 +336,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-freezer", specifier = ">=0.4.9" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "ruff" },
     { name = "types-boto3-lite", extras = ["essential"], specifier = ">=1.36.11" },
@@ -377,6 +379,18 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/ce/18f6d9969416d8c9e0728f042091717606f2cd46d570aff6533ce587e71f/flupy-1.2.1.tar.gz", hash = "sha256:42aab3b4b3eb1984a4616c40d8f049ecdee546eaad9467470731d456dbff7fa4", size = 12346 }
+
+[[package]]
+name = "freezegun"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ef/722b8d71ddf4d48f25f6d78aa2533d505bf3eec000a7cacb8ccc8de61f2f/freezegun-1.5.1.tar.gz", hash = "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9", size = 33697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/0b/0d7fee5919bccc1fdc1c2a7528b98f65c6f69b223a3fd8f809918c142c36/freezegun-1.5.1-py3-none-any.whl", hash = "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1", size = 17569 },
+]
 
 [[package]]
 name = "greenlet"
@@ -734,6 +748,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "pytest-freezer"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "freezegun" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/f0/98dcbc5324064360b19850b14c84cea9ca50785d921741dbfc442346e925/pytest_freezer-0.4.9.tar.gz", hash = "sha256:21bf16bc9cc46bf98f94382c4b5c3c389be7056ff0be33029111ae11b3f1c82a", size = 3177 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/e9/30252bc05bcf67200a17f4f0b4cc7598f0a68df4fa9fa356193aa899f145/pytest_freezer-0.4.9-py3-none-any.whl", hash = "sha256:8b6c50523b7d4aec4590b52bfa5ff766d772ce506e2bf4846c88041ea9ccae59", size = 3192 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 1
 requires-python = "==3.12.*"
 
+[options]
+exclude-newer = "2025-03-24T00:00:00Z"
+
 [[package]]
 name = "alembic"
 version = "1.15.1"
@@ -53,16 +56,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.8.0"
+version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
 ]
 
 [[package]]
@@ -76,42 +79,42 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.37.10"
+version = "1.37.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/65/9bb28b0297a1cefd912fb6974a4231d581fb3188707526e7601c3ccdf6dd/boto3-1.37.10.tar.gz", hash = "sha256:0c6eb8191b1ea4c7a139e56425399405d46e86c7e814ef497176b9af1f7ca056", size = 111331 }
+sdist = { url = "https://files.pythonhosted.org/packages/87/42/2b102f999c76614e55afd8a8c2392c35ce2f390cdeb78007aba029cd1171/boto3-1.37.18.tar.gz", hash = "sha256:9b272268794172b0b8bb9fb1f3c470c3b6c0ffb92fbd4882465cc740e40fbdcd", size = 111358 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/ed/013209af8268b0d8544bdac128aca9970295bd5b95d89f9204c4d3d0fe7b/boto3-1.37.10-py3-none-any.whl", hash = "sha256:fc649fb4c9521f60660fd562d6bf2034753832968b0c93ec60ad30634afb1b0f", size = 139551 },
+    { url = "https://files.pythonhosted.org/packages/12/94/dccc4dd874cf455c8ea6dfb4c43a224632c03c3f503438aa99021759a097/boto3-1.37.18-py3-none-any.whl", hash = "sha256:1545c943f36db41853cdfdb6ff09c4eda9220dd95bd2fae76fc73091603525d1", size = 139561 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.37.10"
+version = "1.37.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/16/c782d8bb598da5e123cf6208bbe6527b5c391c81ae73f9fa7371a6f1820f/botocore-1.37.10.tar.gz", hash = "sha256:ab311982a9872eeb4e71906d3e3fcd2ba331a869d0fed16836ade7ce2e58bcea", size = 13636458 }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/fa/a176046c74032ca3bda68c71ad544602a69be21d7ee3b199f4f2099fe4bf/botocore-1.37.18.tar.gz", hash = "sha256:99e8eefd5df6347ead15df07ce55f4e62a51ea7b54de1127522a08597923b726", size = 13667977 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/82/86d1108838084cc591add7bf09762bdb0bbeeaf7f23e1a1b582b6f657978/botocore-1.37.10-py3-none-any.whl", hash = "sha256:7515c8dfaaf5ba02604db9cf73c172615afee976136f31d8aec628629f24029f", size = 13406391 },
+    { url = "https://files.pythonhosted.org/packages/a9/fd/059e57de7405b1ba93117c1b79a6daa45d6865f557b892f3cc7645836f3b/botocore-1.37.18-py3-none-any.whl", hash = "sha256:a8b97d217d82b3c4f6bcc906e264df7ebb51e2c6a62b3548a97cd173fb8759a1", size = 13428387 },
 ]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.37.10"
+version = "1.37.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/18/1ba668afadc7d466005f984991132dd720c63d655ed122d6be5721f94a46/botocore_stubs-1.37.10.tar.gz", hash = "sha256:e6183ca37b7b3b5c36daae38d44040858cf7ce69d02797d4d3d4d800985c10b4", size = 42102 }
+sdist = { url = "https://files.pythonhosted.org/packages/53/fa/3f33f6c7eafa1fa40c24849f30a5f2747fdf01ca7a6ac1301058b4f17e45/botocore_stubs-1.37.18.tar.gz", hash = "sha256:937c9b787e4f784019f321fa1d88a505965c25f425e810bde45e23b7ca564282", size = 42125 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/84/b428b58004a39ae82baaa80bcd82b96abcfbc00c9bc68d1c47a2aadbe7d7/botocore_stubs-1.37.10-py3-none-any.whl", hash = "sha256:a7e9acc0085cb42332f55a5e99b7e06ee7b18b8be6ac9ef7ad8dbac2a5c44145", size = 65387 },
+    { url = "https://files.pythonhosted.org/packages/24/ac/6a814919a3144ebad74fbedbcf18dc4bbad5caa6906555943d372891caff/botocore_stubs-1.37.18-py3-none-any.whl", hash = "sha256:bb9a9e7cd2f48ecb429a7d0df0387f63399db8fb363bdfa38eba285854d622a2", size = 65423 },
 ]
 
 [[package]]
@@ -199,21 +202,21 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.6.12"
+version = "7.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/d6/2b53ab3ee99f2262e6f0b8369a43f6d66658eab45510331c0b3d5c8c4272/coverage-7.6.12.tar.gz", hash = "sha256:48cfc4641d95d34766ad41d9573cc0f22a48aa88d22657a1fe01dca0dbae4de2", size = 805941 }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/bf/3effb7453498de9c14a81ca21e1f92e6723ce7ebdc5402ae30e4dcc490ac/coverage-7.7.1.tar.gz", hash = "sha256:199a1272e642266b90c9f40dec7fd3d307b51bf639fa0d15980dc0b3246c1393", size = 810332 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/7f/4af2ed1d06ce6bee7eafc03b2ef748b14132b0bdae04388e451e4b2c529b/coverage-7.6.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b172f8e030e8ef247b3104902cc671e20df80163b60a203653150d2fc204d1ad", size = 208645 },
-    { url = "https://files.pythonhosted.org/packages/dc/60/d19df912989117caa95123524d26fc973f56dc14aecdec5ccd7d0084e131/coverage-7.6.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:641dfe0ab73deb7069fb972d4d9725bf11c239c309ce694dd50b1473c0f641c3", size = 208898 },
-    { url = "https://files.pythonhosted.org/packages/bd/10/fecabcf438ba676f706bf90186ccf6ff9f6158cc494286965c76e58742fa/coverage-7.6.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e549f54ac5f301e8e04c569dfdb907f7be71b06b88b5063ce9d6953d2d58574", size = 242987 },
-    { url = "https://files.pythonhosted.org/packages/4c/53/4e208440389e8ea936f5f2b0762dcd4cb03281a7722def8e2bf9dc9c3d68/coverage-7.6.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959244a17184515f8c52dcb65fb662808767c0bd233c1d8a166e7cf74c9ea985", size = 239881 },
-    { url = "https://files.pythonhosted.org/packages/c4/47/2ba744af8d2f0caa1f17e7746147e34dfc5f811fb65fc153153722d58835/coverage-7.6.12-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bda1c5f347550c359f841d6614fb8ca42ae5cb0b74d39f8a1e204815ebe25750", size = 242142 },
-    { url = "https://files.pythonhosted.org/packages/e9/90/df726af8ee74d92ee7e3bf113bf101ea4315d71508952bd21abc3fae471e/coverage-7.6.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1ceeb90c3eda1f2d8c4c578c14167dbd8c674ecd7d38e45647543f19839dd6ea", size = 241437 },
-    { url = "https://files.pythonhosted.org/packages/f6/af/995263fd04ae5f9cf12521150295bf03b6ba940d0aea97953bb4a6db3e2b/coverage-7.6.12-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f16f44025c06792e0fb09571ae454bcc7a3ec75eeb3c36b025eccf501b1a4c3", size = 239724 },
-    { url = "https://files.pythonhosted.org/packages/1c/8e/5bb04f0318805e190984c6ce106b4c3968a9562a400180e549855d8211bd/coverage-7.6.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b076e625396e787448d27a411aefff867db2bffac8ed04e8f7056b07024eed5a", size = 241329 },
-    { url = "https://files.pythonhosted.org/packages/9e/9d/fa04d9e6c3f6459f4e0b231925277cfc33d72dfab7fa19c312c03e59da99/coverage-7.6.12-cp312-cp312-win32.whl", hash = "sha256:00b2086892cf06c7c2d74983c9595dc511acca00665480b3ddff749ec4fb2a95", size = 211289 },
-    { url = "https://files.pythonhosted.org/packages/53/40/53c7ffe3c0c3fff4d708bc99e65f3d78c129110d6629736faf2dbd60ad57/coverage-7.6.12-cp312-cp312-win_amd64.whl", hash = "sha256:7ae6eabf519bc7871ce117fb18bf14e0e343eeb96c377667e3e5dd12095e0288", size = 212079 },
-    { url = "https://files.pythonhosted.org/packages/fb/b2/f655700e1024dec98b10ebaafd0cedbc25e40e4abe62a3c8e2ceef4f8f0a/coverage-7.6.12-py3-none-any.whl", hash = "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953", size = 200552 },
+    { url = "https://files.pythonhosted.org/packages/cf/b0/4eaba302a86ec3528231d7cfc954ae1929ec5d42b032eb6f5b5f5a9155d2/coverage-7.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:eff187177d8016ff6addf789dcc421c3db0d014e4946c1cc3fbf697f7852459d", size = 211253 },
+    { url = "https://files.pythonhosted.org/packages/fd/68/21b973e6780a3f2457e31ede1aca6c2f84bda4359457b40da3ae805dcf30/coverage-7.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2444fbe1ba1889e0b29eb4d11931afa88f92dc507b7248f45be372775b3cef4f", size = 211504 },
+    { url = "https://files.pythonhosted.org/packages/d1/b4/c19e9c565407664390254252496292f1e3076c31c5c01701ffacc060e745/coverage-7.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:177d837339883c541f8524683e227adcaea581eca6bb33823a2a1fdae4c988e1", size = 245566 },
+    { url = "https://files.pythonhosted.org/packages/7b/0e/f9829cdd25e5083638559c8c267ff0577c6bab19dacb1a4fcfc1e70e41c0/coverage-7.7.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15d54ecef1582b1d3ec6049b20d3c1a07d5e7f85335d8a3b617c9960b4f807e0", size = 242455 },
+    { url = "https://files.pythonhosted.org/packages/29/57/a3ada2e50a665bf6d9851b5eb3a9a07d7e38f970bdd4d39895f311331d56/coverage-7.7.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c82b27c56478d5e1391f2e7b2e7f588d093157fa40d53fd9453a471b1191f2", size = 244713 },
+    { url = "https://files.pythonhosted.org/packages/0f/d3/f15c7d45682a73eca0611427896016bad4c8f635b0fc13aae13a01f8ed9d/coverage-7.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:315ff74b585110ac3b7ab631e89e769d294f303c6d21302a816b3554ed4c81af", size = 244476 },
+    { url = "https://files.pythonhosted.org/packages/19/3b/64540074e256082b220e8810fd72543eff03286c59dc91976281dc0a559c/coverage-7.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4dd532dac197d68c478480edde74fd4476c6823355987fd31d01ad9aa1e5fb59", size = 242695 },
+    { url = "https://files.pythonhosted.org/packages/8a/c1/9cad25372ead7f9395a91bb42d8ae63e6cefe7408eb79fd38797e2b763eb/coverage-7.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:385618003e3d608001676bb35dc67ae3ad44c75c0395d8de5780af7bb35be6b2", size = 243888 },
+    { url = "https://files.pythonhosted.org/packages/66/c6/c3e6c895bc5b95ccfe4cb5838669dbe5226ee4ad10604c46b778c304d6f9/coverage-7.7.1-cp312-cp312-win32.whl", hash = "sha256:63306486fcb5a827449464f6211d2991f01dfa2965976018c9bab9d5e45a35c8", size = 213744 },
+    { url = "https://files.pythonhosted.org/packages/cc/8a/6df2fcb4c3e38ec6cd7e211ca8391405ada4e3b1295695d00aa07c6ee736/coverage-7.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:37351dc8123c154fa05b7579fdb126b9f8b1cf42fd6f79ddf19121b7bdd4aa04", size = 214546 },
+    { url = "https://files.pythonhosted.org/packages/52/26/9f53293ff4cc1d47d98367ce045ca2e62746d6be74a5c6851a474eabf59b/coverage-7.7.1-py3-none-any.whl", hash = "sha256:822fa99dd1ac686061e1219b67868e25d9757989cf2259f735a4802497d6da31", size = 203006 },
 ]
 
 [[package]]
@@ -253,14 +256,14 @@ wheels = [
 
 [[package]]
 name = "deepdiff"
-version = "8.3.0"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "orderly-set" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/23/26a13806c06d9a9202433dae15740444d0bfbb365965a8af8a0b6b3a95bb/deepdiff-8.3.0.tar.gz", hash = "sha256:92a8d7c75a4b26b385ec0372269de258e20082307ccf74a4314341add3d88391", size = 509468 }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/2f/232a9f6d88a59526347cb483ec601d878ad41ab30ee4f2fba4aca1d5a10e/deepdiff-8.4.2.tar.gz", hash = "sha256:5c741c0867ebc7fcb83950ad5ed958369c17f424e14dee32a11c56073f4ee92a", size = 515380 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/a5/79af91ab5909fa98a150b2fb16b2ab0aaaa440cb1264abe3ffc9806e391e/deepdiff-8.3.0-py3-none-any.whl", hash = "sha256:838acf1b17d228f4155bcb69bb265c41cbb5b2aba2575f07efa67ad9b9b7a0b5", size = 86227 },
+    { url = "https://files.pythonhosted.org/packages/0b/03/810d2e70a6944eddc826deb7b68879d8de109369040b25eeb58cdd64d94c/deepdiff-8.4.2-py3-none-any.whl", hash = "sha256:7e39e5b26f3747c54f9d0e8b9b29daab670c3100166b77cc0185d5793121b099", size = 87610 },
 ]
 
 [[package]]
@@ -346,16 +349,16 @@ dev = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.11"
+version = "0.115.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/28/c5d26e5860df807241909a961a37d45e10533acef95fc368066c7dd186cd/fastapi-0.115.11.tar.gz", hash = "sha256:cc81f03f688678b92600a65a5e618b93592c65005db37157147204d8924bf94f", size = 294441 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/55/ae499352d82338331ca1e28c7f4a63bfd09479b16395dce38cf50a39e2c2/fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681", size = 295236 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/5d/4d8bbb94f0dbc22732350c06965e40740f4a92ca560e90bb566f4f73af41/fastapi-0.115.11-py3-none-any.whl", hash = "sha256:32e1541b7b74602e4ef4a0260ecaf3aadf9d4f19590bba3e1bf2ac4666aa2c64", size = 94926 },
+    { url = "https://files.pythonhosted.org/packages/50/b3/b51f09c2ba432a576fe63758bddc81f78f0c6309d9e5c10d194313bf021e/fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d", size = 95164 },
 ]
 
 [[package]]
@@ -472,11 +475,11 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
 ]
 
 [[package]]
@@ -840,41 +843,41 @@ wheels = [
 
 [[package]]
 name = "responses"
-version = "0.25.6"
+version = "0.25.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/63/759996eea0f17e8dc4c9ea9c60765292d28a7750bdbee073ad55d83caa57/responses-0.25.6.tar.gz", hash = "sha256:eae7ce61a9603004e76c05691e7c389e59652d91e94b419623c12bbfb8e331d8", size = 79145 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/7e/2345ac3299bd62bd7163216702bbc88976c099cfceba5b889f2a457727a1/responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb", size = 79203 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/c4/8d23584b3a3471ea6f5a18cfb035e11eeb9fa9b3112d901477c6ad10cc4e/responses-0.25.6-py3-none-any.whl", hash = "sha256:9cac8f21e1193bb150ec557875377e41ed56248aed94e4567ed644db564bacf1", size = 34730 },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/1d20b64fa90e81e4fa0a34c9b0240a6cfb1326b7e06d18a5432a9917c316/responses-0.25.7-py3-none-any.whl", hash = "sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c", size = 34732 },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.9.10"
+version = "0.11.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/8e/fafaa6f15c332e73425d9c44ada85360501045d5ab0b81400076aff27cf6/ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7", size = 3759776 }
+sdist = { url = "https://files.pythonhosted.org/packages/90/61/fb87430f040e4e577e784e325351186976516faef17d6fcd921fe28edfd7/ruff-0.11.2.tar.gz", hash = "sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94", size = 3857511 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b2/af7c2cc9e438cbc19fafeec4f20bfcd72165460fe75b2b6e9a0958c8c62b/ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d", size = 10049494 },
-    { url = "https://files.pythonhosted.org/packages/6d/12/03f6dfa1b95ddd47e6969f0225d60d9d7437c91938a310835feb27927ca0/ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d", size = 10853584 },
-    { url = "https://files.pythonhosted.org/packages/02/49/1c79e0906b6ff551fb0894168763f705bf980864739572b2815ecd3c9df0/ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d", size = 10155692 },
-    { url = "https://files.pythonhosted.org/packages/5b/01/85e8082e41585e0e1ceb11e41c054e9e36fed45f4b210991052d8a75089f/ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c", size = 10369760 },
-    { url = "https://files.pythonhosted.org/packages/a1/90/0bc60bd4e5db051f12445046d0c85cc2c617095c0904f1aa81067dc64aea/ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e", size = 9912196 },
-    { url = "https://files.pythonhosted.org/packages/66/ea/0b7e8c42b1ec608033c4d5a02939c82097ddcb0b3e393e4238584b7054ab/ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12", size = 11434985 },
-    { url = "https://files.pythonhosted.org/packages/d5/86/3171d1eff893db4f91755175a6e1163c5887be1f1e2f4f6c0c59527c2bfd/ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16", size = 12155842 },
-    { url = "https://files.pythonhosted.org/packages/89/9e/700ca289f172a38eb0bca752056d0a42637fa17b81649b9331786cb791d7/ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52", size = 11613804 },
-    { url = "https://files.pythonhosted.org/packages/f2/92/648020b3b5db180f41a931a68b1c8575cca3e63cec86fd26807422a0dbad/ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1", size = 13823776 },
-    { url = "https://files.pythonhosted.org/packages/5e/a6/cc472161cd04d30a09d5c90698696b70c169eeba2c41030344194242db45/ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c", size = 11302673 },
-    { url = "https://files.pythonhosted.org/packages/6c/db/d31c361c4025b1b9102b4d032c70a69adb9ee6fde093f6c3bf29f831c85c/ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43", size = 10235358 },
-    { url = "https://files.pythonhosted.org/packages/d1/86/d6374e24a14d4d93ebe120f45edd82ad7dcf3ef999ffc92b197d81cdc2a5/ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c", size = 9886177 },
-    { url = "https://files.pythonhosted.org/packages/00/62/a61691f6eaaac1e945a1f3f59f1eea9a218513139d5b6c2b8f88b43b5b8f/ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5", size = 10864747 },
-    { url = "https://files.pythonhosted.org/packages/ee/94/2c7065e1d92a8a8a46d46d9c3cf07b0aa7e0a1e0153d74baa5e6620b4102/ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8", size = 11360441 },
-    { url = "https://files.pythonhosted.org/packages/a7/8f/1f545ea6f9fcd7bf4368551fb91d2064d8f0577b3079bb3f0ae5779fb773/ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029", size = 10247401 },
-    { url = "https://files.pythonhosted.org/packages/4f/18/fb703603ab108e5c165f52f5b86ee2aa9be43bb781703ec87c66a5f5d604/ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1", size = 11366360 },
-    { url = "https://files.pythonhosted.org/packages/35/85/338e603dc68e7d9994d5d84f24adbf69bae760ba5efd3e20f5ff2cec18da/ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69", size = 10436892 },
+    { url = "https://files.pythonhosted.org/packages/62/99/102578506f0f5fa29fd7e0df0a273864f79af044757aef73d1cae0afe6ad/ruff-0.11.2-py3-none-linux_armv6l.whl", hash = "sha256:c69e20ea49e973f3afec2c06376eb56045709f0212615c1adb0eda35e8a4e477", size = 10113146 },
+    { url = "https://files.pythonhosted.org/packages/74/ad/5cd4ba58ab602a579997a8494b96f10f316e874d7c435bcc1a92e6da1b12/ruff-0.11.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2c5424cc1c4eb1d8ecabe6d4f1b70470b4f24a0c0171356290b1953ad8f0e272", size = 10867092 },
+    { url = "https://files.pythonhosted.org/packages/fc/3e/d3f13619e1d152c7b600a38c1a035e833e794c6625c9a6cea6f63dbf3af4/ruff-0.11.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9", size = 10224082 },
+    { url = "https://files.pythonhosted.org/packages/90/06/f77b3d790d24a93f38e3806216f263974909888fd1e826717c3ec956bbcd/ruff-0.11.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c543bf65d5d27240321604cee0633a70c6c25c9a2f2492efa9f6d4b8e4199bb", size = 10394818 },
+    { url = "https://files.pythonhosted.org/packages/99/7f/78aa431d3ddebfc2418cd95b786642557ba8b3cb578c075239da9ce97ff9/ruff-0.11.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20967168cc21195db5830b9224be0e964cc9c8ecf3b5a9e3ce19876e8d3a96e3", size = 9952251 },
+    { url = "https://files.pythonhosted.org/packages/30/3e/f11186d1ddfaca438c3bbff73c6a2fdb5b60e6450cc466129c694b0ab7a2/ruff-0.11.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:955a9ce63483999d9f0b8f0b4a3ad669e53484232853054cc8b9d51ab4c5de74", size = 11563566 },
+    { url = "https://files.pythonhosted.org/packages/22/6c/6ca91befbc0a6539ee133d9a9ce60b1a354db12c3c5d11cfdbf77140f851/ruff-0.11.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:86b3a27c38b8fce73bcd262b0de32e9a6801b76d52cdb3ae4c914515f0cef608", size = 12208721 },
+    { url = "https://files.pythonhosted.org/packages/19/b0/24516a3b850d55b17c03fc399b681c6a549d06ce665915721dc5d6458a5c/ruff-0.11.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a3b66a03b248c9fcd9d64d445bafdf1589326bee6fc5c8e92d7562e58883e30f", size = 11662274 },
+    { url = "https://files.pythonhosted.org/packages/d7/65/76be06d28ecb7c6070280cef2bcb20c98fbf99ff60b1c57d2fb9b8771348/ruff-0.11.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0397c2672db015be5aa3d4dac54c69aa012429097ff219392c018e21f5085147", size = 13792284 },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/4ceed7147e05852876f3b5f3fdc23f878ce2b7e0b90dd6e698bda3d20787/ruff-0.11.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869bcf3f9abf6457fbe39b5a37333aa4eecc52a3b99c98827ccc371a8e5b6f1b", size = 11327861 },
+    { url = "https://files.pythonhosted.org/packages/c4/78/4935ecba13706fd60ebe0e3dc50371f2bdc3d9bc80e68adc32ff93914534/ruff-0.11.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2a2b50ca35457ba785cd8c93ebbe529467594087b527a08d487cf0ee7b3087e9", size = 10276560 },
+    { url = "https://files.pythonhosted.org/packages/81/7f/1b2435c3f5245d410bb5dc80f13ec796454c21fbda12b77d7588d5cf4e29/ruff-0.11.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7c69c74bf53ddcfbc22e6eb2f31211df7f65054bfc1f72288fc71e5f82db3eab", size = 9945091 },
+    { url = "https://files.pythonhosted.org/packages/39/c4/692284c07e6bf2b31d82bb8c32f8840f9d0627d92983edaac991a2b66c0a/ruff-0.11.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6e8fb75e14560f7cf53b15bbc55baf5ecbe373dd5f3aab96ff7aa7777edd7630", size = 10977133 },
+    { url = "https://files.pythonhosted.org/packages/94/cf/8ab81cb7dd7a3b0a3960c2769825038f3adcd75faf46dd6376086df8b128/ruff-0.11.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:842a472d7b4d6f5924e9297aa38149e5dcb1e628773b70e6387ae2c97a63c58f", size = 11378514 },
+    { url = "https://files.pythonhosted.org/packages/d9/3a/a647fa4f316482dacf2fd68e8a386327a33d6eabd8eb2f9a0c3d291ec549/ruff-0.11.2-py3-none-win32.whl", hash = "sha256:aca01ccd0eb5eb7156b324cfaa088586f06a86d9e5314b0eb330cb48415097cc", size = 10319835 },
+    { url = "https://files.pythonhosted.org/packages/86/54/3c12d3af58012a5e2cd7ebdbe9983f4834af3f8cbea0e8a8c74fa1e23b2b/ruff-0.11.2-py3-none-win_amd64.whl", hash = "sha256:3170150172a8f994136c0c66f494edf199a0bbea7a409f649e4bc8f4d7084080", size = 11373713 },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/dd813703af8a1e2ac33bf3feb27e8a5ad514c9f219df80c64d69807e7f71/ruff-0.11.2-py3-none-win_arm64.whl", hash = "sha256:52933095158ff328f4c77af3d74f0379e34fd52f175144cefc1b192e7ccd32b4", size = 10441990 },
 ]
 
 [[package]]
@@ -909,23 +912,23 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.38"
+version = "2.0.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/08/9a90962ea72acd532bda71249a626344d855c4032603924b1b547694b837/sqlalchemy-2.0.38.tar.gz", hash = "sha256:e5a4d82bdb4bf1ac1285a68eab02d253ab73355d9f0fe725a97e1e0fa689decb", size = 9634782 }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8e/e77fcaa67f8b9f504b4764570191e291524575ddbfe78a90fc656d671fdc/sqlalchemy-2.0.39.tar.gz", hash = "sha256:5d2d1fe548def3267b4c70a8568f108d1fed7cbbeccb9cc166e05af2abc25c22", size = 9644602 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/f8/6d0424af1442c989b655a7b5f608bc2ae5e4f94cdf6df9f6054f629dc587/SQLAlchemy-2.0.38-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12d5b06a1f3aeccf295a5843c86835033797fea292c60e72b07bcb5d820e6dd3", size = 2104927 },
-    { url = "https://files.pythonhosted.org/packages/25/80/fc06e65fca0a19533e2bfab633a5633ed8b6ee0b9c8d580acf84609ce4da/SQLAlchemy-2.0.38-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e036549ad14f2b414c725349cce0772ea34a7ab008e9cd67f9084e4f371d1f32", size = 2095317 },
-    { url = "https://files.pythonhosted.org/packages/98/2d/5d66605f76b8e344813237dc160a01f03b987201e974b46056a7fb94a874/SQLAlchemy-2.0.38-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee3bee874cb1fadee2ff2b79fc9fc808aa638670f28b2145074538d4a6a5028e", size = 3244735 },
-    { url = "https://files.pythonhosted.org/packages/73/8d/b0539e8dce90861efc38fea3eefb15a5d0cfeacf818614762e77a9f192f9/SQLAlchemy-2.0.38-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e185ea07a99ce8b8edfc788c586c538c4b1351007e614ceb708fd01b095ef33e", size = 3255581 },
-    { url = "https://files.pythonhosted.org/packages/ac/a5/94e1e44bf5bdffd1782807fcc072542b110b950f0be53f49e68b5f5eca1b/SQLAlchemy-2.0.38-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b79ee64d01d05a5476d5cceb3c27b5535e6bb84ee0f872ba60d9a8cd4d0e6579", size = 3190877 },
-    { url = "https://files.pythonhosted.org/packages/91/13/f08b09996dce945aec029c64f61c13b4788541ac588d9288e31e0d3d8850/SQLAlchemy-2.0.38-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:afd776cf1ebfc7f9aa42a09cf19feadb40a26366802d86c1fba080d8e5e74bdd", size = 3217485 },
-    { url = "https://files.pythonhosted.org/packages/13/8f/8cfe2ba5ba6d8090f4de0e658330c53be6b7bf430a8df1b141c2b180dcdf/SQLAlchemy-2.0.38-cp312-cp312-win32.whl", hash = "sha256:a5645cd45f56895cfe3ca3459aed9ff2d3f9aaa29ff7edf557fa7a23515a3725", size = 2075254 },
-    { url = "https://files.pythonhosted.org/packages/c2/5c/e3c77fae41862be1da966ca98eec7fbc07cdd0b00f8b3e1ef2a13eaa6cca/SQLAlchemy-2.0.38-cp312-cp312-win_amd64.whl", hash = "sha256:1052723e6cd95312f6a6eff9a279fd41bbae67633415373fdac3c430eca3425d", size = 2100865 },
-    { url = "https://files.pythonhosted.org/packages/aa/e4/592120713a314621c692211eba034d09becaf6bc8848fabc1dc2a54d8c16/SQLAlchemy-2.0.38-py3-none-any.whl", hash = "sha256:63178c675d4c80def39f1febd625a6333f44c0ba269edd8a468b156394b27753", size = 1896347 },
+    { url = "https://files.pythonhosted.org/packages/98/86/b2cb432aeb00a1eda7ed33ce86d943c2452dc1642f3ec51bfe9eaae9604b/sqlalchemy-2.0.39-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c457a38351fb6234781d054260c60e531047e4d07beca1889b558ff73dc2014b", size = 2107210 },
+    { url = "https://files.pythonhosted.org/packages/bf/b0/b2479edb3419ca763ba1b587161c292d181351a33642985506a530f9162b/sqlalchemy-2.0.39-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:018ee97c558b499b58935c5a152aeabf6d36b3d55d91656abeb6d93d663c0c4c", size = 2097599 },
+    { url = "https://files.pythonhosted.org/packages/58/5e/c5b792a4abcc71e68d44cb531c4845ac539d558975cc61db1afbc8a73c96/sqlalchemy-2.0.39-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5493a8120d6fc185f60e7254fc056a6742f1db68c0f849cfc9ab46163c21df47", size = 3247012 },
+    { url = "https://files.pythonhosted.org/packages/e0/a8/055fa8a7c5f85e6123b7e40ec2e9e87d63c566011d599b4a5ab75e033017/sqlalchemy-2.0.39-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2cf5b5ddb69142511d5559c427ff00ec8c0919a1e6c09486e9c32636ea2b9dd", size = 3257851 },
+    { url = "https://files.pythonhosted.org/packages/f6/40/aec16681e91a22ddf03dbaeb3c659bce96107c5f47d2a7c665eb7f24a014/sqlalchemy-2.0.39-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f03143f8f851dd8de6b0c10784363712058f38209e926723c80654c1b40327a", size = 3193155 },
+    { url = "https://files.pythonhosted.org/packages/21/9d/cef697b137b9eb0b66ab8e9cf193a7c7c048da3b4bb667e5fcea4d90c7a2/sqlalchemy-2.0.39-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06205eb98cb3dd52133ca6818bf5542397f1dd1b69f7ea28aa84413897380b06", size = 3219770 },
+    { url = "https://files.pythonhosted.org/packages/57/05/e109ca7dde837d8f2f1b235357e4e607f8af81ad8bc29c230fed8245687d/sqlalchemy-2.0.39-cp312-cp312-win32.whl", hash = "sha256:7f5243357e6da9a90c56282f64b50d29cba2ee1f745381174caacc50d501b109", size = 2077567 },
+    { url = "https://files.pythonhosted.org/packages/97/c6/25ca068e38c29ed6be0fde2521888f19da923dbd58f5ff16af1b73ec9b58/sqlalchemy-2.0.39-cp312-cp312-win_amd64.whl", hash = "sha256:2ed107331d188a286611cea9022de0afc437dd2d3c168e368169f27aa0f61338", size = 2103136 },
+    { url = "https://files.pythonhosted.org/packages/7b/0f/d69904cb7d17e65c65713303a244ec91fd3c96677baf1d6331457fd47e16/sqlalchemy-2.0.39-py3-none-any.whl", hash = "sha256:a1c6b0a5e3e326a466d809b651c63f278b1256146a377a528b6938a279da334f", size = 1898621 },
 ]
 
 [[package]]
@@ -954,11 +957,11 @@ wheels = [
 
 [[package]]
 name = "types-awscrt"
-version = "0.24.1"
+version = "0.24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/6e/32779b967eee6ef627eaf10f3414163482b3980fc45ba21765fdd05359d4/types_awscrt-0.24.1.tar.gz", hash = "sha256:fc6eae56f8dc5a3f8cc93cc2c7c332fa82909f8284fbe25e014c575757af397d", size = 15450 }
+sdist = { url = "https://files.pythonhosted.org/packages/28/2d/393ac8f215417bc532ef9451ba42f148ecedcd5ff91095d8640042ecae2c/types_awscrt-0.24.2.tar.gz", hash = "sha256:5826baf69ad5d29c76be49fc7df00222281fa31b14f99e9fb4492d71ec98fea5", size = 15441 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/1a/22e327d29fe231a10ed00e35ed2a100d2462cea253c3d24d41162769711a/types_awscrt-0.24.1-py3-none-any.whl", hash = "sha256:f3f2578ff74a254a79882b95961fb493ba217cebc350b3eb239d1cd948d4d7fa", size = 19414 },
+    { url = "https://files.pythonhosted.org/packages/3f/33/e2b7dcb6acc3ba8e8191571c38d2d64fc0822e8fd53fff0f2736859abef6/types_awscrt-0.24.2-py3-none-any.whl", hash = "sha256:345ab84a4f75b26bfb816b249657855824a4f2d1ce5b58268c549f81fce6eccc", size = 19414 },
 ]
 
 [[package]]
@@ -972,42 +975,42 @@ wheels = [
 
 [[package]]
 name = "types-boto3-dynamodb"
-version = "1.37.0"
+version = "1.37.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/87/5cf9b2fd83be693785191bf6eb8251f9c8be9e463cdbc6bbdd1ce1000378/types_boto3_dynamodb-1.37.0.tar.gz", hash = "sha256:064bf448234d1c35b3ccf93c933263acd9c8a566ba2e411e889c2feca7842c65", size = 47097 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/36/96834a143f458812479fedd12170cbd627cf5dfc358d7390660b9d5d07e6/types_boto3_dynamodb-1.37.12.tar.gz", hash = "sha256:009178e5eacd2432989ce724a44ae89f03d6cac9b4931783679073d157598244", size = 47123 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/21/c0e3ea19a9ace8a8d11c9fcc3fdf4b75ecf94506d15cfb517b4c52158a19/types_boto3_dynamodb-1.37.0-py3-none-any.whl", hash = "sha256:8c4009b1e360b0a6971f94c654f40547641068020244a10b44f147ed32bdb591", size = 56125 },
+    { url = "https://files.pythonhosted.org/packages/a1/70/e1fd6fe60475fcbb957b96452f40d0b15ea281451e172dde29564feb44b5/types_boto3_dynamodb-1.37.12-py3-none-any.whl", hash = "sha256:f772ad6cf59f87b7ae71274e4672c4d06b7f8ec74b8d1afbb797c448e0bf4e2e", size = 56160 },
 ]
 
 [[package]]
 name = "types-boto3-ec2"
-version = "1.37.9"
+version = "1.37.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/49/b2509204966e73189b4b85b036ef49aec4d61fe68accb53d3d42b0da3903/types_boto3_ec2-1.37.9.tar.gz", hash = "sha256:9ad4cf8696529732465e7780fd7129e6f1a20a0e42b523a6c33a09f9c1145e10", size = 387328 }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/8b991969ce853f20ec869534b953538b1c7242305a960b1771fc6fe42810/types_boto3_ec2-1.37.16.tar.gz", hash = "sha256:ad0e3c06a03beab39ae18bb924bdfd43371b2a8bb3754b296f4b1dcfc12a22bd", size = 387398 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/ba/9b6c6ab9886dc877af7f835c64194ccc43c96ef1c1fe335e33f34c32708d/types_boto3_ec2-1.37.9-py3-none-any.whl", hash = "sha256:3bb8db3a42e47d65505832abe5fb6924eb5b94b2ce8ff4a1f6fd46890c0b4c40", size = 377236 },
+    { url = "https://files.pythonhosted.org/packages/3d/d9/da1a50795782afed2349160a0d7825a0338f083b3a7775bce231c185ac6e/types_boto3_ec2-1.37.16-py3-none-any.whl", hash = "sha256:a42d1ac8116a0abae90dfdf32a2890789a4f0d25236b2162e36dec33b6e42e16", size = 377292 },
 ]
 
 [[package]]
 name = "types-boto3-lambda"
-version = "1.37.0"
+version = "1.37.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/86/76fec909407803d9cc4a8da5eaaeb30b6c42b9fd20474f978de1f143432c/types_boto3_lambda-1.37.0.tar.gz", hash = "sha256:99d193115efc2333eeb895b8013d88535f520c2382670aeee3416ed3aa9e4a68", size = 41430 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/04/ff510efe77867b431c17a4d63f9d9dadc9fd89b97b9e6c14e34ae56a10ff/types_boto3_lambda-1.37.16.tar.gz", hash = "sha256:e388adf2dd82e9ab2884d2e52f2fe24731b8521c0595220e99dea435843204a7", size = 41439 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/fa/bb10bdbe05098e8d92c54fc4480ff5b3fbf54e7bb64053b5620b15489347/types_boto3_lambda-1.37.0-py3-none-any.whl", hash = "sha256:03cce330fbd79c9c8e31b4e3dc58fbc8dab71791b87b14e697f6d66446be56b3", size = 47947 },
+    { url = "https://files.pythonhosted.org/packages/a2/74/07a41d0e7239169dd49b4dc58d3aca58be7ef69eb1eb5e78061855ba4d6d/types_boto3_lambda-1.37.16-py3-none-any.whl", hash = "sha256:d4c040beb3418f8f10d4faa65d09435311a15249f47b19cca9610f26ced4ac4b", size = 48019 },
 ]
 
 [[package]]
 name = "types-boto3-lite"
-version = "1.37.10"
+version = "1.37.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/07/a1109b276255e6c165dcbb91e558c91d6261604e0f4b6ec85c689c1830c0/types_boto3_lite-1.37.10.tar.gz", hash = "sha256:87984e163806ce0e2fcc810cd723837f2ef9926228dae3a6fdf35d5c74d40e1a", size = 71887 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/2b/6705de58e6e3994744b182e63c9c424ad4302fc737d417d75029ffce8559/types_boto3_lite-1.37.18.tar.gz", hash = "sha256:4061b8193e47333c63bb5b406f80bfb9827dc8f7224130ce9265e6207cd93bcb", size = 71918 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/0b/cba0e8776f3f5bc512419191129582aa8d4850723087f0c2fde217b204e1/types_boto3_lite-1.37.10-py3-none-any.whl", hash = "sha256:22ca3c36658eced76063d92160ab20dc76afda21e5005478d40ffe7fe29c634a", size = 42155 },
+    { url = "https://files.pythonhosted.org/packages/b5/4a/007110dd6499e37eed2a3edba51bbddb2f0fc3cc6e4e8feff17b8b9cd5ad/types_boto3_lite-1.37.18-py3-none-any.whl", hash = "sha256:36bee5ff4c4213e9e861bf8a04837156b0c0a20b19a1e6280b9bdb487280965a", size = 42195 },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 1
 requires-python = "==3.12.*"
 
-[options]
-exclude-newer = "2025-03-24T00:00:00Z"
-
 [[package]]
 name = "alembic"
 version = "1.15.1"
@@ -79,42 +76,42 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.37.18"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/42/2b102f999c76614e55afd8a8c2392c35ce2f390cdeb78007aba029cd1171/boto3-1.37.18.tar.gz", hash = "sha256:9b272268794172b0b8bb9fb1f3c470c3b6c0ffb92fbd4882465cc740e40fbdcd", size = 111358 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/03/43244d4c6b67f34a979d2805ebb4f63c29b9aef3683ad179470fea52a5f3/boto3-1.37.19.tar.gz", hash = "sha256:c69c90500f18fd72d782d1612170b7d3db9a98ed51a4da3bebe38e693497ebf8", size = 111363 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/94/dccc4dd874cf455c8ea6dfb4c43a224632c03c3f503438aa99021759a097/boto3-1.37.18-py3-none-any.whl", hash = "sha256:1545c943f36db41853cdfdb6ff09c4eda9220dd95bd2fae76fc73091603525d1", size = 139561 },
+    { url = "https://files.pythonhosted.org/packages/e6/bb/7f3d90cc732c8c2f0dc971fa910b601f3c9bbe56df518f037653baf8ade3/boto3-1.37.19-py3-none-any.whl", hash = "sha256:fbfc2c43ad686b63c8aa02aee634c269f856eed68941d8e570cc45950be52130", size = 139560 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.37.18"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/fa/a176046c74032ca3bda68c71ad544602a69be21d7ee3b199f4f2099fe4bf/botocore-1.37.18.tar.gz", hash = "sha256:99e8eefd5df6347ead15df07ce55f4e62a51ea7b54de1127522a08597923b726", size = 13667977 }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/4a/cf22a677045a02cf769d8126ce25572695508e4bd5d7f6fe984dc5d23c76/botocore-1.37.19.tar.gz", hash = "sha256:eadcdc37de09df25cf1e62e8106660c61f60a68e984acfc1a8d43fb6267e53b8", size = 13667634 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/fd/059e57de7405b1ba93117c1b79a6daa45d6865f557b892f3cc7645836f3b/botocore-1.37.18-py3-none-any.whl", hash = "sha256:a8b97d217d82b3c4f6bcc906e264df7ebb51e2c6a62b3548a97cd173fb8759a1", size = 13428387 },
+    { url = "https://files.pythonhosted.org/packages/b4/10/f2482186a83deb8fc45cf46e5455e501e0b2db9565251e66998a80b89aaf/botocore-1.37.19-py3-none-any.whl", hash = "sha256:6e1337e73a6b8146c1ec20a6a72d67e2809bd4c0af076431fe6e1561e0c89415", size = 13429649 },
 ]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.37.18"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/fa/3f33f6c7eafa1fa40c24849f30a5f2747fdf01ca7a6ac1301058b4f17e45/botocore_stubs-1.37.18.tar.gz", hash = "sha256:937c9b787e4f784019f321fa1d88a505965c25f425e810bde45e23b7ca564282", size = 42125 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/61/2c6409106fed6cbbcf5669b4bde1650bb24fee453a52f1b4373adda40053/botocore_stubs-1.37.19.tar.gz", hash = "sha256:d8fcf941d10ff9af71cf7a4bda4b2e4f458d780f7c691f93811a130d636963f1", size = 42126 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/ac/6a814919a3144ebad74fbedbcf18dc4bbad5caa6906555943d372891caff/botocore_stubs-1.37.18-py3-none-any.whl", hash = "sha256:bb9a9e7cd2f48ecb429a7d0df0387f63399db8fb363bdfa38eba285854d622a2", size = 65423 },
+    { url = "https://files.pythonhosted.org/packages/e9/ee/7d3c8f53858f744499b2be2cbe7c29976ea0629489781e32ac9471232a09/botocore_stubs-1.37.19-py3-none-any.whl", hash = "sha256:c33db42760989cd3c3bfc57dc676445c0b644bfb60d2c0ef409ab7e051445f63", size = 65423 },
 ]
 
 [[package]]
@@ -1002,15 +999,15 @@ wheels = [
 
 [[package]]
 name = "types-boto3-lite"
-version = "1.37.18"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/2b/6705de58e6e3994744b182e63c9c424ad4302fc737d417d75029ffce8559/types_boto3_lite-1.37.18.tar.gz", hash = "sha256:4061b8193e47333c63bb5b406f80bfb9827dc8f7224130ce9265e6207cd93bcb", size = 71918 }
+sdist = { url = "https://files.pythonhosted.org/packages/80/9f/080f35471639516ef1eb2a1d5abe372dc91a7630daaf1ef4a995bcb2be36/types_boto3_lite-1.37.19.tar.gz", hash = "sha256:e16378ae2cabde329ef1f012e7b1cd749909d71902bb4a714d3c32cb3b18e9a8", size = 71913 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/4a/007110dd6499e37eed2a3edba51bbddb2f0fc3cc6e4e8feff17b8b9cd5ad/types_boto3_lite-1.37.18-py3-none-any.whl", hash = "sha256:36bee5ff4c4213e9e861bf8a04837156b0c0a20b19a1e6280b9bdb487280965a", size = 42195 },
+    { url = "https://files.pythonhosted.org/packages/5d/eb/61fae8262e58598361503293594da470bc5074e1eb5713a9a1e7a5bf05a1/types_boto3_lite-1.37.19-py3-none-any.whl", hash = "sha256:ba8b51eeb1a6aa3016af79542a014af20f0b8a054c9068a7f600210431f9c28f", size = 42195 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
- Add UserContext
- Add caching to reduce calls to KeyCloak
- Reuse the same instance of httpx.Client
- Add authentication to all the endpoints except /docs /health /version
- Allow to read public entities even when project-id isn't passed
- Introduce the role of service admin: service/entitycore/admin (needs updates to keycloak groups)
- Allow to write global resources only to the service admin role

More details in docs/authentication.md