### PR TITLE
Add filter by authorized_public and authorized_project_id

### DIFF
--- a/app/filters/common.py
+++ b/app/filters/common.py
@@ -27,6 +27,11 @@ class IdFilterMixin:
     id__in: list[str] | None = None
 
 
+class AuthorizedFilterMixin:
+    authorized_public: bool | None = None
+    authorized_project_id: uuid.UUID | None = None
+
+
 class NameFilterMixin:
     name: str | None = None
     name__in: list[str] | None = None
@@ -210,6 +215,7 @@ class BrainRegionFilterMixin:
 
 class EntityFilterMixin(
     IdFilterMixin,
+    AuthorizedFilterMixin,
     CreatorFilterMixin,
     CreationFilterMixin,
     ContributionFilterMixin,

--- a/app/filters/ion_channel_model.py
+++ b/app/filters/ion_channel_model.py
@@ -4,6 +4,7 @@ from app.db.model import IonChannelModel
 from app.dependencies.filter import FilterDepends
 from app.filters.base import CustomFilter
 from app.filters.common import (
+    AuthorizedFilterMixin,
     BrainRegionFilterMixin,
     CreationFilterMixin,
     SpeciesFilterMixin,
@@ -11,7 +12,11 @@ from app.filters.common import (
 
 
 class IonChannelModelFilter(
-    CustomFilter, CreationFilterMixin, BrainRegionFilterMixin, SpeciesFilterMixin
+    CustomFilter,
+    CreationFilterMixin,
+    AuthorizedFilterMixin,
+    BrainRegionFilterMixin,
+    SpeciesFilterMixin,
 ):
     nmodl_suffix: str | None = None
 

--- a/app/filters/simulation.py
+++ b/app/filters/simulation.py
@@ -7,13 +7,7 @@ from app.db.model import Simulation
 from app.dependencies.filter import FilterDepends
 from app.filters.base import CustomFilter
 from app.filters.circuit import NestedCircuitFilter, NestedCircuitFilterDep
-from app.filters.common import (
-    ContributionFilterMixin,
-    CreationFilterMixin,
-    CreatorFilterMixin,
-    IdFilterMixin,
-    NameFilterMixin,
-)
+from app.filters.common import EntityFilterMixin, IdFilterMixin, NameFilterMixin
 
 
 class SimulationFilterBase(NameFilterMixin, IdFilterMixin, CustomFilter):
@@ -27,9 +21,7 @@ class NestedSimulationFilter(SimulationFilterBase):
         model = Simulation
 
 
-class SimulationFilter(
-    CreationFilterMixin, CreatorFilterMixin, ContributionFilterMixin, SimulationFilterBase
-):
+class SimulationFilter(EntityFilterMixin, SimulationFilterBase):
     simulation_campaign_id: uuid.UUID | None = None
     simulation_campaign_id__in: list[uuid.UUID] | None = None
 

--- a/app/filters/subject.py
+++ b/app/filters/subject.py
@@ -7,9 +7,7 @@ from app.db.model import Subject
 from app.dependencies.filter import FilterDepends
 from app.filters.base import CustomFilter
 from app.filters.common import (
-    ContributionFilterMixin,
-    CreationFilterMixin,
-    CreatorFilterMixin,
+    EntityFilterMixin,
     IdFilterMixin,
     NameFilterMixin,
     NestedSpeciesFilter,
@@ -36,10 +34,8 @@ class NestedSubjectFilter(IdFilterMixin, NameFilterMixin, CustomFilter):
 
 
 class SubjectFilter(
-    ContributionFilterMixin,
+    EntityFilterMixin,
     SpeciesFilterMixin,
-    CreationFilterMixin,
-    CreatorFilterMixin,
     NameFilterMixin,
     CustomFilter,
 ):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+import pytest
+
+# Enable assertion rewriting in specific modules. See:
+# https://docs.pytest.org/en/stable/how-to/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("tests.utils")

--- a/tests/test_ion_channel_model.py
+++ b/tests/test_ion_channel_model.py
@@ -7,7 +7,13 @@ from app.db.model import IonChannelModel
 from app.db.types import EntityType
 from app.schemas.ion_channel_model import IonChannelModelRead
 
-from .utils import PROJECT_ID, TEST_DATA_DIR, check_brain_region_filter, upload_entity_asset
+from .utils import (
+    PROJECT_ID,
+    TEST_DATA_DIR,
+    check_authorization,
+    check_brain_region_filter,
+    upload_entity_asset,
+)
 
 FILE_EXAMPLE_PATH = TEST_DATA_DIR / "example.json"
 ROUTE = "/ion-channel-model"
@@ -136,64 +142,18 @@ def test_authorization(
     client_no_project: TestClient,
     species_id: str,
     strain_id: str,
-    brain_region_id: uuid.UUID,
+    brain_region_id: str,
 ):
-    public_obj = create(
-        client_user_1, species_id, strain_id, brain_region_id, name="public", authorized_public=True
-    )
-    assert public_obj.status_code == 200
-    public_obj = public_obj.json()
-
-    inaccessible_obj = create(
-        client_user_2, species_id, strain_id, brain_region_id, name="inaccessible_obj"
-    )
-
-    assert inaccessible_obj.status_code == 200
-
-    inaccessible_obj = inaccessible_obj.json()
-
-    private_obj = create(
-        client_user_1,
-        species_id,
-        strain_id,
-        brain_region_id,
-        name="private",
-        authorized_public=False,
-    )
-    assert private_obj.status_code == 200
-    private_obj = private_obj.json()
-
-    private_obj1 = create(
-        client_user_1,
-        species_id,
-        strain_id,
-        brain_region_id,
-        name="private1",
-        authorized_public=False,
-    )
-    assert private_obj1.status_code == 200
-    private_obj1 = private_obj1.json()
-
-    # only return results that matches the desired project, and public ones
-    response = client_user_1.get(ROUTE)
-    data = response.json()["data"]
-    assert len(data) == 3
-
-    ids = {row["id"] for row in data}
-    assert ids == {
-        public_obj["id"],
-        private_obj["id"],
-        private_obj1["id"],
+    json_data = {
+        "description": "Test description",
+        "nmodl_suffix": "test",
+        "temperature_celsius": 0,
+        "neuron_block": {},
+        "brain_region_id": brain_region_id,
+        "species_id": species_id,
+        "strain_id": strain_id,
     }
-
-    response = client_user_1.get(f"{ROUTE}/{inaccessible_obj['id']}")
-    assert response.status_code == 404
-
-    # only return public results
-    response = client_no_project.get(ROUTE)
-    data = response.json()["data"]
-    assert len(data) == 1
-    assert data[0]["id"] == public_obj["id"]
+    check_authorization(ROUTE, client_user_1, client_user_2, client_no_project, json_data)
 
 
 def test_paginate(client: TestClient, species_id: str, strain_id: str, brain_region_id: uuid.UUID):

--- a/tests/test_single_neuron_synaptome.py
+++ b/tests/test_single_neuron_synaptome.py
@@ -17,6 +17,7 @@ from .utils import (
     PROJECT_ID,
     add_db,
     assert_request,
+    check_authorization,
     check_brain_region_filter,
     create_brain_region,
 )
@@ -138,69 +139,7 @@ def test_missing(client, route_id, expected_status_code):
 
 
 def test_authorization(client_user_1, client_user_2, client_no_project, json_data):
-    response = assert_request(
-        client_user_1.post,
-        url=ROUTE,
-        json=json_data
-        | {
-            "name": "Public Entity",
-            "authorized_public": True,
-        },
-    )
-    public_morph = response.json()
-
-    inaccessible_obj = assert_request(
-        client_user_2.post,
-        url=ROUTE,
-        json=json_data | {"name": "inaccessable morphology 1"},
-    )
-    inaccessible_obj = inaccessible_obj.json()
-
-    private_obj0 = assert_request(
-        client_user_1.post,
-        url=ROUTE,
-        json=json_data | {"name": "private morphology 0"},
-    )
-    private_obj0 = private_obj0.json()
-
-    private_obj1 = assert_request(
-        client_user_1.post,
-        url=ROUTE,
-        json=json_data
-        | {
-            "name": "private morphology 1",
-        },
-    )
-    private_obj1 = private_obj1.json()
-
-    # only return results that matches the desired project, and public ones
-    response = assert_request(
-        client_user_1.get,
-        url=ROUTE,
-    )
-    data = response.json()["data"]
-
-    ids = {row["id"] for row in data}
-    assert ids == {
-        public_morph["id"],
-        private_obj0["id"],
-        private_obj1["id"],
-    }, data
-
-    assert_request(
-        client_user_1.get,
-        url=f"{ROUTE}/{inaccessible_obj['id']}",
-        expected_status_code=404,
-    )
-
-    # only returns public results
-    response = assert_request(
-        client_no_project.get,
-        url=ROUTE,
-    )
-    data = response.json()["data"]
-    assert len(data) == 1
-    assert data[0]["id"] == public_morph["id"]
+    check_authorization(ROUTE, client_user_1, client_user_2, client_no_project, json_data)
 
 
 def test_pagination(db, client, brain_region_id, emodel_id, morphology_id, species_id, person_id):

--- a/tests/test_single_neuron_synaptome_simulation.py
+++ b/tests/test_single_neuron_synaptome_simulation.py
@@ -13,6 +13,7 @@ from .utils import (
     PROJECT_ID,
     add_db,
     assert_request,
+    check_authorization,
     check_brain_region_filter,
     create_brain_region,
 )
@@ -180,69 +181,7 @@ def test_missing(client, route_id, expected_status_code):
 
 
 def test_authorization(client_user_1, client_user_2, client_no_project, json_data):
-    response = assert_request(
-        client_user_1.post,
-        url=ROUTE,
-        json=json_data
-        | {
-            "name": "Public Entity",
-            "authorized_public": True,
-        },
-    )
-    public_morph = response.json()
-
-    inaccessible_obj = assert_request(
-        client_user_2.post,
-        url=ROUTE,
-        json=json_data | {"name": "inaccessable morphology 1"},
-    )
-    inaccessible_obj = inaccessible_obj.json()
-
-    private_obj0 = assert_request(
-        client_user_1.post,
-        url=ROUTE,
-        json=json_data | {"name": "private morphology 0"},
-    )
-    private_obj0 = private_obj0.json()
-
-    private_obj1 = assert_request(
-        client_user_1.post,
-        url=ROUTE,
-        json=json_data
-        | {
-            "name": "private morphology 1",
-        },
-    )
-    private_obj1 = private_obj1.json()
-
-    # only return results that matches the desired project, and public ones
-    response = assert_request(
-        client_user_1.get,
-        url=ROUTE,
-    )
-    data = response.json()["data"]
-
-    ids = {row["id"] for row in data}
-    assert ids == {
-        public_morph["id"],
-        private_obj0["id"],
-        private_obj1["id"],
-    }, data
-
-    assert_request(
-        client_user_1.get,
-        url=f"{ROUTE}/{inaccessible_obj['id']}",
-        expected_status_code=404,
-    )
-
-    # only returns public results
-    response = assert_request(
-        client_no_project.get,
-        url=ROUTE,
-    )
-    data = response.json()["data"]
-    assert len(data) == 1
-    assert data[0]["id"] == public_morph["id"]
+    check_authorization(ROUTE, client_user_1, client_user_2, client_no_project, json_data)
 
 
 def test_pagination(db, client, brain_region_id, memodel_id, person_id):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -358,74 +358,159 @@ def check_pagination(route, client, constructor_func):
 
 
 def check_authorization(route, client_user_1, client_user_2, client_no_project, json_data):
-    response = assert_request(
+    """Check the authorization when trying to access the entities.
+
+    Created entities:
+
+    public_u1_0 (PROJECT_ID)
+    public_u2_0 (UNRELATED_PROJECT_ID)
+    private_u2_0 (UNRELATED_PROJECT_ID)
+    private_u1_0 (PROJECT_ID)
+    private_u1_1 (PROJECT_ID)
+    """
+    # create the entities
+    public_u1_0 = assert_request(
         client_user_1.post,
         url=route,
-        json=json_data
-        | {
-            "name": "Public Entity",
-            "authorized_public": True,
-        },
-    )
-    public_morph = response.json()
+        json=json_data | {"name": "Public u1/0", "authorized_public": True},
+    ).json()
+    assert public_u1_0["authorized_public"] is True
+    assert public_u1_0["authorized_project_id"] == PROJECT_ID
 
-    inaccessible_obj = assert_request(
+    public_u2_0 = assert_request(
         client_user_2.post,
         url=route,
-        json=json_data | {"name": "inaccessible morphology 1"},
-    )
-    inaccessible_obj = inaccessible_obj.json()
+        json=json_data | {"name": "Public u2/0", "authorized_public": True},
+    ).json()
+    assert public_u2_0["authorized_public"] is True
+    assert public_u2_0["authorized_project_id"] == UNRELATED_PROJECT_ID
 
-    private_obj0 = assert_request(
-        client_user_1.post,
-        url=route,
-        json=json_data | {"name": "private morphology 0"},
-    )
-    private_obj0 = private_obj0.json()
+    private_u2_0 = assert_request(
+        client_user_2.post, url=route, json=json_data | {"name": "Private u2/0"}
+    ).json()
+    assert private_u2_0["authorized_public"] is False
+    assert private_u2_0["authorized_project_id"] == UNRELATED_PROJECT_ID
 
-    private_obj1 = assert_request(
-        client_user_1.post,
-        url=route,
-        json=json_data
-        | {
-            "name": "private morphology 1",
-        },
-    )
-    private_obj1 = private_obj1.json()
+    private_u1_0 = assert_request(
+        client_user_1.post, url=route, json=json_data | {"name": "Private u1/0"}
+    ).json()
+    assert private_u1_0["authorized_public"] is False
+    assert private_u1_0["authorized_project_id"] == PROJECT_ID
+
+    private_u1_1 = assert_request(
+        client_user_1.post, url=route, json=json_data | {"name": "Private u1/1"}
+    ).json()
+    assert private_u1_1["authorized_public"] is False
+    assert private_u1_1["authorized_project_id"] == PROJECT_ID
 
     # only return results that matches the desired project, and public ones
-    response = assert_request(
-        client_user_1.get,
-        url=route,
-    )
-    data = response.json()["data"]
-
-    ids = {row["id"] for row in data}
-    expected = {
-        public_morph["id"],
-        private_obj0["id"],
-        private_obj1["id"],
+    data = assert_request(client_user_1.get, url=route).json()["data"]
+    assert len(data) == 4
+    assert {row["id"] for row in data} == {
+        public_u1_0["id"],
+        public_u2_0["id"],
+        private_u1_0["id"],
+        private_u1_1["id"],
     }
-    assert ids == expected, (
-        "Failed to fetch project-specific and public ids.\n"
-        f"Expected: {sorted(expected)}\n"
-        f"Actual  : {sorted(ids)}"
-    )
 
+    # cannot access the private entity of the other user
     assert_request(
         client_user_1.get,
-        url=f"{route}/{inaccessible_obj['id']}",
+        url=f"{route}/{private_u2_0['id']}",
         expected_status_code=404,
     )
 
-    # only returns public results
-    response = assert_request(
-        client_no_project.get,
+    # client_no_project can get public entities only
+    data = assert_request(client_no_project.get, url=route).json()["data"]
+    assert len(data) == 2
+    assert {row["id"] for row in data} == {
+        public_u1_0["id"],
+        public_u2_0["id"],
+    }
+
+    # client_user_1 wants only public results
+    data = assert_request(
+        client_user_1.get,
         url=route,
-    )
-    data = response.json()["data"]
+        params={"authorized_public": True},
+    ).json()["data"]
+    assert len(data) == 2
+    assert {row["id"] for row in data} == {public_u1_0["id"], public_u2_0["id"]}
+
+    # client_user_1 wants only private (and accessible) results
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_public": False},
+    ).json()["data"]
+    assert len(data) == 2
+    assert {row["id"] for row in data} == {private_u1_0["id"], private_u1_1["id"]}
+
+    # client_user_1 wants only their own entities (private or public)
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_project_id": PROJECT_ID},
+    ).json()["data"]
+    assert len(data) == 3
+    assert {row["id"] for row in data} == {
+        public_u1_0["id"],
+        private_u1_0["id"],
+        private_u1_1["id"],
+    }
+
+    # client_user_1 can get entities in other projects only if they are public
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_project_id": UNRELATED_PROJECT_ID},
+    ).json()["data"]
     assert len(data) == 1
-    assert data[0]["id"] == public_morph["id"]
+    assert {row["id"] for row in data} == {public_u2_0["id"]}
+
+    # client_user_1 can get entities in other projects only if they are public (again)
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_public": True, "authorized_project_id": UNRELATED_PROJECT_ID},
+    ).json()["data"]
+    assert len(data) == 1
+    assert {row["id"] for row in data} == {public_u2_0["id"]}
+
+    # client_user_1 can get entities in other projects only if they are public (no results)
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_public": False, "authorized_project_id": UNRELATED_PROJECT_ID},
+    ).json()["data"]
+    assert len(data) == 0
+
+    # client_user_2 wants only their own entities (private or public)
+    data = assert_request(
+        client_user_2.get,
+        url=route,
+        params={"authorized_project_id": UNRELATED_PROJECT_ID},
+    ).json()["data"]
+    assert len(data) == 2
+    assert {row["id"] for row in data} == {public_u2_0["id"], private_u2_0["id"]}
+
+    # client_user_1 wants only their own public entities
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_public": True, "authorized_project_id": PROJECT_ID},
+    ).json()["data"]
+    assert len(data) == 1
+    assert {row["id"] for row in data} == {public_u1_0["id"]}
+
+    # client_user_1 wants only their own private entities
+    data = assert_request(
+        client_user_1.get,
+        url=route,
+        params={"authorized_public": False, "authorized_project_id": PROJECT_ID},
+    ).json()["data"]
+    assert len(data) == 2
+    assert {row["id"] for row in data} == {private_u1_0["id"], private_u1_1["id"]}
 
 
 def check_brain_region_filter(route, client, db, brain_region_hierarchy_id, create_model_function):


### PR DESCRIPTION
This PR adds the possibility to specify `authorized_public` and `authorized_project_id` in the get many endpoint of any entity.

Fix https://github.com/openbraininstitute/prod-platform-architecture/issues/125

- To keep the current behaviour: do not pass any additional parameter.
- To request public data only: set `authorized_public=true`, don't set authorized_project_id (the `project-id` header is meaningless in this case)
- To request project data only: set `authorized_project_id=P0`, don't set authorized_public (the public data are always returned, the private data are returned only if the `project-id` header is passed as well with the same value P0)

Other combinations of `authorized_public` and `authorized_project_id` can be used in other use cases, keeping in mind that:
- `authorized_public` and `authorized_project_id` are used as regular parameters combined with any other parameter in the filter using AND.
- the header `project-id` is still needed if one wants to retrieve the private entities for that project (this isn't used in a regular filter, but it's used in the condition `authorized_public is True or authorized_project_id=<project-id>`)