### PR TITLE
Ensure that project_id is always considered in read_one

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,14 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: "pyproject.toml"
       - name: Check requirements

--- a/app/service/analysis_notebook_environment.py
+++ b/app/service/analysis_notebook_environment.py
@@ -51,7 +51,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookEnvironment,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=AnalysisNotebookEnvironmentRead,
         apply_operations=_load,
     )
@@ -65,7 +65,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookEnvironment,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=AnalysisNotebookEnvironmentRead,
         apply_operations=_load,
     )

--- a/app/service/analysis_notebook_execution.py
+++ b/app/service/analysis_notebook_execution.py
@@ -56,7 +56,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookExecution,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=AnalysisNotebookExecutionRead,
         apply_operations=_load,
     )
@@ -70,7 +70,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookExecution,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=AnalysisNotebookExecutionRead,
         apply_operations=_load,
     )

--- a/app/service/analysis_notebook_result.py
+++ b/app/service/analysis_notebook_result.py
@@ -51,7 +51,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookResult,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=AnalysisNotebookResultRead,
         apply_operations=_load,
     )
@@ -65,7 +65,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookResult,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=AnalysisNotebookResultRead,
         apply_operations=_load,
     )

--- a/app/service/analysis_notebook_template.py
+++ b/app/service/analysis_notebook_template.py
@@ -51,7 +51,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookTemplate,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=AnalysisNotebookTemplateRead,
         apply_operations=_load,
     )
@@ -65,7 +65,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=AnalysisNotebookTemplate,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=AnalysisNotebookTemplateRead,
         apply_operations=_load,
     )

--- a/app/service/brain_atlas.py
+++ b/app/service/brain_atlas.py
@@ -52,7 +52,7 @@ def read_one(user_context: UserContextDep, atlas_id: uuid.UUID, db: SessionDep) 
         id_=atlas_id,
         db=db,
         db_model_class=BrainAtlas,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=BrainAtlasRead,
         apply_operations=_load_brain_atlas,
     )
@@ -63,7 +63,7 @@ def admin_read_one(db: SessionDep, atlas_id: uuid.UUID) -> BrainAtlasRead:
         id_=atlas_id,
         db=db,
         db_model_class=BrainAtlas,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=BrainAtlasRead,
         apply_operations=_load_brain_atlas,
     )
@@ -102,7 +102,7 @@ def read_one_region(
         id_=atlas_region_id,
         db=db,
         db_model_class=BrainAtlasRegion,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=BrainAtlasRegionRead,
         apply_operations=lambda select: select.filter(
             BrainAtlasRegion.brain_atlas_id == atlas_id

--- a/app/service/brain_region_hierarchy.py
+++ b/app/service/brain_region_hierarchy.py
@@ -50,7 +50,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> BrainRegionHierarchyRead:
         id_=id_,
         db=db,
         db_model_class=BrainRegionHierarchy,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=BrainRegionHierarchyRead,
         apply_operations=_load,
     )

--- a/app/service/calibration.py
+++ b/app/service/calibration.py
@@ -54,7 +54,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=Calibration,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=CalibrationRead,
         apply_operations=_load,
     )
@@ -68,7 +68,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=Calibration,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=CalibrationRead,
         apply_operations=_load,
     )

--- a/app/service/cell_composition.py
+++ b/app/service/cell_composition.py
@@ -44,7 +44,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=CellComposition,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=CellCompositionRead,
         apply_operations=_load,
     )
@@ -58,7 +58,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=CellComposition,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=CellCompositionRead,
         apply_operations=_load,
     )

--- a/app/service/cell_morphology.py
+++ b/app/service/cell_morphology.py
@@ -99,7 +99,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=CellMorphology,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=response_schema_class,
         apply_operations=apply_operations,
     )
@@ -113,7 +113,7 @@ def admin_read_one(
         id_=id_,
         db=db,
         db_model_class=CellMorphology,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=CellMorphologyRead,
         apply_operations=_load_from_db,
     )

--- a/app/service/cell_morphology_protocol.py
+++ b/app/service/cell_morphology_protocol.py
@@ -58,7 +58,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=CellMorphologyProtocol,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=CellMorphologyProtocolReadAdapter,
         apply_operations=_load_from_db,
     )
