### PR TITLE
Check write permissions for activity update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ restore:  ## Delete and restore the local database from file
 		db bash -c '\
 		echo "Restoring database $$PGDATABASE from $$DUMPFILE to $$PGHOST:$$PGPORT" && \
 		dropdb --force $$PGDATABASE && createdb $$PGDATABASE && \
-		pg_restore --clean --if-exists --exit-on-error --no-owner --dbname $$PGDATABASE $$DUMPFILE \
+		pg_restore --clean --if-exists --exit-on-error --no-owner --no-acl --dbname $$PGDATABASE $$DUMPFILE \
 		&& psql -c "ANALYZE;"'
 
 extract-traces: export REQUEST_TRACER_ENABLE=1

--- a/app/config.py
+++ b/app/config.py
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     LOG_CATCH: bool = True
     LOG_STANDARD_LOGGER: dict[str, str] = {"root": "INFO"}
 
-    KEYCLOAK_URL: str = "https://staging.openbraininstitute.org/auth/realms/SBO"
+    KEYCLOAK_URL: str = "https://staging.cell-a.openbraininstitute.org/auth/realms/SBO"
     AUTH_CACHE_MAXSIZE: int = 128  # items
     AUTH_CACHE_MAX_TTL: int = 300  # seconds
     AUTH_CACHE_INFO: bool = False

--- a/app/db/auth.py
+++ b/app/db/auth.py
@@ -44,7 +44,7 @@ def constrain_to_writable_entities[Q: Query | Select](
     )
 
 
