### PR TITLE
Use scope=function in get_db dependency

### DIFF
--- a/app/dependencies/db.py
+++ b/app/dependencies/db.py
@@ -19,5 +19,9 @@ def _get_repo_group(db: "SessionDep") -> RepositoryGroup:
     return RepositoryGroup(db=db)
 
 
-SessionDep = Annotated[Session, Depends(get_db)]
+# Using Depends(scope="function"), the exit code after yield is executed right after the path
+# operation function is finished, before the response is sent back to the client.
+# In this way, the commit of the db transaction and the associated events
+# are executed before the response is sent back to the client.
+SessionDep = Annotated[Session, Depends(get_db, scope="function")]
 RepoGroupDep = Annotated[RepositoryGroup, Depends(_get_repo_group)]


### PR DESCRIPTION
This change might need more discussion and testing, but it's mainly intended to ensure that:
- in case of error during the commit, the client knows that the operation failed
- in case of deletion of assets from S3 via events, the client can be sure that the deletion operation has finished, so it's possible to upload a new asset with the same name without risk of race conditions