@@ -72,7 +72,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=CellMorphologyProtocol,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=CellMorphologyProtocolReadAdapter,
         apply_operations=_load_from_db,
     )

--- a/app/service/circuit.py
+++ b/app/service/circuit.py
@@ -64,7 +64,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=Circuit,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=CircuitRead,
         apply_operations=_load,
     )
@@ -78,7 +78,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=Circuit,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=CircuitRead,
         apply_operations=_load,
     )

--- a/app/service/consortium.py
+++ b/app/service/consortium.py
@@ -72,7 +72,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> ConsortiumRead:
         id_=id_,
         db=db,
         db_model_class=Consortium,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ConsortiumRead,
         apply_operations=_load,
     )
@@ -83,7 +83,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> ConsortiumRead:
         id_=id_,
         db=db,
         db_model_class=Consortium,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ConsortiumRead,
         apply_operations=_load,
     )

--- a/app/service/contribution.py
+++ b/app/service/contribution.py
@@ -90,7 +90,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=Contribution,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ContributionRead,
         apply_operations=lambda q: constrain_to_accessible_entities(
             _load(q), user_context.project_id
@@ -106,7 +106,7 @@ def admin_read_one(
         id_=id_,
         db=db,
         db_model_class=Contribution,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ContributionRead,
         apply_operations=_load,
     )

--- a/app/service/electrical_cell_recording.py
+++ b/app/service/electrical_cell_recording.py
@@ -70,7 +70,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ElectricalCellRecording,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ElectricalCellRecordingRead,
         apply_operations=_load,
     )
@@ -84,7 +84,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ElectricalCellRecording,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ElectricalCellRecordingRead,
         apply_operations=_load,
     )

--- a/app/service/electrical_recording_stimulus.py
+++ b/app/service/electrical_recording_stimulus.py
@@ -55,7 +55,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ElectricalRecordingStimulus,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ElectricalRecordingStimulusRead,
         apply_operations=_load,
     )
@@ -69,7 +69,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ElectricalRecordingStimulus,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ElectricalRecordingStimulusRead,
         apply_operations=_load,
     )

--- a/app/service/em_cell_mesh.py
+++ b/app/service/em_cell_mesh.py
@@ -109,7 +109,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=EMCellMesh,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=EMCellMeshRead,
         apply_operations=_load,
     )
@@ -123,7 +123,7 @@ def admin_read_one(
         id_=id_,
         db=db,
         db_model_class=EMCellMesh,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=EMCellMeshRead,
         apply_operations=_load,
     )

--- a/app/service/em_dense_reconstruction_dataset.py
+++ b/app/service/em_dense_reconstruction_dataset.py
@@ -98,7 +98,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=EMDenseReconstructionDataset,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=EMDenseReconstructionDatasetRead,
         apply_operations=_load,
     )

--- a/app/service/emodel.py
+++ b/app/service/emodel.py
@@ -77,7 +77,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=EModel,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=EModelReadExpanded,
         apply_operations=_load,
     )
@@ -91,7 +91,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=EModel,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=EModelReadExpanded,
         apply_operations=_load,
     )

--- a/app/service/etype.py
+++ b/app/service/etype.py
@@ -44,7 +44,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> ETypeClassRead:
         id_=id_,
         db=db,
         db_model_class=ETypeClass,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ETypeClassRead,
         apply_operations=None,
     )

--- a/app/service/etype_classification.py
+++ b/app/service/etype_classification.py
@@ -78,7 +78,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ETypeClassification,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ETypeClassificationRead,
         apply_operations=_load,
     )
@@ -92,7 +92,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ETypeClassification,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ETypeClassificationRead,
         apply_operations=_load,
     )

--- a/app/service/experimental_bouton_density.py
+++ b/app/service/experimental_bouton_density.py
@@ -131,7 +131,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ExperimentalBoutonDensity,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ExperimentalBoutonDensityRead,
         apply_operations=_load,
     )
@@ -145,7 +145,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ExperimentalBoutonDensity,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ExperimentalBoutonDensityRead,
         apply_operations=_load,
     )