-def constrain_to_accessible_entities[Q: Query | Select](
+def constrain_to_readable_entities[Q: Query | Select](
     query: Q,
     project_id: UUID4 | None,
     db_model_class: Any = Entity,

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import operators
 
 from app.db.auth import (
-    constrain_to_accessible_entities,
+    constrain_to_readable_entities,
     constrain_to_writable_entities,
     is_user_authorized_for_deletion,
     select_unauthorized_entities,
@@ -68,7 +68,7 @@ def router_read_one[T: BaseModel, I: Identifiable](
     if user_context and (
         id_model_class := get_declaring_class(db_model_class, "authorized_project_id")
     ):
-        query = constrain_to_accessible_entities(
+        query = constrain_to_readable_entities(
             query=query,
             project_id=user_context.project_id,
             db_model_class=id_model_class,
@@ -311,7 +311,7 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
     """
     filter_query = sa.select(db_model_class)
     if id_model_class := get_declaring_class(db_model_class, "authorized_project_id"):
-        filter_query = constrain_to_accessible_entities(
+        filter_query = constrain_to_readable_entities(
             filter_query,
             project_id=authorized_project_id,
             db_model_class=id_model_class,
@@ -469,7 +469,7 @@ def router_update_activity_one[T: BaseModel, I: Activity](
     id_: uuid.UUID,
     db: Session,
     db_model_class: type[I],
-    user_context: UserContext | UserContextWithProjectId | None,
+    user_context: UserContext | None,
     json_model: ActivityUpdate,
     response_schema_class: SupportsModelValidate[T],
     apply_operations: ApplyOperations | None = None,
@@ -478,8 +478,8 @@ def router_update_activity_one[T: BaseModel, I: Activity](
     if user_context and (
         id_model_class := get_declaring_class(db_model_class, "authorized_project_id")
     ):
-        query = constrain_to_accessible_entities(
-            query, user_context.project_id, db_model_class=id_model_class
+        query = constrain_to_writable_entities(
+            query, user_context=user_context, db_model_class=id_model_class
         )
     if apply_operations:
         query = apply_operations(query)

--- a/app/queries/entity.py
+++ b/app/queries/entity.py
@@ -3,7 +3,7 @@ import uuid
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from app.db.auth import constrain_entity_query_to_project, constrain_to_accessible_entities
+from app.db.auth import constrain_entity_query_to_project, constrain_to_readable_entities
 from app.db.model import Entity
 from app.errors import ensure_result
 
@@ -27,7 +27,7 @@ def get_readable_entity[T: Entity](
         or raises NoResultFound if the entity doesn't exist, or it's forbidden.
     """
     query = sa.select(db_model_class).where(db_model_class.id == entity_id)
-    query = constrain_to_accessible_entities(query, project_id=project_id)
+    query = constrain_to_readable_entities(query, project_id=project_id)
     with ensure_result(f"Entity {db_model_class.__name__} {entity_id} not found or forbidden"):
         return db.execute(query).scalar_one()
 

--- a/app/service/analysis_notebook_execution.py
+++ b/app/service/analysis_notebook_execution.py
@@ -161,7 +161,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: AnalysisNotebookExecutionUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> AnalysisNotebookExecutionRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/calibration.py
+++ b/app/service/calibration.py
@@ -159,7 +159,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: CalibrationUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> CalibrationRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/circuit_extraction_config_generation.py
+++ b/app/service/circuit_extraction_config_generation.py
@@ -156,7 +156,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: CircuitExtractionConfigGenerationUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> CircuitExtractionConfigGenerationRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/circuit_extraction_execution.py
+++ b/app/service/circuit_extraction_execution.py
@@ -159,7 +159,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: CircuitExtractionExecutionUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> CircuitExtractionExecutionRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/contribution.py
+++ b/app/service/contribution.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import aliased, joinedload, raiseload
 
 import app.queries.common
-from app.db.auth import constrain_entity_query_to_project, constrain_to_accessible_entities
+from app.db.auth import constrain_entity_query_to_project, constrain_to_readable_entities
 from app.db.model import Agent, Contribution, Entity, Person
 from app.dependencies.auth import UserContextDep, UserContextWithProjectIdDep
 from app.dependencies.common import PaginationQuery
@@ -63,7 +63,7 @@ def read_many(
         aliases=aliases,
     )
 
-    filter_query = lambda q: constrain_to_accessible_entities(_load(q), user_context.project_id)
+    filter_query = lambda q: constrain_to_readable_entities(_load(q), user_context.project_id)
 
     return app.queries.common.router_read_many(
         db=db,
@@ -94,7 +94,7 @@ def read_one(
         db_model_class=Contribution,
         user_context=None,
         response_schema_class=ContributionRead,
-        apply_operations=lambda q: constrain_to_accessible_entities(
+        apply_operations=lambda q: constrain_to_readable_entities(
             _load(q), user_context.project_id
         ),
     )

--- a/app/service/entity.py
+++ b/app/service/entity.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 import app.queries.entity
-from app.db.auth import constrain_to_accessible_entities
+from app.db.auth import constrain_to_readable_entities
 from app.db.model import Entity
 from app.db.types import EntityType
 from app.db.utils import (
@@ -87,7 +87,7 @@ def count_entities_by_type(
                 sa.literal(et.value).label("type"),
                 sa.func.count(entity_class.id).label("count"),
             )
-            q = constrain_to_accessible_entities(
+            q = constrain_to_readable_entities(
                 q, project_id=user_context.project_id, db_model_class=entity_class
             )
             q = q.join(brain_region_cte, entity_class.brain_region_id == brain_region_cte.c.id)  # type: ignore[reportAttributeAccessIssue]
@@ -103,7 +103,7 @@ def count_entities_by_type(
         query = sa.select(
             Entity.type.label("type"), sa.func.count(Entity.id).label("count")
         ).select_from(Entity)
-        query = constrain_to_accessible_entities(
+        query = constrain_to_readable_entities(
             query, project_id=user_context.project_id, db_model_class=Entity
         )
         query = query.where(Entity.type.in_(entity_types))

--- a/app/service/etype_classification.py
+++ b/app/service/etype_classification.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from fastapi import HTTPException
 from sqlalchemy.orm import aliased, joinedload, raiseload
 
-from app.db.auth import constrain_to_accessible_entities
+from app.db.auth import constrain_to_readable_entities
 from app.db.model import (
     Entity,
     ETypeClassification,
@@ -45,7 +45,7 @@ def create_one(
     json_model: ETypeClassificationCreate,
     user_context: UserContextWithProjectIdDep,
 ) -> ETypeClassificationRead:
-    stmt = constrain_to_accessible_entities(
+    stmt = constrain_to_readable_entities(
         sa.select(sa.func.count(Entity.id)).where(Entity.id == json_model.entity_id),
         user_context.project_id,
     )

--- a/app/service/hierarchy.py
+++ b/app/service/hierarchy.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from fastapi import HTTPException
 from sqlalchemy.orm import Session, aliased
 
-from app.db.auth import constrain_to_accessible_entities
+from app.db.auth import constrain_to_readable_entities
 from app.db.model import Circuit, Derivation, Entity
 from app.db.types import DerivationType
 from app.dependencies.auth import UserContextDep
@@ -35,7 +35,7 @@ def _load_nodes(
         )
     )
     # needed to consider as root also the children with private parents in a different project
-    matching_derivation_for_root = constrain_to_accessible_entities(
+    matching_derivation_for_root = constrain_to_readable_entities(
         matching_derivation_for_root, project_id=project_id, db_model_class=root_parent
     )
     query_roots = (
@@ -49,7 +49,7 @@ def _load_nodes(
         .where(~sa.exists(matching_derivation_for_root))
         .order_by(*order_by)
     )
-    query_roots = constrain_to_accessible_entities(
+    query_roots = constrain_to_readable_entities(
         query_roots, project_id=project_id, db_model_class=root
     )
     query_children = (
@@ -66,10 +66,10 @@ def _load_nodes(
         .where(Derivation.derivation_type == derivation_type)
         .order_by(*order_by)
     )
-    query_children = constrain_to_accessible_entities(
+    query_children = constrain_to_readable_entities(
         query_children, project_id=project_id, db_model_class=parent
     )
-    query_children = constrain_to_accessible_entities(
+    query_children = constrain_to_readable_entities(
         query_children, project_id=project_id, db_model_class=child
     )
     query = query_roots.union_all(query_children)

--- a/app/service/ion_channel_modeling_config_generation.py
+++ b/app/service/ion_channel_modeling_config_generation.py
@@ -156,7 +156,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: IonChannelModelingConfigGenerationUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> IonChannelModelingConfigGenerationRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/ion_channel_modeling_execution.py
+++ b/app/service/ion_channel_modeling_execution.py
@@ -159,7 +159,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: IonChannelModelingExecutionUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> IonChannelModelingExecutionRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/measurement_annotation.py
+++ b/app/service/measurement_annotation.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import (
     selectinload,
 )
 
-from app.db.auth import constrain_entity_query_to_project, constrain_to_accessible_entities
+from app.db.auth import constrain_entity_query_to_project, constrain_to_readable_entities
 from app.db.model import (
     Entity,
     MeasurementAnnotation,
@@ -101,7 +101,7 @@ def read_many(
     filter_model: MeasurementAnnotationFilterDep,
     pagination_request: PaginationQuery,
 ) -> ListResponse[MeasurementAnnotationRead]:
-    apply_filter_query_operations = lambda q: constrain_to_accessible_entities(
+    apply_filter_query_operations = lambda q: constrain_to_readable_entities(
         q.join(Entity, Entity.id == MeasurementAnnotation.entity_id),
         project_id=user_context.project_id,
     )
@@ -142,7 +142,7 @@ def read_one(
 ) -> MeasurementAnnotationRead:
     def apply_operations(q):
         q = q.join(Entity, Entity.id == MeasurementAnnotation.entity_id)
-        q = constrain_to_accessible_entities(q, project_id=user_context.project_id)
+        q = constrain_to_readable_entities(q, project_id=user_context.project_id)
         return _load_from_db(q=q)
 
     return router_read_one(

--- a/app/service/mtype_classification.py
+++ b/app/service/mtype_classification.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from fastapi import HTTPException
 from sqlalchemy.orm import aliased, joinedload, raiseload
 
-from app.db.auth import constrain_to_accessible_entities
+from app.db.auth import constrain_to_readable_entities
 from app.db.model import (
     Entity,
     MTypeClassification,
@@ -45,7 +45,7 @@ def create_one(
     json_model: MTypeClassificationCreate,
     user_context: UserContextWithProjectIdDep,
 ) -> MTypeClassificationRead:
-    stmt = constrain_to_accessible_entities(
+    stmt = constrain_to_readable_entities(
         sa.select(sa.func.count(Entity.id)).where(Entity.id == json_model.entity_id),
         user_context.project_id,
     )

--- a/app/service/scientific_artifact_external_url_link.py
+++ b/app/service/scientific_artifact_external_url_link.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import aliased, joinedload, raiseload
 
 from app.db.auth import (
-    constrain_to_accessible_entities,
+    constrain_to_readable_entities,
 )
 from app.db.model import (
     ExternalUrl,
@@ -133,7 +133,7 @@ def read_many(
         aliases=aliases,
     )
 
-    filter_query = lambda q: constrain_to_accessible_entities(
+    filter_query = lambda q: constrain_to_readable_entities(
         q.join(
             scientific_artifact_alias,
             ScientificArtifactExternalUrlLink.scientific_artifact_id

--- a/app/service/scientific_artifact_publication_link.py
+++ b/app/service/scientific_artifact_publication_link.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import aliased, joinedload, raiseload
 
 from app.db.auth import (
-    constrain_to_accessible_entities,
+    constrain_to_readable_entities,
 )
 from app.db.model import (
     Person,
@@ -133,7 +133,7 @@ def read_many(
         aliases=aliases,
     )
 
-    filter_query = lambda q: constrain_to_accessible_entities(
+    filter_query = lambda q: constrain_to_readable_entities(
         q.join(
             scientific_artifact_alias,
             ScientificArtifactPublicationLink.scientific_artifact_id

--- a/app/service/simulation_execution.py
+++ b/app/service/simulation_execution.py
@@ -159,7 +159,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: SimulationExecutionUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> SimulationExecutionRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/simulation_generation.py
+++ b/app/service/simulation_generation.py
@@ -154,7 +154,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: SimulationGenerationUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> SimulationGenerationRead:
     return router_update_activity_one(
         db=db,

--- a/app/service/skeletonization_config_generation.py
+++ b/app/service/skeletonization_config_generation.py
@@ -168,7 +168,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: UserUpdateSchema,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> ReadSchema:
     return router_update_activity_one(
         db=db,

--- a/app/service/skeletonization_execution.py
+++ b/app/service/skeletonization_execution.py
@@ -167,7 +167,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: UserUpdateSchema,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> ReadSchema:
     return router_update_activity_one(
         db=db,

--- a/app/service/validation.py
+++ b/app/service/validation.py
@@ -159,7 +159,7 @@ def update_one(
     db: SessionDep,
     id_: uuid.UUID,
     json_model: ValidationUserUpdate,  # pyright: ignore [reportInvalidTypeForm]
-    user_context: UserContextWithProjectIdDep,
+    user_context: UserContextDep,
 ) -> ValidationRead:
     return router_update_activity_one(
         db=db,

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -30,7 +30,7 @@ The special Keycloak group `/service/entitycore/maintainer` allows users to:
 
 * update public entities within authorized projects
 * delete public entities within authorized projects
-* hard delete assets within authorized projects
+* delete assets of public entities within authorized projects
 
 ## Caching
 


### PR DESCRIPTION
- Check write permissions when updating an activity.
- Do not require the header project_id when updating the activity, similar to updating entities.
- Rename `constrain_to_accessible_entities` to `constrain_to_readable_entities` for clarity.

Other, minor:
- add `--no-acl` to `make restore`
- update default KEYCLOAK_URL
- minor update to `docs/authentication.md`
