### PR TITLE
add species to ion channel model filters

### DIFF
--- a/app/filters/ion_channel_model.py
+++ b/app/filters/ion_channel_model.py
@@ -32,7 +32,14 @@ class IonChannelModelFilter(ScientificArtifactFilter, NameFilterMixin):
 
     class Constants(ScientificArtifactFilter.Constants):
         model = IonChannelModel
-        ordering_model_fields = ["creation_date", "update_date", "name"]  # noqa: RUF012
+        ordering_model_fields = [  # noqa: RUF012
+            "creation_date",
+            "update_date",
+            "name",
+            "subject__species__name",
+            "brain_region__acronym",
+            "brain_region__name",
+        ]
 
 
 # Dependencies


### PR DESCRIPTION
For this ticket: https://github.com/openbraininstitute/prod-build-ion-channel-model/issues/30 we need to be able to filter by species for ion channel model.
Is this the way to do it?