### PR TITLE
Introduce service maintainer role for update/delete

### DIFF
--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -139,12 +139,14 @@ def _check_user_info(
     )
 
     is_service_admin = user_info_response.is_service_admin(settings.APP_NAME)
+    is_service_maintainer = user_info_response.is_service_maintainer(settings.APP_NAME)
 
     user_context = UserContext(
         profile=UserProfile.from_user_info(user_info_response),
         expiration=decoded.exp if decoded else None,
         is_authorized=is_authorized,
         is_service_admin=is_service_admin,
+        is_service_maintainer=is_service_maintainer,
         virtual_lab_id=project_context.virtual_lab_id,
         project_id=project_context.project_id,
         auth_error_reason=AuthErrorReason.NOT_AUTHORIZED_PROJECT if not is_authorized else None,

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.db.auth import (
     constrain_to_accessible_entities,
-    constrain_to_private_entities,
+    constrain_to_writable_entities,
     select_unauthorized_entities,
 )
 from app.db.model import Activity, Agent, Generation, Identifiable, Person, Usage
@@ -367,7 +367,7 @@ def router_update_one[T: BaseModel, I: Identifiable](
     if user_context and (
         id_model_class := get_declaring_class(db_model_class, "authorized_project_id")
     ):
-        query = constrain_to_private_entities(query, user_context, db_model_class=id_model_class)
+        query = constrain_to_writable_entities(query, user_context, db_model_class=id_model_class)
     if apply_operations:
         query = apply_operations(query)
 
@@ -405,7 +405,7 @@ def router_delete_one[T: BaseModel, I: Identifiable](
     if user_context and (
         id_model_class := get_declaring_class(db_model_class, "authorized_project_id")
     ):
-        query = constrain_to_private_entities(
+        query = constrain_to_writable_entities(
             query=query,
             user_context=user_context,
             db_model_class=id_model_class,

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -86,6 +86,10 @@ class UserInfoResponse(UserInfoBase):
             ]
         )
 
+    def is_service_maintainer(self, service_name: str) -> bool:
+        """Return True if admin for the specified service."""
+        return f"/service/{service_name}/maintainer" in self.groups
+
     def is_authorized_for(self, virtual_lab_id: UUID | None, project_id: UUID | None) -> bool:
         """Return True if authorized for the specified virtual_lab_id and project_id."""
         match (virtual_lab_id, project_id):
@@ -157,6 +161,7 @@ class UserContextBase(BaseModel):
     expiration: float | None
     is_authorized: bool
     is_service_admin: bool = False
+    is_service_maintainer: bool = False
     auth_error_reason: AuthErrorReason | None = None
 
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -19,7 +19,18 @@
 
 ## Service Admin Group
 
-To call endpoints that modify global resources, the user must belong to a special Keycloak group: `/service/entitycore/admin`.
+The special Keycloak group `/service/entitycore/admin` allows users to:
+
+* call endpoints that modify global resources
+* call admin endpoints
+
+## Service Maintainer group
+
+The special Keycloak group `/service/entitycore/maintainer` allows users to:
+
+* update public entities within authorized projects
+* delete public entities within authorized projects
+* hard delete assets within authorized projects
 
 ## Caching
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -59,8 +59,11 @@ def _get_token(exp):
 @pytest.mark.parametrize("project_context", PROJECT_CONTEXTS)
 @pytest.mark.parametrize("is_token_jwt", [True, False])
 @pytest.mark.parametrize("is_admin", [True, False])
+@pytest.mark.parametrize("is_maintainer", [True, False])
 @pytest.mark.usefixtures("freezer")
-def test_user_verified_ok(httpx_mock, request_mock, is_admin, is_token_jwt, project_context):
+def test_user_verified_ok(
+    httpx_mock, request_mock, is_maintainer, is_admin, is_token_jwt, project_context
+):
     if is_token_jwt:
         token_expiration = int(time.time() + 3600)
         token = _get_token(exp=token_expiration)
@@ -77,6 +80,7 @@ def test_user_verified_ok(httpx_mock, request_mock, is_admin, is_token_jwt, proj
             "preferred_username": TEST_USER_NAME,
             "groups": [
                 "/service/entitycore/admin" if is_admin else "/other",
+                "/service/entitycore/maintainer" if is_maintainer else "/other",
                 f"/proj/{VIRTUAL_LAB_ID}/{PROJECT_ID}/admin",
                 f"/vlab/{VIRTUAL_LAB_ID}/admin",
             ],
@@ -95,6 +99,7 @@ def test_user_verified_ok(httpx_mock, request_mock, is_admin, is_token_jwt, proj
         expiration=token_expiration,
         is_authorized=True,
         is_service_admin=is_admin,
+        is_service_maintainer=is_maintainer,
         virtual_lab_id=project_context.virtual_lab_id,
         project_id=project_context.project_id,
         user_project_ids=[uuid.UUID(PROJECT_ID)],
@@ -116,6 +121,7 @@ def test_user_verified_ok_when_auth_is_disabled(monkeypatch, request_mock, proje
         expiration=None,
         is_authorized=True,
         is_service_admin=True,
+        is_service_maintainer=False,
         virtual_lab_id=project_context.virtual_lab_id,
         project_id=project_context.project_id,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,10 +45,16 @@ USER_SUB_ID_2 = "00000000-0000-0000-0000-000000000002"
 TOKEN_ADMIN = "I'm admin"  # noqa: S105
 TOKEN_USER_1 = "I'm user 1"  # noqa: S105
 TOKEN_USER_2 = "I'm user 2"  # noqa: S105
+TOKEN_MAINTAINER_1 = "I'm maintainer 1"  # noqa: S105
+TOKEN_MAINTAINER_2 = "I'm maintainer 2"  # noqa: S105
+TOKEN_MAINTAINER_3 = "I'm maintainer 3"  # noqa: S105
 
 AUTH_HEADER_ADMIN = {"Authorization": f"Bearer {TOKEN_ADMIN}"}
 AUTH_HEADER_USER_1 = {"Authorization": f"Bearer {TOKEN_USER_1}"}
 AUTH_HEADER_USER_2 = {"Authorization": f"Bearer {TOKEN_USER_2}"}
+AUTH_HEADER_MAINTAINER_1 = {"Authorization": f"Bearer {TOKEN_MAINTAINER_1}"}
+AUTH_HEADER_MAINTAINER_2 = {"Authorization": f"Bearer {TOKEN_MAINTAINER_2}"}
+AUTH_HEADER_MAINTAINER_3 = {"Authorization": f"Bearer {TOKEN_MAINTAINER_3}"}
 
 VIRTUAL_LAB_ID = "9c6fba01-2c6f-4eac-893f-f0dc665605c5"
 PROJECT_ID = "ee86d4a0-eaca-48ca-9788-ddc450250b15"
@@ -104,6 +110,9 @@ class ClientProxies(NamedTuple):
     user_2: ClientProxy
     no_project: ClientProxy
     admin: ClientProxy
+    maintainer_1: ClientProxy
+    maintainer_2: ClientProxy
+    maintainer_3: ClientProxy
 
 
 def create_cell_morphology_id(
@@ -1008,12 +1017,40 @@ def check_entity_update_one(
     assert data["error_code"] == "ENTITY_NOT_FOUND"
 
     # admin has no such restrictions
-    _patch_compare(clients.admin, f"{admin_route}/{public_1_id}", {"authorized_public": False})
+    _patch_compare(clients.admin, f"{admin_route}/{public_1_id}", patch_payload)
+
+    # neither does a maintainer that has access to the project
+    _patch_compare(clients.maintainer_1, f"{route}/{public_1_id}", patch_payload)
+    _patch_compare(clients.maintainer_3, f"{route}/{public_1_id}", patch_payload)
+
+    data = assert_request(
+        clients.maintainer_2.patch,
+        url=f"{route}/{public_1_id}",
+        json={},
+        expected_status_code=404,
+    ).json()
+    assert data["error_code"] == "ENTITY_NOT_FOUND"
 
 
 def check_entity_delete_one(
     db, clients, route, admin_route, json_data, expected_counts_before, expected_counts_after
 ):
+    def _create_model_id(client, data):
+        return assert_request(client.post, url=route, json=data).json()["id"]
+
+    def _assert_not_found(client, model_id):
+        data = assert_request(
+            client.delete, url=f"{route}/{model_id}", expected_status_code=404
+        ).json()
+        assert data["error_code"] == "ENTITY_NOT_FOUND"
+
+    def _assert_no_admin_access(client, model_id):
+        data = assert_request(
+            client.delete, url=f"{admin_route}/{model_id}", expected_status_code=403
+        ).json()
+        assert data["error_code"] == "NOT_AUTHORIZED"
+        assert data["message"] == "Service admin role required"
+
     def _req_count(client, client_route, model_id):
         for db_class, count in expected_counts_before.items():
             assert count_db_class(db, db_class) == count
@@ -1024,40 +1061,54 @@ def check_entity_delete_one(
         for db_class, count in expected_counts_after.items():
             assert count_db_class(db, db_class) == count
 
-    model_id = assert_request(clients.user_1.post, url=route, json=json_data).json()["id"]
+    model_id = _create_model_id(clients.user_1, json_data)
 
     # user 2 has no access to project id
-    data = assert_request(
-        clients.user_2.delete, url=f"{route}/{model_id}", expected_status_code=404
-    ).json()
-    assert data["error_code"] == "ENTITY_NOT_FOUND"
+    _assert_not_found(clients.user_2, model_id)
+
+    # maintainer 2 has no access to project id
+    _assert_not_found(clients.maintainer_2, model_id)
 
     # user 1 can delete
     _req_count(clients.user_1, route, model_id)
 
-    model_id = assert_request(clients.user_1.post, url=route, json=json_data).json()["id"]
+    model_id = _create_model_id(clients.user_1, json_data)
+
+    # maintainer 1 can delete
+    _req_count(clients.maintainer_1, route, model_id)
+
+    model_id = _create_model_id(clients.user_1, json_data)
 
     # user cannot use admin route
-    data = assert_request(
-        clients.user_1.delete, url=f"{admin_route}/{model_id}", expected_status_code=403
-    ).json()
-    assert data["error_code"] == "NOT_AUTHORIZED"
-    assert data["message"] == "Service admin role required"
+    _assert_no_admin_access(clients.user_1, model_id)
 
+    # maintainer cannot use admin route
+    _assert_no_admin_access(clients.maintainer_1, model_id)
+    _assert_no_admin_access(clients.maintainer_2, model_id)
+
+    # admin can delete via admin route
     _req_count(clients.admin, admin_route, model_id)
 
-    model_id = assert_request(
-        clients.user_1.post, url=route, json=json_data | {"authorized_public": True}
-    ).json()["id"]
+    model_id = _create_model_id(clients.user_1, json_data | {"authorized_public": True})
 
     # users cannot delete public resources
-    data = assert_request(
-        clients.user_1.delete, url=f"{route}/{model_id}", expected_status_code=404
-    ).json()
-    assert data["error_code"] == "ENTITY_NOT_FOUND"
+    _assert_not_found(clients.user_1, model_id)
 
     # admins should be able to
     _req_count(clients.admin, admin_route, model_id)
+
+    model_id = _create_model_id(clients.user_1, json_data | {"authorized_public": True})
+
+    # maintainers are also able to delete as long as they have access to the project
+    _assert_not_found(clients.maintainer_2, model_id)
+
+    # via project context header
+    _req_count(clients.maintainer_1, route, model_id)
+
+    model_id = _create_model_id(clients.user_1, json_data | {"authorized_public": True})
+
+    # via user_project_ids
+    _req_count(clients.maintainer_3, route, model_id)
 
 
 # so far they don't differ


### PR DESCRIPTION
Add support for a special Keycloak group `/service/entitycore/maintainer` that allows users to:

* update public entities within authorized projects
* delete public entities within authorized projects
* hard delete assets within authorized projects

To allow hard deletion from regular endpoints a new boolean parameter "hard" has been introduced that only service maintainers and admins can set to True.