### PR TITLE
Disable redirect_slashes

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -128,6 +128,7 @@ app = FastAPI(
         StarletteHTTPException: http_exception_handler,
     },
     root_path=settings.ROOT_PATH,
+    redirect_slashes=False,
 )
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
Disable redirect_slashes because:

- Redirecting doesn't always work well with some clients because of the required headers. For example requests, see https://github.com/openbraininstitute/entitycore/issues/389
- It causes the client to hit the endpoint multiple times (3)

This is a potentially breaking change if any client is misconfigured to use an endpoint with a trailing slash.

cc @bilalesi @pgetta @g-bar @jankrepl @WonderPG @BoBer78 