### PR TITLE
Add support for different s3 storages

### DIFF
--- a/.env.run-docker
+++ b/.env.run-docker
@@ -12,7 +12,6 @@ export LOG_STANDARD_LOGGER__sqlalchemy.pool=INFO
 export AWS_ACCESS_KEY_ID=entitycore
 export AWS_SECRET_ACCESS_KEY=entitycore
 export AWS_ENDPOINT_URL=http://minio:9000
-export AWS_DEFAULT_REGION=us-east-1
 export AWS_MAX_ATTEMPTS=3
 export AWS_RETRY_MODE=standard
 

--- a/.env.run-local
+++ b/.env.run-local
@@ -17,7 +17,6 @@ export DB_PORT=5433
 export AWS_ACCESS_KEY_ID=entitycore
 export AWS_SECRET_ACCESS_KEY=entitycore
 export AWS_ENDPOINT_URL=http://127.0.0.1:9000
-export AWS_DEFAULT_REGION=us-east-1
 export AWS_MAX_ATTEMPTS=3
 export AWS_RETRY_MODE=standard
 

--- a/alembic/versions/20250723_110119_69af7e08cc08_add_asset_storage_type.py
+++ b/alembic/versions/20250723_110119_69af7e08cc08_add_asset_storage_type.py
@@ -1,0 +1,61 @@
+"""Add asset.storage_type column.
+
+Revision ID: 69af7e08cc08
+Revises: 992a74ce92fc
+Create Date: 2025-07-23 11:01:19.819579
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from sqlalchemy import Text
+import app.db.types
+
+# revision identifiers, used by Alembic.
+revision: str = "69af7e08cc08"
+down_revision: Union[str, None] = "992a74ce92fc"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    sa.Enum("aws_s3_internal", "aws_s3_open", name="storagetype").create(op.get_bind())
+    op.add_column(
+        "asset",
+        sa.Column(
+            "storage_type",
+            postgresql.ENUM(
+                "aws_s3_internal", "aws_s3_open", name="storagetype", create_type=False
+            ),
+            server_default="aws_s3_internal",
+            nullable=False,
+        ),
+    )
+    # remove server_default after the migration
+    op.alter_column(
+        "asset",
+        "storage_type",
+        server_default=None,
+    )
+    # ensure that path is unique per entity_id
+    op.create_index(
+        "uq_asset_entity_id_path",
+        "asset",
+        ["path", "entity_id"],
+        unique=True,
+        postgresql_where=sa.text("status != 'DELETED'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_asset_entity_id_path",
+        table_name="asset",
+        postgresql_where=sa.text("status != 'DELETED'"),
+    )
+    op.drop_column("asset", "storage_type")
+    sa.Enum("aws_s3_internal", "aws_s3_open", name="storagetype").drop(op.get_bind())

--- a/app/cli/utils.py
+++ b/app/cli/utils.py
@@ -39,7 +39,7 @@ from app.db.model import (
     Strain,
     Subject,
 )
-from app.db.types import AssetLabel, AssetStatus, ContentType, EntityType, Sex
+from app.db.types import AssetLabel, AssetStatus, ContentType, EntityType, Sex, StorageType
 from app.logger import L
 from app.schemas.base import ProjectContext
 from app.schemas.ion_channel_model import NeuronBlock
@@ -418,6 +418,7 @@ def get_or_create_distribution(
         entity_id=entity_id,
         created_by_id=created_by_id,
         updated_by_id=updated_by_id,
+        storage_type=StorageType.aws_s3_internal,
     )
     db.add(asset)
     db.commit()

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -57,6 +57,7 @@ from app.db.types import (
     Sex,
     SimulationExecutionStatus,
     SingleNeuronSimulationStatus,
+    StorageType,
     StructuralDomain,
     ValidationStatus,
 )
@@ -1044,12 +1045,20 @@ class Asset(Identifiable):
     meta: Mapped[JSON_DICT]  # not used yet. can be useful?
     label: Mapped[AssetLabel]
     entity_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("entity.id"), index=True)
+    storage_type: Mapped[StorageType]
 
     # partial unique index
     __table_args__ = (
         Index(
             "ix_asset_full_path",
             "full_path",
+            unique=True,
+            postgresql_where=(status != AssetStatus.DELETED.name),
+        ),
+        Index(
+            "uq_asset_entity_id_path",
+            "path",
+            "entity_id",
             unique=True,
             postgresql_where=(status != AssetStatus.DELETED.name),
         ),

--- a/app/db/types.py
+++ b/app/db/types.py
@@ -43,6 +43,13 @@ JSON_DICT = Annotated[dict[str, Any], mapped_column(JSONB)]
 STRING_LIST = Annotated[list[str], mapped_column(ARRAY(VARCHAR))]
 
 
+class StorageType(StrEnum):
+    """Storage type."""
+
+    aws_s3_internal = auto()
+    aws_s3_open = auto()
+
+
 class EntityType(StrEnum):
     """Entity types."""
 

--- a/app/dependencies/s3.py
+++ b/app/dependencies/s3.py
@@ -1,8 +1,7 @@
 from typing import Annotated
 
 from fastapi import Depends
-from types_boto3_s3 import S3Client
 
-from app.utils.s3 import get_s3_client
+from app.utils.s3 import StorageClientFactory, get_s3_client
 
-S3ClientDep = Annotated[S3Client, Depends(get_s3_client)]
+StorageClientFactoryDep = Annotated[StorageClientFactory, Depends(lambda: get_s3_client)]

--- a/app/errors.py
+++ b/app/errors.py
@@ -157,4 +157,4 @@ def ensure_valid_schema(
             error_code=error_code,
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             details=[e["msg"] for e in err.errors()],
-        ) from err
+        ) from None  # do not include the original exception because the wrapper is sufficient

--- a/app/repository/asset.py
+++ b/app/repository/asset.py
@@ -66,6 +66,7 @@ class AssetRepository(BaseRepository):
                 sha256_digest=sha256_digest,
                 meta=asset.meta,
                 label=asset.label,
+                storage_type=asset.storage_type,
                 created_by_id=asset.created_by_id,
                 updated_by_id=asset.updated_by_id,
             )

--- a/app/utils/s3.py
+++ b/app/utils/s3.py
@@ -1,17 +1,25 @@
 import os
 import uuid
 from pathlib import Path
-from typing import IO
+from typing import IO, Protocol
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID
 
 import boto3
+import botocore.client
 from boto3.s3.transfer import TransferConfig
+from botocore.exceptions import ClientError
 from types_boto3_s3 import S3Client
+from types_boto3_s3.type_defs import PaginatorConfigTypeDef
 
-from app.config import settings
+from app.config import StorageUnion, settings
 from app.db.types import EntityType
 from app.logger import L
+from app.schemas.asset import validate_path
+
+
+class StorageClientFactory(Protocol):
+    def __call__(self, storage: StorageUnion) -> S3Client: ...
 
 
 def build_s3_path(
@@ -25,12 +33,15 @@ def build_s3_path(
 ) -> str:
     """Return the key used to store the file on S3."""
     prefix = "public" if is_public else "private"
-    # TODO: verify if prefix partitioning is needed for better performance
     return f"{prefix}/{vlab_id}/{proj_id}/assets/{entity_type.name}/{entity_id}/{filename}"
 
 
 def validate_filename(filename: str) -> bool:
-    return "/" not in filename
+    try:
+        validate_path(filename)
+    except ValueError:
+        return False
+    return True
 
 
 def sanitize_directory_traversal(filename: str | Path) -> Path:
@@ -41,7 +52,7 @@ def validate_filesize(filesize: int) -> bool:
     return filesize <= settings.API_ASSET_POST_MAX_SIZE
 
 
-def get_s3_client() -> S3Client:
+def get_s3_client(storage: StorageUnion) -> S3Client:
     """Return a new S3 client (not thread-safe).
 
     Boto should get credentials from ~/.aws/credentials or the environment.
