### PR TITLE
Increase statement_timeout and lock_timeout in db migration

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections.abc import Iterable
 from logging.config import fileConfig
 
@@ -15,13 +16,14 @@ from app.db.model import Base
 
 L = logging.getLogger("alembic.env")
 
-# server settings to reduce possible service disruptions while running the migration
-SERVER_SETTINGS = {
+# Connection settings to reduce possible service disruptions while running the migration.
+# See https://www.postgresql.org/docs/17/runtime-config-client.html
+CONNECTION_SETTINGS = {
     # Abort any statement that takes more than the specified amount of time
-    "statement_timeout": "6000",
+    "statement_timeout": os.getenv("DB_MIGRATION_STATEMENT_TIMEOUT_MS", "30000"),
     # Abort any statement that waits longer than the specified amount of time while
     # attempting to acquire a lock on a table, index, row, or other database object
-    "lock_timeout": "4000",
+    "lock_timeout": os.getenv("DB_MIGRATION_LOCK_TIMEOUT_MS", "5000"),
 }
 
 # register triggers only if alembic is run with `-x register_triggers="true"`
@@ -102,7 +104,7 @@ def run_migrations_online() -> None:
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
         connect_args={
-            "options": " ".join(f"-c {key}={value}" for key, value in SERVER_SETTINGS.items()),
+            "options": " ".join(f"-c {key}={value}" for key, value in CONNECTION_SETTINGS.items()),
             "application_name": "alembic",
         },
     )


### PR DESCRIPTION
Considering acceptable a statement timeout of 30 seconds, it should fix the failure in the current db migration:
> sqlalchemy.exc.OperationalError: (psycopg2.errors.QueryCanceled) canceling statement due to statement timeout

during the query:

>UPDATE measurement_kind
SET measurement_label_id = ml.id
FROM measurement_label ml
WHERE ml.entity_type = 'cell_morphology'::entitytype
AND ml.pref_label = measurement_kind.pref_label
