### PR TITLE
Add mtypes and measurement_annotation to em_cell_mesh

### DIFF
--- a/app/filters/em_cell_mesh.py
+++ b/app/filters/em_cell_mesh.py
@@ -5,11 +5,17 @@ from fastapi_filter import with_prefix
 from app.db.model import EMCellMesh
 from app.db.types import EMCellMeshType
 from app.dependencies.filter import FilterDepends
+from app.filters.common import MTypeClassFilterMixin
 from app.filters.em_dense_reconstruction_dataset import NestedEMDenseReconstructionDatasetFilter
+from app.filters.measurement_annotation import MeasurableFilterMixin
 from app.filters.scientific_artifact import ScientificArtifactFilter
 
 
-class EMCellMeshFilter(ScientificArtifactFilter):
+class EMCellMeshFilter(
+    ScientificArtifactFilter,
+    MTypeClassFilterMixin,
+    MeasurableFilterMixin,
+):
     release_version: int | None = None
     dense_reconstruction_cell_id: int | None = None
     level_of_detail: int | None = None

--- a/app/schemas/em_cell_mesh.py
+++ b/app/schemas/em_cell_mesh.py
@@ -4,7 +4,9 @@ from typing import Any
 from pydantic import BaseModel
 
 from app.db.types import EMCellMeshGenerationMethod, EMCellMeshType
+from app.schemas.annotation import MTypeClassRead
 from app.schemas.base import BasicEntityRead
+from app.schemas.measurement_annotation import MeasurementAnnotationRead
 from app.schemas.scientific_artifact import (
     NestedScientificArtifactRead,
     ScientificArtifactCreate,
@@ -34,6 +36,7 @@ class EMCellMeshRead(
     ScientificArtifactRead,
 ):
     em_dense_reconstruction_dataset: BasicEntityRead
+    mtypes: list[MTypeClassRead] | None
 
 
 class EMCellMeshCreate(
@@ -46,3 +49,7 @@ class EMCellMeshCreate(
 EMCellMeshUserUpdate = make_update_schema(
     EMCellMeshCreate, "EMCellMeshUserUpdate"
 )  # pyright : ignore [reportInvalidTypeForm]
+
+
+class EMCellMeshAnnotationExpandedRead(EMCellMeshRead):
+    measurement_annotation: MeasurementAnnotationRead | None

--- a/tests/test_em_cell_mesh.py
+++ b/tests/test_em_cell_mesh.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 
 from app.db.model import EMCellMesh
@@ -48,6 +50,7 @@ def _assert_read_response(data, json_data):
         "id": json_data["em_dense_reconstruction_dataset_id"],
         "type": EntityType.em_dense_reconstruction_dataset,
     }
+    assert data["mtypes"] == []
     check_creation_fields(data)
 
 
@@ -63,6 +66,12 @@ def test_read_one(client, model, json_data):
     data = assert_request(client.get, url=f"{ROUTE}").json()["data"]
     assert len(data) == 1
     _assert_read_response(data[0], json_data)
+
+    params = {"expand": "measurement_annotation"}
+    data = assert_request(client.get, url=f"{ROUTE}/{model.id}", params=params).json()
+    _assert_read_response(data, json_data)
+    assert "measurement_annotation" in data
+    assert data["measurement_annotation"] is None
 
 
 def test_missing(client):
@@ -149,6 +158,23 @@ def test_filtering(client, models, brain_region_id, species_id, strain_id):
                 "type": "subject.strain",
             },
         ],
+        "created_by": [
+            {
+                "count": 1,
+                "id": ANY,
+                "label": ANY,
+                "type": "person",
+            },
+        ],
+        "updated_by": [
+            {
+                "count": 1,
+                "id": ANY,
+                "label": ANY,
+                "type": "person",
+            },
+        ],
+        "mtype": [],
     }
 
     data = assert_request(


### PR DESCRIPTION
The db model has been updated in https://github.com/openbraininstitute/entitycore/pull/488 to inherit from MTypesMixin and MeasurableEntityMixin.

These changes are needed to consider mtypes and measurement_annotation in the pydantic schemas and filters.

Similarly to CellMorphology, the measurement_annotation is returned only in the read_one endpoint when passing `expand=measurement_annotation`

Needed for https://github.com/openbraininstitute/entitycore/issues/463