### PR TITLE
add types to entities read schema

### DIFF
--- a/app/schemas/base.py
+++ b/app/schemas/base.py
@@ -1,10 +1,13 @@
 import uuid
-from datetime import datetime, timedelta
-from typing import Annotated
+from datetime import datetime
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field, model_validator
+from pydantic import UUID4, BaseModel, ConfigDict
 
-from app.db.types import AgePeriod, Sex
+from app.db.types import EntityType
+
+
+class EntityTypeMixin(BaseModel):
+    type: EntityType | None = None
 
 
 class AuthorizationMixin(BaseModel):
@@ -123,69 +126,3 @@ class MeasurementCreate(BaseModel):
 
 class MeasurementRead(MeasurementCreate):
     id: int
-
-
-class SubjectBase(BaseModel):
-    model_config = ConfigDict(from_attributes=True, ser_json_timedelta="float")
-    name: str
-    description: str
-    sex: Annotated[
-        Sex,
-        Field(title="Sex", description="Sex of the subject"),
-    ]
-    weight: Annotated[
-        float | None,
-        Field(title="Weight", description="Weight in grams", gt=0.0),
-    ] = None
-    age_value: Annotated[
-        timedelta | None,
-        Field(title="Age value", description="Age value interval.", gt=timedelta(0)),
-    ] = None
-    age_min: Annotated[
-        timedelta | None,
-        Field(title="Minimum age range", description="Minimum age range", gt=timedelta(0)),
-    ] = None
-    age_max: Annotated[
-        timedelta | None,
-        Field(title="Maximum age range", description="Maximum age range", gt=timedelta(0)),
-    ] = None
-    age_period: AgePeriod | None = None
-
-    @model_validator(mode="after")
-    def age_period_mandatory_with_age_fields(self):
-        """Age period must be provided when age fields are provided."""
-        if any([self.age_value, self.age_min, self.age_max]) and not self.age_period:
-            msg = "age_period must be provided when age fields are provided"
-            raise ValueError(msg)
-        return self
-
-    @model_validator(mode="after")
-    def either_age_value_or_age_range(self):
-        """Either age_value or age_min and age_max must be provided."""
-        if self.age_value and any([self.age_min, self.age_max]):
-            msg = "age_value and age_min/age_max cannot both be provided"
-            raise ValueError(msg)
-        return self
-
-    @model_validator(mode="after")
-    def min_max_age_range_consistency(self):
-        """Age min and max must be provided together or not at all."""
-        if self.age_min and self.age_max:
-            if self.age_min >= self.age_max:
-                msg = "age_max must be greater than age_min"
-                raise ValueError(msg)
-            return self
-
-        if self.age_min or self.age_max:
-            msg = "age_min and age_max must be provided together"
-            raise ValueError(msg)
-
-        return self
-
-
-class SubjectCreate(AuthorizationOptionalPublicMixin, SubjectBase):
-    species_id: uuid.UUID
-
-
-class SubjectRead(SubjectBase, CreationMixin, AuthorizationMixin, IdentifiableMixin):
-    species: SpeciesRead

--- a/app/schemas/density.py
+++ b/app/schemas/density.py
@@ -1,9 +1,8 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType, MeasurementUnit
+from app.db.types import MeasurementUnit
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -11,12 +10,13 @@ from app.schemas.base import (
     AuthorizationOptionalPublicMixin,
     BrainRegionRead,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
     LicensedCreateMixin,
     LicensedReadMixin,
-    SubjectRead,
 )
 from app.schemas.contribution import ContributionReadWithoutEntity
+from app.schemas.subject import SubjectRead
 
 
 class MeasurementRead(BaseModel):
