### PR TITLE
Remove octet-stream content type because it is not needed/used

### DIFF
--- a/app/db/types.py
+++ b/app/db/types.py
@@ -337,4 +337,3 @@ class ContentType(StrEnum):
     pdf = "application/pdf"
     png = "image/png"
     jpg = "image/jpeg"
-    stream = "application/octet-stream"

--- a/app/errors.py
+++ b/app/errors.py
@@ -45,6 +45,7 @@ class ApiErrorCode(UpperStrEnum):
     ASSET_INVALID_PATH = auto()
     ASSET_NOT_A_DIRECTORY = auto()
     ASSET_INVALID_SCHEMA = auto()
+    ASSET_INVALID_CONTENT_TYPE = auto()
     ION_NAME_NOT_FOUND = auto()
     S3_CANNOT_CREATE_PRESIGNED_URL = auto()
 

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -28,7 +28,7 @@ def get_content_type(file: UploadFile) -> ContentType:
             original_content_type,
             guessed_content_type,
         )
-    str_content_type = original_content_type or guessed_content_type or "application/octet-stream"
+    str_content_type = original_content_type or guessed_content_type
     return ContentType(str_content_type)
 
 

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -143,6 +143,18 @@ def test_upload_entity_asset(client, entity):
     error = ErrorResponse.model_validate(response.json())
     assert error.error_code == ApiErrorCode.ASSET_INVALID_PATH
 
+    with FILE_EXAMPLE_PATH.open("rb") as f:
+        files = {
+            # (filename, file (or bytes), content_type, headers)
+            "file": ("foo.obj", f)
+        }
+        response = upload_entity_asset(
+            client=client, entity_type=entity.type, entity_id=entity.id, files=files
+        )
+    assert response.status_code == 422, f"Asset creation didn't fail as expected: {response.text}"
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.ASSET_INVALID_CONTENT_TYPE
+
 
 def test_upload_entity_asset__label(monkeypatch, client, entity):
     response = _upload_entity_asset(


### PR DESCRIPTION
I added it because it was being set in get_content_type, however on second thought we shouldn't really allow it unless there is a use case that requires it.