### PR TITLE
Allow downloading directory files

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -39,6 +39,10 @@ class ApiErrorCode(UpperStrEnum):
     ENTITY_DUPLICATED = auto()
     ASSET_NOT_FOUND = auto()
     ASSET_DUPLICATED = auto()
+    ASSET_INVALID_FILE = auto()
+    ASSET_MISSING_PATH = auto()
+    ASSET_INVALID_PATH = auto()
+    ASSET_NOT_A_DIRECTORY = auto()
 
 
 class PostgresInternalErrorCode(UpperStrEnum):

--- a/app/routers/asset.py
+++ b/app/routers/asset.py
@@ -131,12 +131,22 @@ def download_entity_asset(
     )
     if asset.is_directory:
         if asset_path is None:
-            raise HTTPException(
-                status_code=400,
-                detail="Missing required parameter for downloading a directory file: asset_path",
+            msg = "Missing required parameter for downloading a directory file: asset_path"
+            raise ApiError(
+                message=msg,
+                error_code=ApiErrorCode.INVALID_REQUEST,
             )
+        if not validate_filename(asset_path):
+            msg = f"Invalid file name {asset_path!r}"
+            raise ApiError(message=msg, error_code=ApiErrorCode.INVALID_REQUEST)
         full_path = str(Path(asset.full_path, asset_path))
     else:
+        if asset_path:
+            msg = "asset_path is only applicable when asset is a directory"
+            raise ApiError(
+                message=msg,
+                error_code=ApiErrorCode.INVALID_REQUEST,
+            )
         full_path = asset.full_path
     url = generate_presigned_url(
         s3_client=s3_client,

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -218,7 +218,9 @@ def test_download_entity_asset(client, entity, asset):
         params={"asset_path": "foo"},
         follow_redirects=False,
     )
-    assert response.status_code == 400, "Failed to forbid asset_path when downloading a file."
+    assert response.status_code == 400, (
+        f"Failed to forbid asset_path when downloading a file: {response.text}"
+    )
 
 
 def test_delete_entity_asset(client, entity, asset):
@@ -280,4 +282,6 @@ def test_download_directory_file(client, entity, asset_directory):
         url=f"{_route(entity.type)}/{entity.id}/assets/{asset_directory.id}/download",
         follow_redirects=False,
     )
-    assert response.status_code == 400
+    assert response.status_code == 400, (
+        f"Failed to send invalid response due to missing asset_path: {response.text}"
+    )

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -30,11 +30,11 @@ def _route(entity_type: str) -> str:
     return f"/{EntityType[entity_type]}"
 
 
-def _upload_entity_asset(client, entity_type, entity_id, path="a/b/c.txt"):
+def _upload_entity_asset(client, entity_type, entity_id):
     with FILE_EXAMPLE_PATH.open("rb") as f:
         files = {
             # (filename, file (or bytes), content_type, headers)
-            "file": (path, f, "text/plain")
+            "file": ("a/b/c.txt", f, "text/plain")
         }
         return client.post(f"{_route(entity_type)}/{entity_id}/assets", files=files)
 

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -218,7 +218,7 @@ def test_download_entity_asset(client, entity, asset):
         params={"asset_path": "foo"},
         follow_redirects=False,
     )
-    assert response.status_code == 400, (
+    assert response.status_code == 409, (
         f"Failed to forbid asset_path when downloading a file: {response.text}"
     )
 
@@ -282,6 +282,6 @@ def test_download_directory_file(client, entity, asset_directory):
         url=f"{_route(entity.type)}/{entity.id}/assets/{asset_directory.id}/download",
         follow_redirects=False,
     )
-    assert response.status_code == 400, (
+    assert response.status_code == 409, (
         f"Failed to send invalid response due to missing asset_path: {response.text}"
     )


### PR DESCRIPTION
Files can be downloaded from directory assets with:
```
GET /{entity_type}/{entity_id}/assets/{asset_id}/download?asset_path=file.ext
```
`asset_path` is mandatory when the asset is a directory