### PR TITLE
add sim execution status to simulations within campaign

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -468,6 +468,15 @@ class Entity(LegacyMixin, Identifiable):
             Entity.id == Asset.entity_id, Asset.status != AssetStatus.DELETED
         ),
     )
+    generated_by: Mapped[list["Activity"]] = relationship(
+        "Activity",
+        secondary="usage",
+        primaryjoin="Entity.id == usage.c.usage_entity_id",
+        secondaryjoin="Activity.id == usage.c.usage_activity_id",
+        uselist=True,
+        viewonly=True,
+        lazy="selectin",
+    )
 
     __mapper_args__ = {  # noqa: RUF012
         "polymorphic_identity": __tablename__,

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -468,7 +468,8 @@ class Entity(LegacyMixin, Identifiable):
             Entity.id == Asset.entity_id, Asset.status != AssetStatus.DELETED
         ),
     )
-    generated_by: Mapped[list["Activity"]] = relationship(
+
+    used_by: Mapped[list["Activity"]] = relationship(
         "Activity",
         secondary="usage",
         primaryjoin="Entity.id == usage.c.usage_entity_id",

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -311,6 +311,7 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
         if facets and name_to_facet_query_params
         else None
     )
+
     return ListResponse[response_schema_class](
         data=[response_schema_class.model_validate(row) for row in data],
         pagination=PaginationResponse(

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.db.types import SimulationExecutionStatus
 from app.schemas.agent import CreatedByUpdatedByMixin
 from app.schemas.base import (
     ActivityTypeMixin,
@@ -21,7 +22,7 @@ class ActivityBase(BaseModel):
 
 
 class NestedActivityRead(ActivityBase, ActivityTypeMixin, IdentifiableMixin):
-    pass
+    status: SimulationExecutionStatus | None = None
 
 
 class ActivityRead(NestedActivityRead, CreatedByUpdatedByMixin, CreationMixin, AuthorizationMixin):

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -3,6 +3,7 @@ import uuid
 from pydantic import BaseModel, ConfigDict
 
 from app.db.types import JSON_DICT, SingleNeuronSimulationStatus
+from app.schemas.activity import NestedActivityRead
 from app.schemas.agent import CreatedByUpdatedByMixin
 from app.schemas.asset import AssetsMixin
 from app.schemas.base import (
@@ -47,6 +48,7 @@ class SingleNeuronSimulationRead(
     CreatedByUpdatedByMixin,
 ):
     me_model: NestedMEModel
+    generated_by: list[NestedActivityRead]
 
 
 class SingleNeuronSynaptomeSimulationCreate(
@@ -68,6 +70,7 @@ class SingleNeuronSynaptomeSimulationRead(
     CreatedByUpdatedByMixin,
 ):
     synaptome: NestedSynaptome
+    generated_by: list[NestedActivityRead]
 
 
 class SimulationBase(BaseModel):
@@ -83,8 +86,15 @@ class SimulationCreate(SimulationBase, AuthorizationOptionalPublicMixin):
     pass
 
 
+class UsageRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    usage_activity_id: uuid.UUID
+    usage_entity_id: uuid.UUID
+
+
 class NestedSimulationRead(SimulationBase, EntityTypeMixin, IdentifiableMixin):
-    pass
+    generated_by: list[NestedActivityRead]
 
 
 class SimulationRead(

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -48,7 +48,7 @@ class SingleNeuronSimulationRead(
     CreatedByUpdatedByMixin,
 ):
     me_model: NestedMEModel
-    generated_by: list[NestedActivityRead]
+    used_by: list[NestedActivityRead]
 
 
 class SingleNeuronSynaptomeSimulationCreate(
@@ -70,7 +70,7 @@ class SingleNeuronSynaptomeSimulationRead(
     CreatedByUpdatedByMixin,
 ):
     synaptome: NestedSynaptome
-    generated_by: list[NestedActivityRead]
+    used_by: list[NestedActivityRead]
 
 
 class SimulationBase(BaseModel):
@@ -94,7 +94,7 @@ class UsageRead(BaseModel):
 
 
 class NestedSimulationRead(SimulationBase, EntityTypeMixin, IdentifiableMixin):
-    generated_by: list[NestedActivityRead]
+    used_by: list[NestedActivityRead]
 
 
 class SimulationRead(

--- a/app/schemas/simulation_execution.py
+++ b/app/schemas/simulation_execution.py
@@ -7,8 +7,8 @@ class SimulationExecutionCreate(ActivityCreate):
 
 
 class SimulationExecutionRead(ActivityRead):
-    status: SimulationExecutionStatus
+    pass
 
 
 class SimulationExecutionUpdate(ActivityUpdate):
-    status: SimulationExecutionStatus | None = None
+    pass

--- a/app/service/simulation.py
+++ b/app/service/simulation.py
@@ -35,7 +35,7 @@ def _load(query: sa.Select):
         joinedload(Simulation.updated_by),
         selectinload(Simulation.assets),
         selectinload(Simulation.contributions),
-        selectinload(Simulation.generated_by),
+        selectinload(Simulation.used_by),
         raiseload("*"),
     )
 

--- a/app/service/simulation.py
+++ b/app/service/simulation.py
@@ -35,6 +35,7 @@ def _load(query: sa.Select):
         joinedload(Simulation.updated_by),
         selectinload(Simulation.assets),
         selectinload(Simulation.contributions),
+        selectinload(Simulation.generated_by),
         raiseload("*"),
     )
 

--- a/app/service/simulation_campaign.py
+++ b/app/service/simulation_campaign.py
@@ -36,7 +36,7 @@ def _load(query: sa.Select):
         joinedload(SimulationCampaign.updated_by),
         selectinload(SimulationCampaign.assets),
         selectinload(SimulationCampaign.contributions),
-        selectinload(SimulationCampaign.simulations).selectinload(Simulation.generated_by),
+        selectinload(SimulationCampaign.simulations).selectinload(Simulation.used_by),
         raiseload("*"),
     )
 

--- a/app/service/simulation_campaign.py
+++ b/app/service/simulation_campaign.py
@@ -36,7 +36,7 @@ def _load(query: sa.Select):
         joinedload(SimulationCampaign.updated_by),
         selectinload(SimulationCampaign.assets),
         selectinload(SimulationCampaign.contributions),
-        selectinload(SimulationCampaign.simulations),
+        selectinload(SimulationCampaign.simulations).selectinload(Simulation.generated_by),
         raiseload("*"),
     )
 

--- a/app/service/single_neuron_simulation.py
+++ b/app/service/single_neuron_simulation.py
@@ -27,6 +27,7 @@ def _load(query: sa.Select):
         joinedload(SingleNeuronSimulation.created_by),
         joinedload(SingleNeuronSimulation.updated_by),
         selectinload(SingleNeuronSimulation.assets),
+        selectinload(SingleNeuronSimulation.generated_by),
         raiseload("*"),
     )
 

--- a/app/service/single_neuron_simulation.py
+++ b/app/service/single_neuron_simulation.py
@@ -27,7 +27,7 @@ def _load(query: sa.Select):
         joinedload(SingleNeuronSimulation.created_by),
         joinedload(SingleNeuronSimulation.updated_by),
         selectinload(SingleNeuronSimulation.assets),
-        selectinload(SingleNeuronSimulation.generated_by),
+        selectinload(SingleNeuronSimulation.used_by),
         raiseload("*"),
     )
 

--- a/app/service/single_neuron_synaptome_simulation.py
+++ b/app/service/single_neuron_synaptome_simulation.py
@@ -40,7 +40,7 @@ def _load(query: sa.Select):
         selectinload(SingleNeuronSynaptomeSimulation.assets),
         joinedload(SingleNeuronSynaptomeSimulation.created_by),
         joinedload(SingleNeuronSynaptomeSimulation.updated_by),
-        selectinload(SingleNeuronSynaptomeSimulation.generated_by),
+        selectinload(SingleNeuronSynaptomeSimulation.used_by),
         raiseload("*"),
     )
 

--- a/app/service/single_neuron_synaptome_simulation.py
+++ b/app/service/single_neuron_synaptome_simulation.py
@@ -40,6 +40,7 @@ def _load(query: sa.Select):
         selectinload(SingleNeuronSynaptomeSimulation.assets),
         joinedload(SingleNeuronSynaptomeSimulation.created_by),
         joinedload(SingleNeuronSynaptomeSimulation.updated_by),
+        selectinload(SingleNeuronSynaptomeSimulation.generated_by),
         raiseload("*"),
     )
 


### PR DESCRIPTION
this is a to have the activity (simulation_execution) status  within the simulation response, 
I had to add `used_by_activities` to the `Entity` model, but i don't know if it's fit the original and db arch you have in mind 