### PR TITLE
Deduce virtual lab id from project id

### DIFF
--- a/app/dependencies/auth.py
+++ b/app/dependencies/auth.py
@@ -128,6 +128,11 @@ def _check_user_info(
 
     user_info_response = deserialize_response(response, model_class=UserInfoResponse)
 
+    if project_context.virtual_lab_id is None and project_context.project_id is not None:
+        project_context.virtual_lab_id = user_info_response.virtual_lab_from_project_id(
+            project_context.project_id
+        )
+
     is_authorized = user_info_response.is_authorized_for(
         virtual_lab_id=project_context.virtual_lab_id,
         project_id=project_context.project_id,

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -10,7 +10,7 @@ from app.errors import AuthErrorReason
 from app.logger import L
 
 PROJECT_REGEX = re.compile(
-    r"/proj/(?P<vlab>[0-9a-fA-F-]+)/(?P<proj>[0-9a-fA-F-]+)/(?P<role>admin|member)"
+    r"^/proj/(?P<vlab>[0-9a-fA-F-]+)/(?P<proj>[0-9a-fA-F-]+)/(?P<role>admin|member)$"
 )
 
 

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -9,6 +9,10 @@ from pydantic import BaseModel, ConfigDict
 from app.errors import AuthErrorReason
 from app.logger import L
 
+PROJECT_REGEX = re.compile(
+    r"/proj/(?P<vlab>[0-9a-fA-F-]+)/(?P<proj>[0-9a-fA-F-]+)/(?P<role>admin|member)"
+)
+
 
 class CacheKey(BaseModel):
     """Cache key for UserContext."""
@@ -106,16 +110,18 @@ class UserInfoResponse(UserInfoBase):
                     ]
                 )
 
+    def virtual_lab_from_project_id(self, project_id: UUID) -> UUID | None:
+        for s in self.groups:
+            if (match := PROJECT_REGEX.match(s)) and match.group("proj") == str(project_id):
+                return UUID(match.group("vlab"))
+        return None
+
     def user_project_ids(self) -> list[UUID]:
         """Return the the list if project_ids the user is authorized for."""
-        pattern = r"/proj/[0-9a-fA-F-]+/([0-9a-fA-F-]+)/(admin|member)"
-
         project_ids: set[UUID] = set()
-
         for s in self.groups:
-            match = re.match(pattern, s)
-            if match:
-                project_ids.add(UUID(match.group(1)))
+            if match := PROJECT_REGEX.match(s):
+                project_ids.add(UUID(match.group("proj")))
 
         return list(project_ids)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,6 +23,7 @@ TEST_USER_NAME = "John Doe"
 PROJECT_CONTEXTS = [
     OptionalProjectContext(virtual_lab_id=None, project_id=None),
     OptionalProjectContext(virtual_lab_id=VIRTUAL_LAB_ID, project_id=PROJECT_ID),
+    OptionalProjectContext(virtual_lab_id=None, project_id=PROJECT_ID),
 ]
 
 


### PR DESCRIPTION
If a project_id is provided in a header context, without an accompanying virtual_lab_id, deduce the latter from the former using the keycloak groups.

Feature discussed in #372