### PR TITLE
rename contribution facet to contributions

### DIFF
--- a/app/queries/facets.py
+++ b/app/queries/facets.py
@@ -4,8 +4,8 @@ from app.dependencies.common import FacetQueryParams
 brain_region: dict[str, FacetQueryParams] = {
     "brain_region": {"id": BrainRegion.id, "label": BrainRegion.name},
 }
-contribution: dict[str, FacetQueryParams] = {
-    "contribution": {
+contributions: dict[str, FacetQueryParams] = {
+    "contributions": {
         "id": Agent.id,
         "label": Agent.pref_label,
         "type": Agent.type,

--- a/app/service/electrical_cell_recording.py
+++ b/app/service/electrical_cell_recording.py
@@ -78,7 +78,7 @@ def read_many(
     agent_alias = aliased(Agent, flat=True)
     protocol_alias = aliased(ElectricalRecordingStimulus, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = {
-        "contribution": {
+        "contributions": {
             "id": agent_alias.id,
             "label": agent_alias.pref_label,
             "type": agent_alias.type,

--- a/app/service/emodel.py
+++ b/app/service/emodel.py
@@ -102,7 +102,7 @@ def read_many(
         "mtype": {"id": MTypeClass.id, "label": MTypeClass.pref_label},
         "etype": {"id": ETypeClass.id, "label": ETypeClass.pref_label},
         "species": {"id": Species.id, "label": Species.name},
-        "contribution": {
+        "contributions": {
             "id": Agent.id,
             "label": Agent.pref_label,
             "type": Agent.type,

--- a/app/service/experimental_bouton_density.py
+++ b/app/service/experimental_bouton_density.py
@@ -36,7 +36,7 @@ def read_many(
 ) -> ListResponse[ExperimentalBoutonDensityRead]:
     subject = aliased(Subject, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = (
-        fc.brain_region | fc.contribution | fc.mtype | fc.species | fc.strain
+        fc.brain_region | fc.contributions | fc.mtype | fc.species | fc.strain
     )
     apply_filter_query = lambda query: (
         query.join(BrainRegion, ExperimentalBoutonDensity.brain_region_id == BrainRegion.id)

--- a/app/service/experimental_neuron_density.py
+++ b/app/service/experimental_neuron_density.py
@@ -38,7 +38,7 @@ def read_many(
 ) -> ListResponse[ExperimentalNeuronDensityRead]:
     subject_alias = aliased(Subject, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = (
-        fc.brain_region | fc.contribution | fc.etype | fc.mtype | fc.species | fc.strain
+        fc.brain_region | fc.contributions | fc.etype | fc.mtype | fc.species | fc.strain
     )
     apply_filter_query = lambda query: (
         query.join(BrainRegion, ExperimentalNeuronDensity.brain_region_id == BrainRegion.id)

--- a/app/service/experimental_synapses_per_connection.py
+++ b/app/service/experimental_synapses_per_connection.py
@@ -39,7 +39,7 @@ def read_many(
     pathway_alias = aliased(SynapticPathway, flat=True)
     subject_alias = aliased(Subject, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = (
-        fc.brain_region | fc.contribution | fc.mtype | fc.species | fc.strain | fc.synaptic_pathway
+        fc.brain_region | fc.contributions | fc.mtype | fc.species | fc.strain | fc.synaptic_pathway
     )
 
     apply_filter_query = lambda query: (

--- a/app/service/memodel.py
+++ b/app/service/memodel.py
@@ -118,7 +118,7 @@ def read_many(
         "etype": {"id": ETypeClass.id, "label": ETypeClass.pref_label},
         "species": {"id": Species.id, "label": Species.name},
         "strain": {"id": Strain.id, "label": Strain.name},
-        "contribution": {
+        "contributions": {
             "id": Agent.id,
             "label": Agent.pref_label,
             "type": Agent.type,

--- a/app/service/morphology.py
+++ b/app/service/morphology.py
@@ -110,7 +110,7 @@ def read_many(
         "mtype": {"id": MTypeClass.id, "label": MTypeClass.pref_label},
         "species": {"id": Species.id, "label": Species.name},
         "strain": {"id": Strain.id, "label": Strain.name},
-        "contribution": {
+        "contributions": {
             "id": Agent.id,
             "label": Agent.pref_label,
             "type": Agent.type,

--- a/app/service/single_neuron_simulation.py
+++ b/app/service/single_neuron_simulation.py
@@ -56,7 +56,7 @@ def read_many(
 ) -> ListResponse[SingleNeuronSimulationRead]:
     me_model_alias = aliased(MEModel, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = {
-        "contribution": {
+        "contributions": {
             "id": Agent.id,
             "label": Agent.pref_label,
             "type": Agent.type,

--- a/app/service/single_neuron_synaptome.py
+++ b/app/service/single_neuron_synaptome.py
@@ -69,7 +69,7 @@ def read_many(
         }
     }
     name_to_facet_query_params: dict[str, FacetQueryParams] = (
-        fc.brain_region | fc.contribution | fc.memodel | created_by_facet
+        fc.brain_region | fc.contributions | fc.memodel | created_by_facet
     )
     apply_filter_query = lambda query: (
         query.join(BrainRegion, SingleNeuronSynaptome.brain_region_id == BrainRegion.id)

--- a/app/service/single_neuron_synaptome_simulation.py
+++ b/app/service/single_neuron_synaptome_simulation.py
@@ -71,7 +71,7 @@ def read_many(
 ) -> ListResponse[SingleNeuronSynaptomeSimulationRead]:
     synaptome_alias = aliased(SingleNeuronSynaptome, flat=True)
     name_to_facet_query_params: dict[str, FacetQueryParams] = {
-        "contribution": {
+        "contributions": {
             "id": Agent.id,
             "label": Agent.pref_label,
             "type": Agent.type,

--- a/tests/test_contribution.py
+++ b/tests/test_contribution.py
@@ -95,8 +95,8 @@ def test_create_contribution(
     assert len(data[0]["contributions"]) == 2
 
     facets = response.json()["facets"]
-    assert len(facets["contribution"]) == 2
-    assert facets["contribution"] == [
+    assert len(facets["contributions"]) == 2
+    assert facets["contributions"] == [
         {"id": str(organization_id), "label": "ACME", "type": "organization", "count": 1},
         {"id": str(person_id), "label": "jd courcol", "type": "person", "count": 1},
     ]
@@ -266,7 +266,7 @@ def test_contribution_facets(
     data = response.json()
     facets = data["facets"]
     assert facets == {
-        "contribution": [
+        "contributions": [
             {"count": 6, "id": str(org.id), "label": "org_pref_label", "type": "organization"},
             {"count": 9, "id": str(person.id), "label": "person_pref_label", "type": "person"},
         ],
@@ -293,7 +293,7 @@ def test_contribution_facets(
     data = response.json()
     facets = data["facets"]
     assert facets == {
-        "contribution": [
+        "contributions": [
             {"count": 9, "id": str(person.id), "label": "person_pref_label", "type": "person"}
         ],
         "mtype": [],

--- a/tests/test_electrical_cell_recording.py
+++ b/tests/test_electrical_cell_recording.py
@@ -213,7 +213,7 @@ def test_facets(client, faceted_ids):
     assert "facets" in data
     facets = data["facets"]
 
-    assert facets["contribution"] == []
+    assert facets["contributions"] == []
     assert facets["brain_region"] == [
         {"id": brain_region_ids[0], "label": "region-0", "count": 1, "type": "brain_region"},
         {"id": brain_region_ids[1], "label": "region-1", "count": 1, "type": "brain_region"},

--- a/tests/test_emodel.py
+++ b/tests/test_emodel.py
@@ -122,7 +122,7 @@ def test_facets(client: TestClient, faceted_emodel_ids: EModelIds):
             {"id": ids.species_ids[0], "label": "TestSpecies0", "count": 4, "type": "species"},
             {"id": ids.species_ids[1], "label": "TestSpecies1", "count": 4, "type": "species"},
         ],
-        "contribution": [],
+        "contributions": [],
         "brain_region": [
             {"id": ids.brain_region_ids[0], "label": "region0", "count": 4, "type": "brain_region"},
             {"id": ids.brain_region_ids[1], "label": "region1", "count": 4, "type": "brain_region"},
@@ -162,7 +162,7 @@ def test_facets(client: TestClient, faceted_emodel_ids: EModelIds):
                 "type": "species",
             }
         ],
-        "contribution": [],
+        "contributions": [],
         "brain_region": [
             {"id": 0, "label": "region0", "count": 2, "type": "brain_region"},
             {"id": 1, "label": "region1", "count": 2, "type": "brain_region"},

--- a/tests/test_memodel.py
+++ b/tests/test_memodel.py
@@ -99,7 +99,7 @@ def test_facets(client: TestClient, faceted_memodels: MEModels):
                 "type": "species",
             },
         ],
-        "contribution": [
+        "contributions": [
             {
                 "id": ids.agent_ids[0],
                 "label": "test_organization_1",
@@ -176,7 +176,7 @@ def test_filtered_facets(client: TestClient, faceted_memodels: MEModels):
             }
         ],
         "strain": [],
-        "contribution": [
+        "contributions": [
             {
                 "id": ids.agent_ids[0],
                 "label": "test_organization_1",
@@ -243,7 +243,7 @@ def test_facets_with_search(client: TestClient, faceted_memodels: MEModels):
             }
         ],
         "strain": [],
-        "contribution": [
+        "contributions": [
             {
                 "id": ids.agent_ids[0],
                 "label": "test_organization_1",

--- a/tests/test_morphology.py
+++ b/tests/test_morphology.py
@@ -161,7 +161,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "facets" in data
     facets = data["facets"]
     assert facets == {
-        "contribution": [],
+        "contributions": [],
         "mtype": [],
         "species": [
             {"id": str(species1.id), "label": "TestSpecies1", "count": 6, "type": "species"},
@@ -180,7 +180,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "facets" in data
     facets = data["facets"]
     assert facets == {
-        "contribution": [],
+        "contributions": [],
         "mtype": [],
         "species": [
             {"id": str(species1.id), "label": "TestSpecies1", "count": 6, "type": "species"},
@@ -200,7 +200,7 @@ def test_query_reconstruction_morphology(db, client, brain_region_id):  # noqa: 
     assert "facets" in data
     facets = data["facets"]
     assert facets == {
-        "contribution": [],
+        "contributions": [],
         "mtype": [],
         "species": [
             {"id": str(species1.id), "label": "TestSpecies1", "count": 6, "type": "species"}
@@ -235,7 +235,7 @@ def test_query_reconstruction_morphology_species_join(db, client, brain_region_i
     assert len(data["data"]) == data["pagination"]["total_items"]
     assert "facets" in data
     assert data["facets"] == {
-        "contribution": [],
+        "contributions": [],
         "mtype": [],
         "species": [
             {"id": str(species0.id), "label": "TestSpecies0", "count": 1, "type": "species"}

--- a/tests/test_single_neuron_simulation.py
+++ b/tests/test_single_neuron_simulation.py
@@ -262,7 +262,7 @@ def test_facets(client, faceted_ids):
     assert "facets" in data
     facets = data["facets"]
 
-    assert facets["contribution"] == []
+    assert facets["contributions"] == []
     assert facets["brain_region"] == [
         {"id": brain_region_ids[0], "label": "region-0", "count": 2, "type": "brain_region"},
         {"id": brain_region_ids[1], "label": "region-1", "count": 2, "type": "brain_region"},

--- a/tests/test_single_neuron_synaptome.py
+++ b/tests/test_single_neuron_synaptome.py
@@ -277,7 +277,7 @@ def test_facets(client, faceted_ids):
             {"id": brain_region_ids[0], "label": "region-0", "count": 2, "type": "brain_region"},
             {"id": brain_region_ids[1], "label": "region-1", "count": 2, "type": "brain_region"},
         ],
-        "contribution": [],
+        "contributions": [],
         "me_model": [
             {
                 "id": str(memodel_ids[0]),

--- a/tests/test_single_neuron_synaptome_simulation.py
+++ b/tests/test_single_neuron_synaptome_simulation.py
@@ -305,7 +305,7 @@ def test_facets(client, faceted_ids):
     assert "facets" in data
     facets = data["facets"]
 
-    assert facets["contribution"] == []
+    assert facets["contributions"] == []
     assert facets["brain_region"] == [
         {"id": brain_region_ids[0], "label": "region-0", "count": 2, "type": "brain_region"},
         {"id": brain_region_ids[1], "label": "region-1", "count": 2, "type": "brain_region"},


### PR DESCRIPTION
the frontend rely heavily on the naming fields to be consistent on all type of entities and facets
so fields in response should match facets fields