@@ -42,7 +42,12 @@ class ExperimentalDensityCreate(
 
 
 class ExperimentalDensityRead(
-    ExperimentalDensityBase, CreationMixin, IdentifiableMixin, LicensedReadMixin, AuthorizationMixin
+    ExperimentalDensityBase,
+    CreationMixin,
+    IdentifiableMixin,
+    LicensedReadMixin,
+    AuthorizationMixin,
+    EntityTypeMixin,
 ):
     subject: SubjectRead
     brain_region: BrainRegionRead
@@ -66,12 +71,10 @@ class ExperimentalSynapsesPerConnectionCreate(ExperimentalDensityCreate):
 class ExperimentalNeuronDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
-    type: Literal[EntityType.experimental_neuron_density] = EntityType.experimental_neuron_density
 
 
 class ExperimentalBoutonDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
-    type: Literal[EntityType.experimental_bouton_density] = EntityType.experimental_bouton_density
 
 
 class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
@@ -83,6 +86,3 @@ class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
 
 class ExperimentalSynapsesPerConnectionRead(ExperimentalDensityRead):
     synaptic_pathway: SynapticPathwayRead
-    type: Literal[EntityType.experimental_synapses_per_connection] = (
-        EntityType.experimental_synapses_per_connection
-    )

--- a/app/schemas/density.py
+++ b/app/schemas/density.py
@@ -1,8 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import MeasurementUnit
+from app.db.types import EntityType, MeasurementUnit
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -65,10 +66,12 @@ class ExperimentalSynapsesPerConnectionCreate(ExperimentalDensityCreate):
 class ExperimentalNeuronDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
+    type: Literal[EntityType.experimental_neuron_density] = EntityType.experimental_neuron_density
 
 
 class ExperimentalBoutonDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
+    type: Literal[EntityType.experimental_bouton_density] = EntityType.experimental_bouton_density
 
 
 class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
@@ -80,3 +83,6 @@ class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
 
 class ExperimentalSynapsesPerConnectionRead(ExperimentalDensityRead):
     synaptic_pathway: SynapticPathwayRead
+    type: Literal[EntityType.experimental_synapses_per_connection] = (
+        EntityType.experimental_synapses_per_connection
+    )

--- a/app/schemas/density.py
+++ b/app/schemas/density.py
@@ -1,9 +1,8 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType, MeasurementUnit
+from app.db.types import MeasurementUnit
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -72,12 +71,10 @@ class ExperimentalSynapsesPerConnectionCreate(ExperimentalDensityCreate):
 class ExperimentalNeuronDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
-    type: Literal[EntityType.experimental_neuron_density] = EntityType.experimental_neuron_density
 
 
 class ExperimentalBoutonDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
-    type: Literal[EntityType.experimental_bouton_density] = EntityType.experimental_bouton_density
 
 
 class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
@@ -89,6 +86,3 @@ class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
 
 class ExperimentalSynapsesPerConnectionRead(ExperimentalDensityRead):
     synaptic_pathway: SynapticPathwayRead
-    type: Literal[EntityType.experimental_synapses_per_connection] = (
-        EntityType.experimental_synapses_per_connection
-    )

--- a/app/schemas/density.py
+++ b/app/schemas/density.py
@@ -1,8 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import MeasurementUnit
+from app.db.types import EntityType, MeasurementUnit
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -71,10 +72,12 @@ class ExperimentalSynapsesPerConnectionCreate(ExperimentalDensityCreate):
 class ExperimentalNeuronDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
+    type: Literal[EntityType.experimental_neuron_density] = EntityType.experimental_neuron_density
 
 
 class ExperimentalBoutonDensityRead(ExperimentalDensityRead):
     mtypes: list[MTypeClassRead] | None
+    type: Literal[EntityType.experimental_bouton_density] = EntityType.experimental_bouton_density
 
 
 class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
@@ -86,3 +89,6 @@ class SynapticPathwayRead(CreationMixin, IdentifiableMixin):
 
 class ExperimentalSynapsesPerConnectionRead(ExperimentalDensityRead):
     synaptic_pathway: SynapticPathwayRead
+    type: Literal[EntityType.experimental_synapses_per_connection] = (
+        EntityType.experimental_synapses_per_connection
+    )

--- a/app/schemas/electrical_cell_recording.py
+++ b/app/schemas/electrical_cell_recording.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, Literal
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -8,7 +8,6 @@ from app.db.types import (
     ElectricalRecordingStimulusShape,
     ElectricalRecordingStimulusType,
     ElectricalRecordingType,
-    EntityType,
 )
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -103,4 +102,3 @@ class ElectricalCellRecordingRead(
             description="List of stimuli applied to the cell with their respective time steps",
         ),
     ] = None
-    type: Literal[EntityType.electrical_cell_recording] = EntityType.electrical_cell_recording

--- a/app/schemas/electrical_cell_recording.py
+++ b/app/schemas/electrical_cell_recording.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -8,6 +8,7 @@ from app.db.types import (
     ElectricalRecordingStimulusShape,
     ElectricalRecordingStimulusType,
     ElectricalRecordingType,
+    EntityType,
 )
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -102,3 +103,4 @@ class ElectricalCellRecordingRead(
             description="List of stimuli applied to the cell with their respective time steps",
         ),
     ] = None
+    type: Literal[EntityType.electrical_cell_recording] = EntityType.electrical_cell_recording

--- a/app/schemas/electrical_cell_recording.py
+++ b/app/schemas/electrical_cell_recording.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -8,6 +8,7 @@ from app.db.types import (
     ElectricalRecordingStimulusShape,
     ElectricalRecordingStimulusType,
     ElectricalRecordingType,
+    EntityType,
 )
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -100,3 +101,4 @@ class ElectricalCellRecordingRead(
             description="List of stimuli applied to the cell with their respective time steps",
         ),
     ] = None
+    type: Literal[EntityType.electrical_cell_recording] = EntityType.electrical_cell_recording