@@ -49,10 +60,20 @@ def get_s3_client() -> S3Client:
 
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
-    - AWS_DEFAULT_REGION
     - AWS_ENDPOINT_URL
+
+    Implements StorageClientFactory.
+
+    Args:
+        storage: Storage configuration.
     """
-    return boto3.client("s3")
+    if storage.is_open:
+        # For open storage, we use unsigned requests
+        config = botocore.client.Config(signature_version=botocore.UNSIGNED)
+    else:
+        # For internal storage, we use signed requests
+        config = botocore.client.Config()
+    return boto3.client("s3", region_name=storage.region, config=config)
 
 
 def upload_to_s3(
@@ -135,6 +156,7 @@ def list_directory_with_details(
     s3_client: S3Client,
     bucket_name: str,
     prefix: str,
+    pagination_config: PaginatorConfigTypeDef | None = None,
 ) -> dict:
     # with `prefix="foo/asdf" argument will match all `foo/asdf/` and `foo/asdf_asdf/,
     # insure we have a ending / to prevent being promiscuous
@@ -143,7 +165,11 @@ def list_directory_with_details(
 
     paginator = s3_client.get_paginator("list_objects_v2")
     files = {}
-    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+    for page in paginator.paginate(
+        Bucket=bucket_name,
+        Prefix=prefix,
+        PaginationConfig=pagination_config or {},
+    ):
         if "Contents" not in page:
             continue
         for obj in page["Contents"]:
@@ -155,3 +181,31 @@ def list_directory_with_details(
                 "last_modified": obj["LastModified"],
             }
     return files
+
+
+def check_object(
+    s3_client: S3Client,
+    *,
+    bucket_name: str,
+    s3_key: str,
+    is_directory: bool,
+) -> dict:
+    """Check if an object exists in S3 and return its type."""
+    try:
+        if is_directory:
+            list_directory_with_details(
+                s3_client,
+                bucket_name=bucket_name,
+                prefix=s3_key,
+                pagination_config={"MaxItems": 1, "PageSize": 1},
+            )
+            object_type = "directory"
+        else:
+            s3_client.head_object(Bucket=bucket_name, Key=s3_key)
+            object_type = "file"
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") in {"404", "403"}:
+            # 404 = Not Found, 403 = Access Denied
+            return {"exists": False}
+        raise
+    return {"exists": True, "type": object_type}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def s3():
 @pytest.fixture(scope="session")
 def _create_buckets(s3):
     s3.create_bucket(Bucket=storages[StorageType.aws_s3_internal].bucket)
-    s3.create_bucket(Bucket=storages[StorageType.aws_s3_open].bucket)
+    s3.create_bucket(Bucket=storages[StorageType.aws_s3_open].bucket, ACL="public-read")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.application import app
-from app.config import settings
+from app.config import storages
 from app.db.model import (
     Agent,
     Base,
@@ -39,6 +39,7 @@ from app.db.model import (
     Subject,
 )
 from app.db.session import DatabaseSessionManager, configure_database_session_manager
+from app.db.types import StorageType
 from app.dependencies import auth
 from app.schemas.auth import UserContext, UserProfile
 
@@ -73,7 +74,6 @@ def _setup_env_variables():
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"  # noqa: S105
     os.environ["AWS_SECURITY_TOKEN"] = "testing"  # noqa: S105
     os.environ["AWS_SESSION_TOKEN"] = "testing"  # noqa: S105
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
 
 
 @pytest.fixture(scope="session")
@@ -85,7 +85,8 @@ def s3():
 
 @pytest.fixture(scope="session")
 def _create_buckets(s3):
-    s3.create_bucket(Bucket=settings.S3_BUCKET_NAME)
+    s3.create_bucket(Bucket=storages[StorageType.aws_s3_internal].bucket)
+    s3.create_bucket(Bucket=storages[StorageType.aws_s3_open].bucket)
 
 
 @pytest.fixture

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -377,6 +377,42 @@ def test_register_entity_asset_with_invalid_full_path(client, entity, full_path)
         "error_code": "INVALID_REQUEST",
         "message": "Validation error",
     }
+    assert response.json()["details"][0]["msg"] == (
+        "Value error, Invalid full path: cannot be empty, start or end with '/', "
+        "and the path components cannot be empty, '.' or '..'"
+    )
+
+
+@pytest.mark.parametrize(
+    ("storage_type", "err_msg"),
+    [
+        (
+            StorageType.aws_s3_internal,
+            "Value error, Only open data storage is supported for registration",
+        ),
+        ("invalid_storage_type", "Input should be 'aws_s3_internal' or 'aws_s3_open'"),
+    ],
+)
+def test_register_entity_asset_with_invalid_storage_type(client, entity, storage_type, err_msg):
+    response = assert_request(
+        client.post,
+        url=f"{route(entity.type)}/{entity.id}/assets/register",
+        json={
+            "path": "my-test.swc",
+            "full_path": "path/to/test.swc",
+            "is_directory": False,
+            "content_type": "application/swc",
+            "label": "morphology",
+            "storage_type": storage_type,
+        },
+        expected_status_code=422,
+    )
+    assert response.json() == {
+        "details": ANY,
+        "error_code": "INVALID_REQUEST",
+        "message": "Validation error",
+    }
+    assert response.json()["details"][0]["msg"] == err_msg
 
 
 def test_get_entity_asset(client, entity, asset):

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -4,7 +4,7 @@ import pytest
 from moto import mock_aws
 
 from app.db.model import Asset, Entity
-from app.db.types import AssetLabel, AssetStatus, EntityType
+from app.db.types import AssetLabel, AssetStatus, EntityType, StorageType
 from app.errors import ApiErrorCode
 from app.schemas.api import ErrorResponse
 from app.schemas.asset import AssetRead
@@ -79,7 +79,7 @@ def asset(client, entity) -> AssetRead:
 
 
 @pytest.fixture
-def asset_directory(db, root_circuit, person_id) -> AssetRead:
+def asset_directory(db, root_circuit, person_id) -> Asset:
     s3_path = _get_expected_full_path(entity=root_circuit, path="my-directory")
     asset = Asset(
         path="my-directory",
@@ -94,6 +94,7 @@ def asset_directory(db, root_circuit, person_id) -> AssetRead:
         created_by_id=person_id,
         updated_by_id=person_id,
         label="sonata_circuit",
+        storage_type=StorageType.aws_s3_internal,
     )
     add_db(db, asset)
     return asset
@@ -123,6 +124,7 @@ def test_upload_entity_asset(client, entity):
         "meta": {},
         "status": "created",
         "label": "morphology",
+        "storage_type": StorageType.aws_s3_internal,
     }
 
     # try to upload again the same file with the same path
@@ -263,6 +265,7 @@ def test_get_entity_asset(client, entity, asset):
         "meta": {},
         "status": "created",
         "label": "morphology",
+        "storage_type": StorageType.aws_s3_internal,
     }
 
     # try to get an asset with non-existent entity id
@@ -296,6 +299,7 @@ def test_get_entity_assets(client, entity, asset):
             "meta": {},
             "status": "created",
             "label": "morphology",
+            "storage_type": StorageType.aws_s3_internal,
         }
     ]
 

--- a/tests/test_brain_atlas.py
+++ b/tests/test_brain_atlas.py
@@ -2,7 +2,7 @@ import itertools as it
 from unittest.mock import ANY
 
 from app.db.model import BrainAtlas, BrainAtlasRegion
-from app.db.types import EntityType
+from app.db.types import EntityType, StorageType
 
 from . import utils
 
@@ -97,6 +97,7 @@ def test_brain_atlas(db, client, species_id, person_id):
                 "sha256_digest": "a8124f083a58b9a8ff80cb327dd6895a10d0bc92bb918506da0c9c75906d3f91",
                 "size": 31,
                 "status": "created",
+                "storage_type": StorageType.aws_s3_internal,
             }
         ],
         "creation_date": ANY,
@@ -166,6 +167,7 @@ def test_brain_atlas(db, client, species_id, person_id):
         "sha256_digest": "a8124f083a58b9a8ff80cb327dd6895a10d0bc92bb918506da0c9c75906d3f91",
         "size": 31,
         "status": "created",
+        "storage_type": StorageType.aws_s3_internal,
     }
     assert response.json()["data"] == [
         {

--- a/tests/test_etype_classification.py
+++ b/tests/test_etype_classification.py
@@ -67,7 +67,7 @@ def test_create_one__unauthorized_entity(client_user_1, unauthorized_morph_id, j
     data = assert_request(
         client_user_1.post, url=ROUTE, json=json_data, expected_status_code=403
     ).json()
-    assert data["detail"] == f"Cannot access entity {unauthorized_morph_id}"
+    assert data["details"] == f"Cannot access entity {unauthorized_morph_id}"
 
 
 def test_do_not_allow_private_classification(client, db, person_id, emodel_id):
@@ -88,4 +88,6 @@ def test_do_not_allow_private_classification(client, db, person_id, emodel_id):
         },
         expected_status_code=400,
     ).json()
-    assert data["detail"] == "Private classifications are not supported. Use authorized_public=True"
+    assert (
+        data["details"] == "Private classifications are not supported. Use authorized_public=True"
+    )

--- a/tests/test_mtype_classification.py
+++ b/tests/test_mtype_classification.py
@@ -66,7 +66,7 @@ def test_create_one__unauthorized_entity(client_user_1, unauthorized_morph_id, j
     data = assert_request(
         client_user_1.post, url=ROUTE, json=json_data, expected_status_code=403
     ).json()
-    assert data["detail"] == f"Cannot access entity {unauthorized_morph_id}"
+    assert data["details"] == f"Cannot access entity {unauthorized_morph_id}"
 
 
 @pytest.fixture
@@ -98,4 +98,6 @@ def test_do_not_allow_private_classification(client, db, person_id, public_morph
         },
         expected_status_code=400,
     ).json()
-    assert data["detail"] == "Private classifications are not supported. Use authorized_public=True"
+    assert (
+        data["details"] == "Private classifications are not supported. Use authorized_public=True"
+    )

--- a/tests/test_simulation_execution.py
+++ b/tests/test_simulation_execution.py
@@ -370,7 +370,7 @@ def test_update_one__fail_if_generated_ids_unauthorized(
     data = assert_request(
         client_user_1.patch, url=f"{ROUTE}/{data['id']}", json=update_json, expected_status_code=404
     ).json()
-    assert data["detail"] == f"Cannot access entities {user2_morph_id}"
+    assert data["details"] == f"Cannot access entities {user2_morph_id}"
 
 
 def test_update_one__fail_if_generated_ids_exists(
@@ -387,4 +387,4 @@ def test_update_one__fail_if_generated_ids_exists(
     data = assert_request(
         client.patch, url=f"{ROUTE}/{gen1}", json=update_json, expected_status_code=404
     ).json()
-    assert data["detail"] == "It is forbidden to update generated_ids if they exist."
+    assert data["details"] == "It is forbidden to update generated_ids if they exist."

--- a/tests/test_simulation_generation.py
+++ b/tests/test_simulation_generation.py
@@ -349,7 +349,7 @@ def test_update_one__fail_if_generated_ids_unauthorized(
     data = assert_request(
         client_user_1.patch, url=f"{ROUTE}/{data['id']}", json=update_json, expected_status_code=404
     ).json()
-    assert data["detail"] == f"Cannot access entities {user2_morph_id}"
+    assert data["details"] == f"Cannot access entities {user2_morph_id}"
 
 
 def test_update_one__fail_if_generated_ids_exists(
@@ -366,4 +366,4 @@ def test_update_one__fail_if_generated_ids_exists(
     data = assert_request(
         client.patch, url=f"{ROUTE}/{gen1}", json=update_json, expected_status_code=404
     ).json()
-    assert data["detail"] == "It is forbidden to update generated_ids if they exist."
+    assert data["details"] == "It is forbidden to update generated_ids if they exist."


### PR DESCRIPTION
Allow to register an existing asset (file or directory) in open data, so it's associated to an existing entity.
There are unique constraints on path (per entity) and full_path (global).

Other: there is also a new http_exception_handler, I can move it to a separate PR if it creates noise.