### PR TITLE
Add config entry to set CORS origin with a regex

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -133,6 +133,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
+    allow_origin_regex=settings.CORS_ORIGIN_REGEX,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     ENVIRONMENT: str | None = None
     ROOT_PATH: str = ""
     CORS_ORIGINS: list[str] = ["*"]
+    CORS_ORIGIN_REGEX: str | None = None
 
     LOG_LEVEL: str = "INFO"
     LOG_FORMAT: str = (


### PR DESCRIPTION
This is to eventually enable CORS for `https://*.preview.openbraininstitute.org` - origins needed by Core Web app preview deployments (where each PR will have it's own).