--- a/app/schemas/electrical_cell_recording.py
+++ b/app/schemas/electrical_cell_recording.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Annotated, Literal
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -8,7 +8,6 @@ from app.db.types import (
     ElectricalRecordingStimulusShape,
     ElectricalRecordingStimulusType,
     ElectricalRecordingType,
-    EntityType,
 )
 from app.schemas.asset import AssetRead
 from app.schemas.base import (
@@ -16,14 +15,15 @@ from app.schemas.base import (
     AuthorizationOptionalPublicMixin,
     BrainRegionRead,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
     LicensedCreateMixin,
     LicensedReadMixin,
-    SubjectRead,
 )
+from app.schemas.subject import SubjectRead
 
 
-class ElectricalRecordingStimulusRead(CreationMixin, IdentifiableMixin):
+class ElectricalRecordingStimulusRead(CreationMixin, IdentifiableMixin, EntityTypeMixin):
     name: str
     description: str
     dt: float | None = None
@@ -90,6 +90,7 @@ class ElectricalCellRecordingRead(
     LicensedReadMixin,
     AuthorizationMixin,
     IdentifiableMixin,
+    EntityTypeMixin,
 ):
     subject: SubjectRead
     brain_region: BrainRegionRead
@@ -101,4 +102,3 @@ class ElectricalCellRecordingRead(
             description="List of stimuli applied to the cell with their respective time steps",
         ),
     ] = None
-    type: Literal[EntityType.electrical_cell_recording] = EntityType.electrical_cell_recording

