### PR TITLE
Remove nested filters in NestedCellMorphologyFilter

### DIFF
--- a/app/filters/cell_morphology.py
+++ b/app/filters/cell_morphology.py
@@ -1,11 +1,9 @@
 from typing import Annotated
 
-from fastapi_filter import with_prefix
-
 from app.db.model import CellMorphology
 from app.dependencies.filter import FilterDepends
 from app.filters.base import CustomFilter
-from app.filters.brain_region import BrainRegionFilterMixin, NestedBrainRegionFilter
+from app.filters.brain_region import BrainRegionFilterMixin
 from app.filters.cell_morphology_protocol import (
     NestedCellMorphologyProtocolFilter,
     NestedCellMorphologyProtocolFilterDep,
@@ -15,11 +13,10 @@ from app.filters.common import (
     ILikeSearchFilterMixin,
     MTypeClassFilterMixin,
     NameFilterMixin,
-    NestedMTypeClassFilter,
 )
 from app.filters.entity import EntityFilterMixin
 from app.filters.measurement_annotation import MeasurableFilterMixin
-from app.filters.subject import NestedSubjectFilter, SubjectFilterMixin
+from app.filters.subject import SubjectFilterMixin
 
 
 class CellMorphologyFilterBase(
@@ -36,35 +33,7 @@ class CellMorphologyFilterBase(
 class NestedCellMorphologyFilter(
     CellMorphologyFilterBase,
 ):
-    brain_region: Annotated[
-        NestedBrainRegionFilter | None,
-        FilterDepends(with_prefix("morphology__brain_region", NestedBrainRegionFilter)),
-    ] = None
-    subject: Annotated[
-        NestedSubjectFilter | None,
-        FilterDepends(with_prefix("morphology__subject", NestedSubjectFilter)),
-    ] = None
-    mtype: Annotated[
-        NestedMTypeClassFilter | None,
-        FilterDepends(with_prefix("morphology__mtype", NestedMTypeClassFilter)),
-    ] = None
-
-
-class NestedExemplarMorphologyFilter(
-    CellMorphologyFilterBase,
-):
-    brain_region: Annotated[
-        NestedBrainRegionFilter | None,
-        FilterDepends(with_prefix("exemplar_morphology__brain_region", NestedBrainRegionFilter)),
-    ] = None
-    subject: Annotated[
-        NestedSubjectFilter | None,
-        FilterDepends(with_prefix("exemplar_morphology__subject", NestedSubjectFilter)),
-    ] = None
-    mtype: Annotated[
-        NestedMTypeClassFilter | None,
-        FilterDepends(with_prefix("exemplar_morphology__mtype", NestedMTypeClassFilter)),
-    ] = None
+    pass
 
 
 class CellMorphologyFilter(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1015,7 +1015,11 @@ def faceted_emodel_ids(db: Session, client, person_id, species_id, ion_channel_m
     )
     brain_region_ids = [
         utils.create_brain_region(
-            db, hierarchy_name.id, i, f"region{i}", created_by_id=person_id
+            db,
+            hierarchy_id=hierarchy_name.id,
+            annotation_value=i,
+            name=f"region{i}",
+            created_by_id=person_id,
         ).id
         for i in range(2)
     ]


### PR DESCRIPTION
Remove nested filters used in emodel.exemplar_morphology and memodel.morphology, since they aren't used and they cannot work unless the query is modified by adding joined tables.

Note also that the filters aren't very useful for `emodel.exemplar_morphology` since it's returned by the read_many endpoints in:
- https://github.com/openbraininstitute/entitycore/blob/2259a9ce02f0890e46b7f3c535fe00a46aec874d/app/schemas/emodel.py#L71

and exemplar_morphology is a subclass of CellMorphologyBase, that doesn't contain brain_region, subject, mtype:
https://github.com/openbraininstitute/entitycore/blob/2259a9ce02f0890e46b7f3c535fe00a46aec874d/app/schemas/cell_morphology.py#L17


Instead, `memodel.morphology` defined in:
- https://github.com/openbraininstitute/entitycore/blob/2259a9ce02f0890e46b7f3c535fe00a46aec874d/app/schemas/me_model.py#L67

is a subclass of CellMorphologyRead and it contains all the nested brain_region, subject, mtype, but these values aren't shown in the list view in the UI