--- a/app/service/experimental_neuron_density.py
+++ b/app/service/experimental_neuron_density.py
@@ -134,7 +134,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ExperimentalNeuronDensity,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ExperimentalNeuronDensityRead,
         apply_operations=_load,
     )
@@ -148,7 +148,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ExperimentalNeuronDensity,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ExperimentalNeuronDensityRead,
         apply_operations=_load,
     )

--- a/app/service/experimental_synapses_per_connection.py
+++ b/app/service/experimental_synapses_per_connection.py
@@ -157,7 +157,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ExperimentalSynapsesPerConnection,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ExperimentalSynapsesPerConnectionRead,
         apply_operations=_load,
     )
@@ -171,7 +171,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ExperimentalSynapsesPerConnection,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ExperimentalSynapsesPerConnectionRead,
         apply_operations=_load,
     )

--- a/app/service/external_url.py
+++ b/app/service/external_url.py
@@ -42,7 +42,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ExternalUrl,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ExternalUrlRead,
         apply_operations=_load,
     )

--- a/app/service/ion_channel.py
+++ b/app/service/ion_channel.py
@@ -50,7 +50,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=IonChannel,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=IonChannelRead,
         apply_operations=_load,
     )

--- a/app/service/ion_channel_model.py
+++ b/app/service/ion_channel_model.py
@@ -116,7 +116,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=IonChannelModel,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=IonChannelModelExpanded,
         apply_operations=_load_expanded,
     )
@@ -130,7 +130,7 @@ def admin_read_one(
         id_=id_,
         db=db,
         db_model_class=IonChannelModel,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=IonChannelModelExpanded,
         apply_operations=_load_expanded,
     )

--- a/app/service/ion_channel_recording.py
+++ b/app/service/ion_channel_recording.py
@@ -70,7 +70,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=IonChannelRecording,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=IonChannelRecordingRead,
         apply_operations=_load,
     )
@@ -84,7 +84,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=IonChannelRecording,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=IonChannelRecordingRead,
         apply_operations=_load,
     )

--- a/app/service/license.py
+++ b/app/service/license.py
@@ -42,7 +42,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> LicenseRead:
         id_=id_,
         db=db,
         db_model_class=License,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=LicenseRead,
         apply_operations=None,
     )

--- a/app/service/measurement_annotation.py
+++ b/app/service/measurement_annotation.py
@@ -113,7 +113,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=MeasurementAnnotation,
-        authorized_project_id=None,  # validated with apply_operations
+        user_context=None,  # validated with apply_operations
         response_schema_class=MeasurementAnnotationRead,
         apply_operations=apply_operations,
     )
@@ -131,7 +131,7 @@ def admin_read_one(
         id_=id_,
         db=db,
         db_model_class=MeasurementAnnotation,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=MeasurementAnnotationRead,
         apply_operations=apply_operations,
     )
@@ -178,7 +178,7 @@ def delete_one(
         id_=id_,
         db=db,
         db_model_class=MeasurementAnnotation,
-        authorized_project_id=None,  # validated with apply_operations
+        user_context=None,  # validated with apply_operations
         response_schema_class=MeasurementAnnotationRead,
         apply_operations=apply_operations,
     )

--- a/app/service/memodel.py
+++ b/app/service/memodel.py
@@ -91,7 +91,7 @@ def read_one(db: SessionDep, id_: uuid.UUID, user_context: UserContextDep) -> ME
         id_=id_,
         db=db,
         db_model_class=MEModel,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=MEModelRead,
         apply_operations=_load,
     )
@@ -102,7 +102,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> MEModelRead:
         id_=id_,
         db=db,
         db_model_class=MEModel,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=MEModelRead,
         apply_operations=_load,
     )

--- a/app/service/memodel_calibration_result.py
+++ b/app/service/memodel_calibration_result.py
@@ -45,7 +45,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=MEModelCalibrationResult,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=MEModelCalibrationResultRead,
         apply_operations=_load,
     )
@@ -59,7 +59,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=MEModelCalibrationResult,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=MEModelCalibrationResultRead,
         apply_operations=_load,
     )