--- a/app/schemas/emodel.py
+++ b/app/schemas/emodel.py
@@ -1,9 +1,7 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -50,7 +48,6 @@ class EModelRead(EModelBase, CreationMixin, AuthorizationMixin, EntityTypeMixin,
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
     exemplar_morphology: ExemplarMorphology
-    type: Literal[EntityType.emodel] = EntityType.emodel
 
 
 class EModelReadExpanded(EModelRead):

--- a/app/schemas/emodel.py
+++ b/app/schemas/emodel.py
@@ -1,9 +1,7 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -11,6 +9,7 @@ from app.schemas.base import (
     AuthorizationOptionalPublicMixin,
     BrainRegionRead,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
     SpeciesRead,
     StrainRead,
@@ -40,7 +39,7 @@ class EModelCreate(EModelBase, AuthorizationOptionalPublicMixin):
     exemplar_morphology_id: uuid.UUID
 
 
-class EModelRead(EModelBase, CreationMixin, AssetsMixin, AuthorizationMixin):
+class EModelRead(EModelBase, CreationMixin, AuthorizationMixin, EntityTypeMixin, AssetsMixin):
     id: uuid.UUID
     species: SpeciesRead
     strain: StrainRead | None
@@ -49,7 +48,6 @@ class EModelRead(EModelBase, CreationMixin, AssetsMixin, AuthorizationMixin):
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
     exemplar_morphology: ExemplarMorphology
-    type: Literal[EntityType.emodel] = EntityType.emodel
 
 
 class EModelReadExpanded(EModelRead):

--- a/app/schemas/emodel.py
+++ b/app/schemas/emodel.py
@@ -1,7 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -47,6 +49,7 @@ class EModelRead(EModelBase, CreationMixin, AssetsMixin, AuthorizationMixin):
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
     exemplar_morphology: ExemplarMorphology
+    type: Literal[EntityType.emodel] = EntityType.emodel
 
 
 class EModelReadExpanded(EModelRead):

--- a/app/schemas/emodel.py
+++ b/app/schemas/emodel.py
@@ -1,7 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -48,6 +50,7 @@ class EModelRead(EModelBase, CreationMixin, AuthorizationMixin, EntityTypeMixin,
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
     exemplar_morphology: ExemplarMorphology
+    type: Literal[EntityType.emodel] = EntityType.emodel
 
 
 class EModelReadExpanded(EModelRead):

--- a/app/schemas/me_model.py
+++ b/app/schemas/me_model.py
@@ -1,16 +1,15 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from app.db.model import ValidationStatus
-from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.base import (
     AuthorizationMixin,
     AuthorizationOptionalPublicMixin,
     BrainRegionRead,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
     SpeciesRead,
     StrainRead,
@@ -45,6 +44,7 @@ class MEModelRead(
     MEModelBase,
     CreationMixin,
     AuthorizationMixin,
+    EntityTypeMixin,
 ):
     id: uuid.UUID
     species: SpeciesRead

--- a/app/schemas/me_model.py
+++ b/app/schemas/me_model.py
@@ -1,8 +1,10 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from app.db.model import ValidationStatus
+from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.base import (
     AuthorizationMixin,
@@ -55,3 +57,4 @@ class MEModelRead(
     etypes: list[ETypeClassRead] | None
     morphology: ReconstructionMorphologyRead
     emodel: EModelRead
+    type: Literal[EntityType.memodel] = EntityType.memodel

--- a/app/schemas/me_model.py
+++ b/app/schemas/me_model.py
@@ -1,8 +1,10 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from app.db.model import ValidationStatus
+from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.base import (
     AuthorizationMixin,

--- a/app/schemas/me_model.py
+++ b/app/schemas/me_model.py
@@ -55,4 +55,3 @@ class MEModelRead(
     etypes: list[ETypeClassRead] | None
     morphology: ReconstructionMorphologyRead
     emodel: EModelRead
-    type: Literal[EntityType.memodel] = EntityType.memodel

--- a/app/schemas/me_model.py
+++ b/app/schemas/me_model.py
@@ -1,10 +1,8 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from app.db.model import ValidationStatus
-from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.base import (
     AuthorizationMixin,

--- a/app/schemas/me_model.py
+++ b/app/schemas/me_model.py
@@ -1,10 +1,8 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from app.db.model import ValidationStatus
-from app.db.types import EntityType
 from app.schemas.annotation import ETypeClassRead, MTypeClassRead
 from app.schemas.base import (
     AuthorizationMixin,
@@ -57,4 +55,3 @@ class MEModelRead(
     etypes: list[ETypeClassRead] | None
     morphology: ReconstructionMorphologyRead
     emodel: EModelRead
-    type: Literal[EntityType.memodel] = EntityType.memodel

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -72,7 +72,6 @@ class ReconstructionMorphologyRead(
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
-    type: Literal[EntityType.reconstruction_morphology] = EntityType.reconstruction_morphology
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -72,6 +72,7 @@ class ReconstructionMorphologyRead(
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
+    type: Literal[EntityType.reconstruction_morphology] = EntityType.reconstruction_morphology
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -1,9 +1,10 @@
 import uuid
 from collections.abc import Sequence
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import PointLocationBase
+from app.db.types import EntityType, PointLocationBase
 from app.schemas.annotation import MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -69,6 +70,7 @@ class ReconstructionMorphologyRead(
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
+    type: Literal[EntityType.reconstruction_morphology] = EntityType.reconstruction_morphology
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -1,9 +1,10 @@
 import uuid
 from collections.abc import Sequence
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import PointLocationBase
+from app.db.types import EntityType, PointLocationBase
 from app.schemas.annotation import MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -71,6 +72,7 @@ class ReconstructionMorphologyRead(
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
+    type: Literal[EntityType.reconstruction_morphology] = EntityType.reconstruction_morphology
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -1,10 +1,9 @@
 import uuid
 from collections.abc import Sequence
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType, PointLocationBase
+from app.db.types import PointLocationBase
 from app.schemas.annotation import MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -12,6 +11,7 @@ from app.schemas.base import (
     AuthorizationOptionalPublicMixin,
     BrainRegionRead,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
     LicensedCreateMixin,
     LicensedReadMixin,
@@ -19,9 +19,9 @@ from app.schemas.base import (
     MeasurementRead,
     SpeciesRead,
     StrainRead,
-    EntityTypeMixin,
 )
 from app.schemas.contribution import ContributionReadWithoutEntity
+
 
 class ReconstructionMorphologyBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -20,9 +20,9 @@ from app.schemas.base import (
     MeasurementRead,
     SpeciesRead,
     StrainRead,
+    EntityTypeMixin,
 )
 from app.schemas.contribution import ContributionReadWithoutEntity
-
 
 class ReconstructionMorphologyBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -72,7 +72,6 @@ class ReconstructionMorphologyRead(
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
-    type: Literal[EntityType.reconstruction_morphology] = EntityType.reconstruction_morphology
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -19,9 +19,9 @@ from app.schemas.base import (
     MeasurementRead,
     SpeciesRead,
     StrainRead,
+    EntityTypeMixin,
 )
 from app.schemas.contribution import ContributionReadWithoutEntity
-
 
 class ReconstructionMorphologyBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -64,13 +64,13 @@ class ReconstructionMorphologyRead(
     LicensedReadMixin,
     AuthorizationMixin,
     AssetsMixin,
+    EntityTypeMixin,
 ):
     species: SpeciesRead
     strain: StrainRead | None
     brain_region: BrainRegionRead
     contributions: list[ContributionReadWithoutEntity] | None
     mtypes: list[MTypeClassRead] | None
-    type: Literal[EntityType.reconstruction_morphology] = EntityType.reconstruction_morphology
 
 
 class ReconstructionMorphologyAnnotationExpandedRead(ReconstructionMorphologyRead):

--- a/app/schemas/morphology.py
+++ b/app/schemas/morphology.py
@@ -1,10 +1,9 @@
 import uuid
 from collections.abc import Sequence
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType, PointLocationBase
+from app.db.types import PointLocationBase
 from app.schemas.annotation import MTypeClassRead
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -20,9 +19,9 @@ from app.schemas.base import (
     MeasurementRead,
     SpeciesRead,
     StrainRead,
-    EntityTypeMixin,
 )
 from app.schemas.contribution import ContributionReadWithoutEntity
+
 
 class ReconstructionMorphologyBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -1,15 +1,15 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType, SingleNeuronSimulationStatus
+from app.db.types import SingleNeuronSimulationStatus
 from app.schemas.base import (
     AuthorizationMixin,
     AuthorizationOptionalPublicMixin,
     BrainRegionCreateMixin,
     BrainRegionReadMixin,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
 )
 from app.schemas.me_model import NestedMEModel
@@ -40,9 +40,9 @@ class SingleNeuronSimulationRead(
     AuthorizationMixin,
     IdentifiableMixin,
     CreationMixin,
+    EntityTypeMixin,
 ):
     me_model: NestedMEModel
-    type: Literal[EntityType.single_neuron_simulation] = EntityType.single_neuron_simulation
 
 
 class SingleNeuronSynaptomeSimulationCreate(
@@ -59,8 +59,6 @@ class SingleNeuronSynaptomeSimulationRead(
     AuthorizationMixin,
     IdentifiableMixin,
     CreationMixin,
+    EntityTypeMixin,
 ):
     synaptome: NestedSynaptome
-    type: Literal[EntityType.single_neuron_synaptome_simulation] = (
-        EntityType.single_neuron_synaptome_simulation
-    )

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -1,9 +1,8 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType, SingleNeuronSimulationStatus
+from app.db.types import SingleNeuronSimulationStatus
 from app.schemas.base import (
     AuthorizationMixin,
     AuthorizationOptionalPublicMixin,
@@ -44,7 +43,6 @@ class SingleNeuronSimulationRead(
     EntityTypeMixin,
 ):
     me_model: NestedMEModel
-    type: Literal[EntityType.single_neuron_simulation] = EntityType.single_neuron_simulation
 
 
 class SingleNeuronSynaptomeSimulationCreate(
@@ -64,6 +62,3 @@ class SingleNeuronSynaptomeSimulationRead(
     EntityTypeMixin,
 ):
     synaptome: NestedSynaptome
-    type: Literal[EntityType.single_neuron_synaptome_simulation] = (
-        EntityType.single_neuron_synaptome_simulation
-    )

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -1,8 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import SingleNeuronSimulationStatus
+from app.db.types import EntityType, SingleNeuronSimulationStatus
 from app.schemas.base import (
     AuthorizationMixin,
     AuthorizationOptionalPublicMixin,
@@ -43,6 +44,7 @@ class SingleNeuronSimulationRead(
     EntityTypeMixin,
 ):
     me_model: NestedMEModel
+    type: Literal[EntityType.single_neuron_simulation] = EntityType.single_neuron_simulation
 
 
 class SingleNeuronSynaptomeSimulationCreate(
@@ -62,3 +64,6 @@ class SingleNeuronSynaptomeSimulationRead(
     EntityTypeMixin,
 ):
     synaptome: NestedSynaptome
+    type: Literal[EntityType.single_neuron_synaptome_simulation] = (
+        EntityType.single_neuron_synaptome_simulation
+    )

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -1,8 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import SingleNeuronSimulationStatus
+from app.db.types import EntityType, SingleNeuronSimulationStatus
 from app.schemas.base import (
     AuthorizationMixin,
     AuthorizationOptionalPublicMixin,
@@ -41,6 +42,7 @@ class SingleNeuronSimulationRead(
     CreationMixin,
 ):
     me_model: NestedMEModel
+    type: Literal[EntityType.single_neuron_simulation] = EntityType.single_neuron_simulation
 
 
 class SingleNeuronSynaptomeSimulationCreate(
@@ -59,3 +61,6 @@ class SingleNeuronSynaptomeSimulationRead(
     CreationMixin,
 ):
     synaptome: NestedSynaptome
+    type: Literal[EntityType.single_neuron_synaptome_simulation] = (
+        EntityType.single_neuron_synaptome_simulation
+    )

--- a/app/schemas/subject.py
+++ b/app/schemas/subject.py
@@ -1,0 +1,81 @@
+import uuid
+from datetime import timedelta
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.db.types import AgePeriod, Sex
+from app.schemas.base import (
+    AuthorizationMixin,
+    AuthorizationOptionalPublicMixin,
+    CreationMixin,
+    IdentifiableMixin,
+    SpeciesRead,
+)
+
+
+class SubjectBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True, ser_json_timedelta="float")
+
+    name: str
+    description: str
+    sex: Annotated[
+        Sex,
+        Field(title="Sex", description="Sex of the subject"),
+    ]
+    weight: Annotated[
+        float | None,
+        Field(title="Weight", description="Weight in grams", gt=0.0),
+    ] = None
+    age_value: Annotated[
+        timedelta | None,
+        Field(title="Age value", description="Age value interval.", gt=timedelta(0)),
+    ] = None
+    age_min: Annotated[
+        timedelta | None,
+        Field(title="Minimum age range", description="Minimum age range", gt=timedelta(0)),
+    ] = None
+    age_max: Annotated[
+        timedelta | None,
+        Field(title="Maximum age range", description="Maximum age range", gt=timedelta(0)),
+    ] = None
+    age_period: AgePeriod | None = None
+
+    @model_validator(mode="after")
+    def age_period_mandatory_with_age_fields(self):
+        """Age period must be provided when age fields are provided."""
+        if any([self.age_value, self.age_min, self.age_max]) and not self.age_period:
+            msg = "age_period must be provided when age fields are provided"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def either_age_value_or_age_range(self):
+        """Either age_value or age_min and age_max must be provided."""
+        if self.age_value and any([self.age_min, self.age_max]):
+            msg = "age_value and age_min/age_max cannot both be provided"
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def min_max_age_range_consistency(self):
+        """Age min and max must be provided together or not at all."""
+        if self.age_min and self.age_max:
+            if self.age_min >= self.age_max:
+                msg = "age_max must be greater than age_min"
+                raise ValueError(msg)
+            return self
+
+        if self.age_min or self.age_max:
+            msg = "age_min and age_max must be provided together"
+            raise ValueError(msg)
+
+        return self
+
+
+class SubjectCreate(AuthorizationOptionalPublicMixin, SubjectBase):
+    species_id: uuid.UUID
+
+
+class SubjectRead(SubjectBase, CreationMixin, AuthorizationMixin, IdentifiableMixin):
+    species: SpeciesRead

--- a/app/schemas/synaptome.py
+++ b/app/schemas/synaptome.py
@@ -1,7 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from app.db.types import EntityType
 from app.schemas.agent import AgentRead
 from app.schemas.base import (
     AuthorizationMixin,
@@ -44,3 +46,4 @@ class SingleNeuronSynaptomeRead(
     brain_region: BrainRegionRead
     createdBy: AgentRead | None
     updatedBy: AgentRead | None
+    type: Literal[EntityType.single_neuron_synaptome] = EntityType.single_neuron_synaptome

--- a/app/schemas/synaptome.py
+++ b/app/schemas/synaptome.py
@@ -1,7 +1,9 @@
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from app.db.types import EntityType
 from app.schemas.agent import AgentRead
 from app.schemas.base import (
     AuthorizationMixin,
@@ -46,3 +48,4 @@ class SingleNeuronSynaptomeRead(
     brain_region: BrainRegionRead
     createdBy: AgentRead | None
     updatedBy: AgentRead | None
+    type: Literal[EntityType.single_neuron_synaptome] = EntityType.single_neuron_synaptome

--- a/app/schemas/synaptome.py
+++ b/app/schemas/synaptome.py
@@ -1,15 +1,14 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType
 from app.schemas.agent import AgentRead
 from app.schemas.base import (
     AuthorizationMixin,
     AuthorizationOptionalPublicMixin,
     BrainRegionRead,
     CreationMixin,
+    EntityTypeMixin,
     IdentifiableMixin,
 )
 from app.schemas.contribution import ContributionReadWithoutEntityMixin
@@ -41,9 +40,9 @@ class SingleNeuronSynaptomeRead(
     IdentifiableMixin,
     CreationMixin,
     ContributionReadWithoutEntityMixin,
+    EntityTypeMixin,
 ):
     me_model: NestedMEModel
     brain_region: BrainRegionRead
     createdBy: AgentRead | None
     updatedBy: AgentRead | None
-    type: Literal[EntityType.single_neuron_synaptome] = EntityType.single_neuron_synaptome

--- a/app/schemas/synaptome.py
+++ b/app/schemas/synaptome.py
@@ -1,9 +1,7 @@
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from app.db.types import EntityType
 from app.schemas.agent import AgentRead
 from app.schemas.base import (
     AuthorizationMixin,
@@ -48,4 +46,3 @@ class SingleNeuronSynaptomeRead(
     brain_region: BrainRegionRead
     createdBy: AgentRead | None
     updatedBy: AgentRead | None
-    type: Literal[EntityType.single_neuron_synaptome] = EntityType.single_neuron_synaptome

--- a/app/service/subject.py
+++ b/app/service/subject.py
@@ -8,7 +8,7 @@ from app.dependencies.common import FacetQueryParams, FacetsDep, PaginationQuery
 from app.dependencies.db import SessionDep
 from app.filters.common import SubjectFilterDep
 from app.queries.common import router_create_one, router_read_many, router_read_one
-from app.schemas.base import SubjectCreate, SubjectRead
+from app.schemas.subject import SubjectCreate, SubjectRead
 from app.schemas.types import ListResponse
 
 

--- a/tests/test_electrical_cell_recording.py
+++ b/tests/test_electrical_cell_recording.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.db.model import ElectricalCellRecording, ElectricalRecordingStimulus
+from app.db.types import EntityType
 
 from .utils import (
     PROJECT_ID,
@@ -128,6 +129,7 @@ def test_create_one(client, subject_id, license_id, brain_region_id, json_data):
     assert data["brain_region"]["id"] == brain_region_id
     assert data["license"]["id"] == str(license_id)
     assert data["authorized_project_id"] == str(PROJECT_ID)
+    assert data["type"] == EntityType.electrical_cell_recording
 
 
 def test_read_one(client, subject_id, license_id, brain_region_id, trace_id):
@@ -145,6 +147,7 @@ def test_read_one(client, subject_id, license_id, brain_region_id, trace_id):
     assert data["authorized_project_id"] == PROJECT_ID
     assert len(data["stimuli"]) == 2
     assert len(data["assets"]) == 1
+    assert data["type"] == EntityType.electrical_cell_recording
 
 
 def test_missing(client):

--- a/tests/test_experimental_bouton_density.py
+++ b/tests/test_experimental_bouton_density.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app.db.types import EntityType
 from app.schemas.density import ExperimentalBoutonDensityCreate
 
 from .utils import (
@@ -30,6 +31,7 @@ def _assert_read_response(data, json_data):
     assert data["description"] == json_data["description"]
     assert data["name"] == json_data["name"]
     assert data["license"]["name"] == "Test License"
+    assert data["type"] == EntityType.experimental_bouton_density
 
 
 @pytest.fixture

--- a/tests/test_experimental_neuron_density.py
+++ b/tests/test_experimental_neuron_density.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.db.model import ExperimentalNeuronDensity
+from app.db.types import EntityType
 
 from .utils import (
     assert_request,
@@ -31,6 +32,7 @@ def _assert_read_response(data, json_data):
     assert data["description"] == json_data["description"]
     assert data["name"] == json_data["name"]
     assert data["license"]["name"] == "Test License"
+    assert data["type"] == EntityType.experimental_neuron_density
 
 
 @pytest.fixture

--- a/tests/test_experimental_synapses_per_connection.py
+++ b/tests/test_experimental_synapses_per_connection.py
@@ -1,5 +1,7 @@
 import pytest
 
+from app.db.types import EntityType
+
 from .utils import (
     assert_request,
     check_authorization,
@@ -30,6 +32,7 @@ def _assert_read_response(data, json_data):
     assert data["name"] == json_data["name"]
     assert data["license"]["name"] == "Test License"
     assert data["synaptic_pathway"]["id"] == json_data["synaptic_pathway_id"]
+    assert data["type"] == EntityType.experimental_synapses_per_connection
 
 
 @pytest.fixture

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -1,6 +1,7 @@
 import itertools as it
 
 from app.db.model import ReconstructionMorphology, Species, Strain
+from app.db.types import EntityType
 
 from .utils import (
     MISSING_ID,
@@ -51,10 +52,17 @@ def test_create_reconstruction_morphology(
     assert data["license"]["name"] == "Test License", (
         f"Failed to get license for reconstruction morphology: {data}"
     )
+    assert data["type"] == EntityType.reconstruction_morphology, (
+        f"Failed to get correct type for reconstruction morphology: {data}"
+    )
 
     response = client.get(ROUTE)
     assert response.status_code == 200, (
         f"Failed to get reconstruction morphologies: {response.text}"
+    )
+    data = response.json()["data"]
+    assert data and all(item["type"] == EntityType.reconstruction_morphology for item in data), (  # noqa: PT018
+        "One or more reconstruction morphologies has incorrect type"
     )
 
 
@@ -113,6 +121,9 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "data" in response_json
     assert response_json["facets"] is None
     assert len(response_json["data"]) == 10
+    assert all(
+        item["type"] == EntityType.reconstruction_morphology for item in response_json["data"]
+    ), "One or more reconstruction morphologies has incorrect type"
 
     response = client.get(ROUTE, params={"page_size": 100, "order_by": "+creation_date"})
     assert response.status_code == 200
@@ -258,20 +269,32 @@ def test_authorization(
     )
     assert public_morph.status_code == 200
     public_morph = public_morph.json()
+    assert public_morph["type"] == EntityType.reconstruction_morphology, (
+        "Public morphology has incorrect type"
+    )
 
     inaccessible_obj = client_user_2.post(
         ROUTE, json=morph_json | {"name": "inaccessible morphology 1"}
     )
     assert inaccessible_obj.status_code == 200
     inaccessible_obj = inaccessible_obj.json()
+    assert inaccessible_obj["type"] == EntityType.reconstruction_morphology, (
+        "Inaccessible morphology has incorrect type"
+    )
 
     private_morph0 = client_user_1.post(ROUTE, json=morph_json | {"name": "private morphology 0"})
     assert private_morph0.status_code == 200
     private_morph0 = private_morph0.json()
+    assert private_morph0["type"] == EntityType.reconstruction_morphology, (
+        "Private morphology 0 has incorrect type"
+    )
 
     private_morph1 = client_user_1.post(ROUTE, json=morph_json | {"name": "private morphology 1"})
     assert private_morph1.status_code == 200
     private_morph1 = private_morph1.json()
+    assert private_morph1["type"] == EntityType.reconstruction_morphology, (
+        "Private morphology 1 has incorrect type"
+    )
 
     # only return results that matches the desired project, and public ones
     response = client_user_1.get(ROUTE)
@@ -317,7 +340,11 @@ def test_pagination(db, client, brain_region_id):
     response = client.get(ROUTE, params={"page_size": total_items + 1})
 
     assert response.status_code == 200
-    assert len(response.json()["data"]) == total_items
+    data = response.json()["data"]
+    assert len(data) == total_items
+    assert all(item["type"] == EntityType.reconstruction_morphology for item in data), (
+        "One or more reconstruction morphologies has incorrect type"
+    )
 
     for i in range(1, total_items + 10, 2):
         response = client.get(ROUTE, params={"page_size": i})
@@ -367,6 +394,9 @@ def test_filter_by_id__in(db, client, brain_region_id):
     data = response.json()["data"]
     assert len(data) == 1
     assert data[0]["id"] == morphology_ids[0]
+    assert data[0]["type"] == EntityType.reconstruction_morphology, (
+        "Filtered morphology has incorrect type"
+    )
 
     # filtering by multiple IDs
     selected_ids = [morphology_ids[1], morphology_ids[3]]

--- a/tests/test_single_neuron_simulation.py
+++ b/tests/test_single_neuron_simulation.py
@@ -3,6 +3,7 @@ import itertools as it
 import pytest
 
 from app.db.model import MEModel, SingleNeuronSimulation
+from app.db.types import EntityType
 
 from .utils import (
     MISSING_ID,
@@ -52,6 +53,7 @@ def test_single_neuron_simulation(client, brain_region_id, memodel_id):
     assert data["me_model"]["id"] == memodel_id, f"Failed to get id frmo me model; {data}"
     assert data["status"] == "success"
     assert data["authorized_project_id"] == PROJECT_ID
+    assert data["type"] == EntityType.single_neuron_simulation
 
     response = assert_request(client.get, url=f"{ROUTE}/{data['id']}")
     data = response.json()
@@ -65,6 +67,7 @@ def test_single_neuron_simulation(client, brain_region_id, memodel_id):
     assert data["me_model"]["id"] == memodel_id, f"Failed to get id frmo me model; {data}"
     assert data["status"] == "success"
     assert data["authorized_project_id"] == PROJECT_ID
+    assert data["type"] == EntityType.single_neuron_simulation
 
 
 @pytest.mark.parametrize(

--- a/tests/test_single_neuron_synaptome.py
+++ b/tests/test_single_neuron_synaptome.py
@@ -7,6 +7,7 @@ from app.db.model import (
     MEModel,
     SingleNeuronSynaptome,
 )
+from app.db.types import EntityType
 
 from .utils import (
     MISSING_ID,
@@ -46,6 +47,7 @@ def _assert_read_response(data, json_data):
     assert len(data["me_model"]["etypes"]) == 1
     assert data["createdBy"]["id"] == json_data["createdBy_id"]
     assert data["updatedBy"]["id"] == json_data["updatedBy_id"]
+    assert data["type"] == EntityType.single_neuron_synaptome
 
 
 def _assert_create_response(data, json_data):

--- a/tests/test_single_neuron_synaptome_simulation.py
+++ b/tests/test_single_neuron_synaptome_simulation.py
@@ -3,6 +3,7 @@ import itertools as it
 import pytest
 
 from app.db.model import SingleNeuronSynaptome, SingleNeuronSynaptomeSimulation
+from app.db.types import EntityType
 
 from .utils import (
     MISSING_ID,
@@ -122,6 +123,7 @@ def test_create_one(client, json_data, brain_region_id, synaptome_id):
     assert data["recordingLocation"] == ["soma[0]_0.5"]
     assert data["synaptome"]["id"] == str(synaptome_id)
     assert data["authorized_project_id"] == PROJECT_ID
+    assert data["type"] == EntityType.single_neuron_synaptome_simulation
 
 
 def test_read_one(client, brain_region_id, synaptome_id, simulation_id):
@@ -137,6 +139,7 @@ def test_read_one(client, brain_region_id, synaptome_id, simulation_id):
     assert data["recordingLocation"] == ["soma[0]_0.5"]
     assert data["synaptome"]["id"] == str(synaptome_id)
     assert data["authorized_project_id"] == PROJECT_ID
+    assert data["type"] == EntityType.single_neuron_synaptome_simulation
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subject.py
+++ b/tests/test_subject.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import pytest
 
 from app.db.model import Subject
-from app.schemas.base import SubjectCreate
+from app.schemas.subject import SubjectCreate
 
 from .utils import (
     PROJECT_ID,


### PR DESCRIPTION
I was thinking of another way to do it using another type-mixin
ex:
```python
class EntityTypeMixin(BaseModel):
    type: str | None = None
```
and then update the common query methods; 
```python
def router_read_one[T: BaseModel, I: Identifiable](
    *,
    id_: uuid.UUID,
    db: Session,
    db_model_class: type[I],
    authorized_project_id: uuid.UUID | None,
    response_schema_class: type[T],
    apply_operations: ApplyOperations[I] | None,
) -> T:
    # ... old code
    validated_data = response_schema_class.model_validate(row)
    if hasattr(validated_data, "type") and hasattr(db_model_class, "__tablename__"):
        validated_data = response_schema_class.model_validate(
            {
                **validated_data.model_dump(),
                "type": db_model_class.__tablename__,
            }
        )

    return validated_data**
```

but find out to have it in the response read schema is more readable and no need for another validation change