### PR TITLE
Fix missing ion channel models in memodel's emodel

### DIFF
--- a/app/schemas/emodel.py
+++ b/app/schemas/emodel.py
@@ -56,7 +56,4 @@ class EModelRead(
     mtypes: list[MTypeClassRead] | None
     etypes: list[ETypeClassRead] | None
     exemplar_morphology: ExemplarMorphology
-
-
-class EModelReadExpanded(EModelRead, AssetsMixin):
     ion_channel_models: list[IonChannelModelWAssets]

--- a/app/service/emodel.py
+++ b/app/service/emodel.py
@@ -28,7 +28,7 @@ from app.dependencies.common import (
 from app.dependencies.db import SessionDep
 from app.filters.emodel import EModelFilterDep
 from app.queries.common import router_create_one, router_read_many, router_read_one
-from app.schemas.emodel import EModelCreate, EModelRead, EModelReadExpanded
+from app.schemas.emodel import EModelCreate, EModelRead
 from app.schemas.types import ListResponse
 
 if TYPE_CHECKING:
@@ -61,13 +61,13 @@ def read_one(
     user_context: UserContextDep,
     db: SessionDep,
     id_: uuid.UUID,
-) -> EModelReadExpanded:
+) -> EModelRead:
     return router_read_one(
         id_=id_,
         db=db,
         db_model_class=EModel,
         authorized_project_id=user_context.project_id,
-        response_schema_class=EModelReadExpanded,
+        response_schema_class=EModelRead,
         apply_operations=_load,
     )
 
@@ -96,7 +96,7 @@ def read_many(
     with_search: SearchDep,
     facets: FacetsDep,
     in_brain_region: InBrainRegionDep,
-) -> ListResponse[EModelReadExpanded]:
+) -> ListResponse[EModelRead]:
     morphology_alias = aliased(ReconstructionMorphology, flat=True)
     agent_alias = aliased(Agent, flat=True)
     created_by_alias = aliased(Agent, flat=True)
@@ -170,7 +170,7 @@ def read_many(
         apply_filter_query_operations=None,
         apply_data_query_operations=_load,
         pagination_request=pagination_request,
-        response_schema_class=EModelReadExpanded,
+        response_schema_class=EModelRead,
         name_to_facet_query_params=name_to_facet_query_params,
         filter_model=emodel_filter,
         filter_joins=filter_joins,

--- a/app/service/memodel.py
+++ b/app/service/memodel.py
@@ -57,6 +57,7 @@ def _load(select: Select):
             joinedload(EModel.createdBy),
             joinedload(EModel.updatedBy),
             selectinload(EModel.assets),
+            selectinload(EModel.ion_channel_models),
         ),
         joinedload(MEModel.morphology).options(
             joinedload(ReconstructionMorphology.brain_region),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -444,27 +444,27 @@ def emodel_id(create_emodel_ids: CreateIds) -> str:
 
 @pytest.fixture
 def create_memodel_ids(
-    db, morphology_id, brain_region_id, species_id, strain_id, emodel_id, agents
+    db, client, morphology_id, brain_region_id, species_id, strain_id, emodel_id, agents
 ) -> CreateIds:
     def _create_memodel_ids(count: int):
         memodel_ids: list[str] = []
         for i in range(count):
-            memodel_id = add_db(
-                db,
-                MEModel(
-                    name=f"{i}",
-                    description=f"{i}_description",
-                    brain_region_id=brain_region_id,
-                    species_id=species_id,
-                    strain_id=strain_id,
-                    morphology_id=morphology_id,
-                    emodel_id=emodel_id,
-                    authorized_public=False,
-                    authorized_project_id=PROJECT_ID,
-                    holding_current=0,
-                    threshold_current=0,
-                ),
-            ).id
+            memodel_id = assert_request(
+                client.post,
+                url="/memodel",
+                json={
+                    "name": f"{i}",
+                    "description": f"{i}_description",
+                    "brain_region_id": str(brain_region_id),
+                    "species_id": str(species_id),
+                    "strain_id": str(strain_id),
+                    "morphology_id": str(morphology_id),
+                    "emodel_id": str(emodel_id),
+                    "authorized_public": False,
+                    "holding_current": 0,
+                    "threshold_current": 0,
+                },
+            ).json()["id"]
 
             add_contributions(db, agents, memodel_id)
 


### PR DESCRIPTION
Use expanded EModel schema everywhere

Fixes https://github.com/openbraininstitute/entitysdk/issues/49