--- a/app/service/mtype.py
+++ b/app/service/mtype.py
@@ -44,7 +44,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> MTypeClassRead:
         id_=id_,
         db=db,
         db_model_class=MTypeClass,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=MTypeClassRead,
         apply_operations=None,
     )

--- a/app/service/mtype_classification.py
+++ b/app/service/mtype_classification.py
@@ -79,7 +79,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=MTypeClassification,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=MTypeClassificationRead,
         apply_operations=_load,
     )
@@ -93,7 +93,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=MTypeClassification,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=MTypeClassificationRead,
         apply_operations=_load,
     )

--- a/app/service/organization.py
+++ b/app/service/organization.py
@@ -72,7 +72,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> OrganizationRead:
         id_=id_,
         db=db,
         db_model_class=Organization,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=OrganizationRead,
         apply_operations=_load,
     )
@@ -83,7 +83,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> OrganizationRead:
         id_=id_,
         db=db,
         db_model_class=Organization,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=OrganizationRead,
         apply_operations=_load,
     )

--- a/app/service/person.py
+++ b/app/service/person.py
@@ -77,7 +77,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> PersonRead:
         id_=id_,
         db=db,
         db_model_class=Person,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=PersonRead,
         apply_operations=_load,
     )
@@ -88,7 +88,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> PersonRead:
         id_=id_,
         db=db,
         db_model_class=Person,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=PersonRead,
         apply_operations=_load,
     )

--- a/app/service/publication.py
+++ b/app/service/publication.py
@@ -50,7 +50,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=Publication,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=PublicationRead,
         apply_operations=_load,
     )

--- a/app/service/role.py
+++ b/app/service/role.py
@@ -42,7 +42,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> RoleRead:
         id_=id_,
         db=db,
         db_model_class=Role,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=RoleRead,
         apply_operations=None,
     )

--- a/app/service/scientific_artifact_external_url_link.py
+++ b/app/service/scientific_artifact_external_url_link.py
@@ -77,7 +77,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ScientificArtifactExternalUrlLink,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ScientificArtifactExternalUrlLinkRead,
         apply_operations=_load,
     )
@@ -93,7 +93,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ScientificArtifactExternalUrlLink,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ScientificArtifactExternalUrlLinkRead,
         apply_operations=_load,
     )

--- a/app/service/scientific_artifact_publication_link.py
+++ b/app/service/scientific_artifact_publication_link.py
@@ -75,7 +75,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ScientificArtifactPublicationLink,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ScientificArtifactPublicationLinkRead,
         apply_operations=_load,
     )
@@ -91,7 +91,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ScientificArtifactPublicationLink,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ScientificArtifactPublicationLinkRead,
         apply_operations=_load,
     )

--- a/app/service/simulation.py
+++ b/app/service/simulation.py
@@ -57,7 +57,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=Simulation,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SimulationRead,
         apply_operations=_load,
     )
@@ -71,7 +71,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=Simulation,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SimulationRead,
         apply_operations=_load,
     )

--- a/app/service/simulation_campaign.py
+++ b/app/service/simulation_campaign.py
@@ -60,7 +60,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationCampaign,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SimulationCampaignRead,
         apply_operations=_load,
     )
@@ -74,7 +74,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationCampaign,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SimulationCampaignRead,
         apply_operations=_load,
     )

--- a/app/service/simulation_execution.py
+++ b/app/service/simulation_execution.py
@@ -54,7 +54,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationExecution,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SimulationExecutionRead,
         apply_operations=_load,
     )
@@ -68,7 +68,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationExecution,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SimulationExecutionRead,
         apply_operations=_load,
     )

--- a/app/service/simulation_generation.py
+++ b/app/service/simulation_generation.py
@@ -54,7 +54,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationGeneration,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SimulationGenerationRead,
         apply_operations=_load,
     )
@@ -68,7 +68,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationGeneration,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SimulationGenerationRead,
         apply_operations=_load,
     )

--- a/app/service/simulation_result.py
+++ b/app/service/simulation_result.py
@@ -56,7 +56,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationResult,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SimulationResultRead,
         apply_operations=_load,
     )
