### PR TITLE
allow morphology get by id to retrieve by legacy id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out.tar
 .DS_Store
 mba_hierarchy.json
 notes.md
+.env.local

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -66,6 +66,7 @@ class ReconstructionMorphologyRead(
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
     assets: list[AssetRead] | None
+    type: str = "reconstruction_morphology"
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):


### PR DESCRIPTION
1. allow `GET` morphology by id to retrieve by legacy id
2. add type to `ReconstructionMorphologyRead` (this is needed in the UI for every entity)

**NOTE**: the `GET /{id_}` may not conform to your API design, please lemme know if it should be in another endpoint

a use case to use  the `legacy id`:
in the generalization section (this part still use nexus) of the the details page, we list the morpho-similarities of a morphology, the user can click on the morphology card to open the details page, and since we use now the entitycore ID we have to get the mapped id-legacyid from entitycode

<img width="1305" alt="Screenshot 2025-04-02 at 11 18 30" src="https://github.com/user-attachments/assets/4f24d574-39ac-4aeb-8a0f-968a2406bd7f" />
