### PR TITLE
work around new docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint:  ## Run linters
 	uv run -m pyright app
 
 build:  ## Build the Docker image
-	docker compose --progress=plain build app
+	docker compose --profile "*" --progress=plain build app
 
 import:  ## Run the import on a database, assumes mba_hierarchy.json and out are in the current dir
 	@$(call load_env,run-local)


### PR DESCRIPTION
* docker-compose seems to have gotten picky about `--profiles` when using build, between version `2.35.1` and `2.36.0`, the latter is used in the CI.
* probably due to https://github.com/docker/compose/issues/12825