### PR TITLE
allow ion channel model in filters of simulation campaign

### DIFF
--- a/app/filters/simulation_campaign.py
+++ b/app/filters/simulation_campaign.py
@@ -14,7 +14,9 @@ from app.filters.simulation import NestedSimulationFilter
 
 
 class NestedEntityFilter(IdFilterMixin, CustomFilter):
-    type: Literal[EntityType.circuit, EntityType.memodel, EntityType.ion_channel_model] | None = None
+    type: Literal[EntityType.circuit, EntityType.memodel, EntityType.ion_channel_model] | None = (
+        None
+    )
 
     class Constants(CustomFilter.Constants):
         model = Entity


### PR DESCRIPTION
to allow for ion channel simulations: they will also use simulation campaigns, but the linked entity_id will be the one of the first ion channel model simulated.