@@ -70,7 +70,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=SimulationResult,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SimulationResultRead,
         apply_operations=_load,
     )

--- a/app/service/single_neuron_simulation.py
+++ b/app/service/single_neuron_simulation.py
@@ -52,7 +52,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=SingleNeuronSimulation,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SingleNeuronSimulationRead,
         apply_operations=_load,
     )
@@ -66,7 +66,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=SingleNeuronSimulation,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SingleNeuronSimulationRead,
         apply_operations=_load,
     )

--- a/app/service/single_neuron_synaptome.py
+++ b/app/service/single_neuron_synaptome.py
@@ -54,7 +54,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=SingleNeuronSynaptome,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SingleNeuronSynaptomeRead,
         apply_operations=_load,
     )
@@ -68,7 +68,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=SingleNeuronSynaptome,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SingleNeuronSynaptomeRead,
         apply_operations=_load,
     )

--- a/app/service/single_neuron_synaptome_simulation.py
+++ b/app/service/single_neuron_synaptome_simulation.py
@@ -61,7 +61,7 @@ def read_one(
     return router_read_one(
         db=db,
         id_=id_,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         db_model_class=SingleNeuronSynaptomeSimulation,
         response_schema_class=SingleNeuronSynaptomeSimulationRead,
         apply_operations=_load,
@@ -75,7 +75,7 @@ def admin_read_one(
     return router_read_one(
         db=db,
         id_=id_,
-        authorized_project_id=None,
+        user_context=None,
         db_model_class=SingleNeuronSynaptomeSimulation,
         response_schema_class=SingleNeuronSynaptomeSimulationRead,
         apply_operations=_load,

--- a/app/service/species.py
+++ b/app/service/species.py
@@ -33,7 +33,7 @@ def read_one(
         id_=id_,
         db=db,
         db_model_class=Species,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SpeciesRead,
         apply_operations=_load,
     )

--- a/app/service/strain.py
+++ b/app/service/strain.py
@@ -70,7 +70,7 @@ def read_one(id_: uuid.UUID, db: SessionDep) -> StrainRead:
         id_=id_,
         db=db,
         db_model_class=Strain,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=StrainRead,
         apply_operations=_load,
     )

--- a/app/service/subject.py
+++ b/app/service/subject.py
@@ -40,7 +40,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=Subject,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=SubjectRead,
         apply_operations=_load,
     )
@@ -54,7 +54,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=Subject,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=SubjectRead,
         apply_operations=_load,
     )

--- a/app/service/validation.py
+++ b/app/service/validation.py
@@ -54,7 +54,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=Validation,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ValidationRead,
         apply_operations=_load,
     )
@@ -68,7 +68,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=Validation,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ValidationRead,
         apply_operations=_load,
     )

--- a/app/service/validation_result.py
+++ b/app/service/validation_result.py
@@ -49,7 +49,7 @@ def read_one(
         db=db,
         id_=id_,
         db_model_class=ValidationResult,
-        authorized_project_id=user_context.project_id,
+        user_context=user_context,
         response_schema_class=ValidationResultRead,
         apply_operations=_load,
     )
@@ -63,7 +63,7 @@ def admin_read_one(
         db=db,
         id_=id_,
         db_model_class=ValidationResult,
-        authorized_project_id=None,
+        user_context=None,
         response_schema_class=ValidationResultRead,
         apply_operations=_load,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -508,6 +508,14 @@ def check_authorization(route, client_user_1, client_user_2, client_no_project, 
         public_u2_0["id"],
     }
 
+    # client_no_project cannot read a private entity
+    result = assert_request(
+        client_no_project.get,
+        url=f"{route}/{private_u1_1['id']}",
+        expected_status_code=404,
+    ).json()
+    assert result["error_code"] == "ENTITY_NOT_FOUND"
+
     # client_user_1 wants only public results
     data = assert_request(
         client_user_1.get,


### PR DESCRIPTION
Hotfix based on 2025.10.7, not to be merged but to be cherry picked on the main branch later.
Based on the same approach used for router_update_one, router_delete_one, router_update_activity_one.

Test added.
Opened as draft so it cannot be merged by mistake.