### PR TITLE
Add scan_indices to Simulations

### DIFF
--- a/app/db/model.py
+++ b/app/db/model.py
@@ -1450,6 +1450,9 @@ class Simulation(Entity, NameDescriptionVectorMixin):
         entity_id (uuid.UUID): Foreign key referencing the entity ID.
         entity (Entity): The entity this simulation is associated with.
         scan_parameters (JSON_DICT): Scan parameters for the simulation.
+        scan_indices (JSON_DICT): Dictionary where keys are the names of scan parameters,
+            and the integer values are the index of this Simulation's value of that scan parameter
+            in the SimulationCampaign scan_parameters dictionary for that key.
     """
 
     __tablename__ = EntityType.simulation.value
@@ -1469,6 +1472,11 @@ class Simulation(Entity, NameDescriptionVectorMixin):
         foreign_keys=[entity_id],
     )
     scan_parameters: Mapped[JSON_DICT] = mapped_column(
+        default={},
+        nullable=False,
+        server_default="{}",
+    )
+    scan_indices: Mapped[JSON_DICT] = mapped_column(
         default={},
         nullable=False,
         server_default="{}",


### PR DESCRIPTION
I think it would be useful for us to represent the n-dimensional index of a Simulation in the n-dimensional hypercube of Simulations within a SimulationCampaign. For example:

For each Simulation
```
scan_parameters= {"param_a": "bar", "param_b": 0.4, param_c: (1, 2, 3)}
scan_indices = {"param_a": 1, "param_b": 3, "param_c": 0}
```

where the values in the scan_indices dictionary are the indices in the scan_parameters dictionary of the SimulationCampaign:
i.e. 

```
SimulationCampaign.scan_parameters = {"param_a": ["foo", "bar"], "param_b": [0.1, 0.2, 0.3, 0.4, 0.5]}, "param_c": [(1, 2, 3), (4, 7)]}
```


This is required, for example, for us to generate a bbp-workflow campaign summary file as input to blueetl, on the fly. The proposed `scan_indices` would allow us to do this during or after staging a campaign (after staging is sufficient for now) irrespective of the layout of the directories that the campaign is staged into.

It also means we don't have infer the locations of individual coordinates within the hypercube, which is:
1) Impossible if the values for a certain dimension aren't unique i.e. "param_a": ["foo", "foo", "bar"]
2) Awkward when the scan values of are of more complex types (i.e. tuples, lists)

In future this might enable other uses, also, such as representing the hypercube of simulations visually

Good to know your thoughts. I'm sure there are other alternatives, but this seems the simplest to me. It would be difficult to do for existing simulation campaigns (especially those where 1 and 2 apply) - so would we leave the values in those columns empty for those rows, for example?