### PR TITLE
Simplify query parameters for within_brain_region_* call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,12 @@ build:  ## Build the Docker image
 publish: build  ## Publish the Docker image to DockerHub
 	docker compose push app
 
-TESTS ?= tests
+# use `PYTEST_ADDOPTS=` to narrow the pytests run, and add options 
 test-local:  ## Run tests locally
 	@$(call load_env,test-local)
 	docker compose up --wait db-test
 	uv run -m alembic upgrade head
-	uv run -m pytest $(TESTS)
+	uv run -m pytest
 	uv run -m coverage xml
 	uv run -m coverage html
 

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,12 @@ build:  ## Build the Docker image
 publish: build  ## Publish the Docker image to DockerHub
 	docker compose push app
 
+TESTS ?= tests
 test-local:  ## Run tests locally
 	@$(call load_env,test-local)
 	docker compose up --wait db-test
 	uv run -m alembic upgrade head
-	uv run -m pytest
+	uv run -m pytest $(TESTS)
 	uv run -m coverage xml
 	uv run -m coverage html
 

--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -5,14 +5,15 @@ from typing import Annotated, NotRequired, TypedDict
 import sqlalchemy as sa
 from fastapi import Depends, Query
 from fastapi.dependencies.models import Dependant
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sqlalchemy.orm import DeclarativeBase, InstrumentedAttribute, Session
 from starlette.requests import Request
 
+from app.db.model import BrainRegion
 from app.db.types import DerivationType
 from app.errors import ApiError, ApiErrorCode
 from app.filters.base import CustomFilter
-from app.filters.brain_region import WithinBrainRegionDirection, filter_by_hierarchy_and_region
+from app.filters.brain_region import WithinBrainRegionDirection, filter_by_region
 from app.queries.filter import filter_from_db
 from app.queries.types import ApplyOperations
 from app.schemas.types import Facet, Facets, PaginationRequest
@@ -149,41 +150,122 @@ class Search[T: DeclarativeBase](BaseModel):
 class InBrainRegionQuery(BaseModel):
     """Handle parameters for within_brain_region_* query params.
 
-    Using `within_brain_region_ascendants` will be deprecated; future usage
-    should only be through `within_brain_region_direction`.
-
-    During the transition, `within_brain_region_direction` will take precedence if it's there
-
+    Only `within_brain_region_direction` and `within_brain_region_brain_region_id`
+    are required. `within_brain_region_hierarchy_id` is optional, and only
+    used to check that the chosen brain_region_id matches the correct hierarchy.
     """
 
     within_brain_region_hierarchy_id: uuid.UUID | None = None
     within_brain_region_brain_region_id: uuid.UUID | None = None
-    within_brain_region_ascendants: bool = False
     within_brain_region_direction: WithinBrainRegionDirection | None = None
 
-    def __call__(self, query: sa.Select, db_model_class):
+    @model_validator(mode="after")
+    def check_range(self):
         if (
-            self.within_brain_region_hierarchy_id is None
-            or self.within_brain_region_brain_region_id is None
+            self.within_brain_region_hierarchy_id is not None
+            and self.within_brain_region_brain_region_id is None
+        ):
+            raise ApiError(
+                message=(
+                    "Need to specify `within_brain_region_brain_region_id` "
+                    "when `within_brain_region_hierarchy_id` is specified"
+                ),
+                error_code=ApiErrorCode.INVALID_REQUEST,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                details={
+                    "within_brain_region_hierarchy_id": f"{self.within_brain_region_hierarchy_id}",
+                },
+            )
+
+        if (
+            self.within_brain_region_brain_region_id is not None
+            and self.within_brain_region_direction is None
+        ):
+            raise ApiError(
+                message=(
+                    "Need to specify `within_brain_region_brain_region_id` "
+                    "when `within_brain_region_direction` is specified"
+                ),
+                error_code=ApiErrorCode.INVALID_REQUEST,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                details={
+                    "within_brain_region_direction": f"{self.within_brain_region_direction}",
+                },
+            )
+
+        if (
+            self.within_brain_region_brain_region_id is None
+            and self.within_brain_region_direction is not None
+        ):
+            raise ApiError(
+                message=(
+                    "Need to specify `within_brain_region_direction` "
+                    "when `within_brain_region_brain_region_id` is specified"
+                ),
+                error_code=ApiErrorCode.INVALID_REQUEST,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                details={
+                    "within_brain_region_direction": f"{self.within_brain_region_direction}",
+                },
+            )
+        return self
+
+    def __call__(self, db: Session, query: sa.Select, db_model_class):
+        if (
+            self.within_brain_region_brain_region_id is None
+            and self.within_brain_region_direction is None
         ):
             return query
 
-        return filter_by_hierarchy_and_region(
+        # should be checked by model_validator
+        assert self.within_brain_region_brain_region_id  # noqa: S101
+        assert self.within_brain_region_direction  # noqa: S101
+
+        if (
+            self.within_brain_region_hierarchy_id is not None
+            and self.within_brain_region_brain_region_id is not None
+            and not db.execute(
+                sa.select(
+                    sa.exists().where(
+                        sa.and_(
+                            BrainRegion.id == self.within_brain_region_brain_region_id,
+                            BrainRegion.hierarchy_id == self.within_brain_region_hierarchy_id,
+                        )
+                    )
+                )
+            ).scalar()
+        ):
+            id_ = f"{self.within_brain_region_brain_region_id}"
+            raise ApiError(
+                message=(
+                    "Mismatch between desired `within_brain_region_hierarchy_id` "
+                    "and the `within_brain_region_brain_region_id`: it "
+                    "must belong to the same hierarchy"
+                ),
+                error_code=ApiErrorCode.INVALID_REQUEST,
+                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                details={
+                    "within_brain_region_hierarchy_id": f"{self.within_brain_region_hierarchy_id}",
+                    "within_brain_region_brain_region_id": id_,
+                },
+            )
+
+        return filter_by_region(
             query=query,
             model=db_model_class,
-            hierarchy_id=self.within_brain_region_hierarchy_id,
             brain_region_id=self.within_brain_region_brain_region_id,
             direction=self.get_direction(),
         )
 
     def get_direction(self) -> WithinBrainRegionDirection:
-        # compatibility; will be deprecated
         if self.within_brain_region_direction is not None:
             return self.within_brain_region_direction
-        return (
-            WithinBrainRegionDirection.ascendants
-            if self.within_brain_region_ascendants
-            else WithinBrainRegionDirection.descendants
+
+        raise ApiError(
+            message=("Need to specify `within_brain_region_direction`"),
+            error_code=ApiErrorCode.INVALID_REQUEST,
+            http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            details={},
         )
 
 

--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -152,6 +152,7 @@ class InBrainRegionQuery(BaseModel):
     Only `within_brain_region_direction` and `within_brain_region_brain_region_id` are required.
     `within_brain_region_hierarchy_id` exists for historical reasons, and is
     not used or verified: see https://github.com/openbraininstitute/entitycore/issues/567
+    It will be deprecated.
     """
 
     within_brain_region_brain_region_id: uuid.UUID | None = None

--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -217,7 +217,7 @@ class InBrainRegionQuery(BaseModel):
         ):
             return query
 
-        # should be checked by model_validator
+        # this was already checked by model_validator; adding asserts so typing is happy
         assert self.within_brain_region_brain_region_id  # noqa: S101
         assert self.within_brain_region_direction  # noqa: S101
 

--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, model_validator
 from sqlalchemy.orm import DeclarativeBase, InstrumentedAttribute, Session
 from starlette.requests import Request
 
-from app.db.model import BrainRegion
 from app.db.types import DerivationType
 from app.errors import ApiError, ApiErrorCode
 from app.filters.base import CustomFilter
@@ -150,33 +149,19 @@ class Search[T: DeclarativeBase](BaseModel):
 class InBrainRegionQuery(BaseModel):
     """Handle parameters for within_brain_region_* query params.
 
-    Only `within_brain_region_direction` and `within_brain_region_brain_region_id`
-    are required. `within_brain_region_hierarchy_id` is optional, and only
-    used to check that the chosen brain_region_id matches the correct hierarchy.
+    Only `within_brain_region_direction` and `within_brain_region_brain_region_id` are required.
+    `within_brain_region_hierarchy_id` exists for historical reasons, and is
+    not used or verified: see https://github.com/openbraininstitute/entitycore/issues/567
     """
 
-    within_brain_region_hierarchy_id: uuid.UUID | None = None
     within_brain_region_brain_region_id: uuid.UUID | None = None
     within_brain_region_direction: WithinBrainRegionDirection | None = None
 
+    # only for backwards compat; ignored
+    within_brain_region_hierarchy_id: uuid.UUID | None = None
+
     @model_validator(mode="after")
     def check_range(self):
-        if (
-            self.within_brain_region_hierarchy_id is not None
-            and self.within_brain_region_brain_region_id is None
-        ):
-            raise ApiError(
-                message=(
-                    "Need to specify `within_brain_region_brain_region_id` "
-                    "when `within_brain_region_hierarchy_id` is specified"
-                ),
-                error_code=ApiErrorCode.INVALID_REQUEST,
-                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-                details={
-                    "within_brain_region_hierarchy_id": f"{self.within_brain_region_hierarchy_id}",
-                },
-            )
-
         if (
             self.within_brain_region_brain_region_id is not None
             and self.within_brain_region_direction is None
@@ -210,7 +195,7 @@ class InBrainRegionQuery(BaseModel):
             )
         return self
 
-    def __call__(self, db: Session, query: sa.Select, db_model_class):
+    def __call__(self, query: sa.Select, db_model_class):
         if (
             self.within_brain_region_brain_region_id is None
             and self.within_brain_region_direction is None
@@ -220,35 +205,6 @@ class InBrainRegionQuery(BaseModel):
         # this was already checked by model_validator; adding asserts so typing is happy
         assert self.within_brain_region_brain_region_id  # noqa: S101
         assert self.within_brain_region_direction  # noqa: S101
-
-        if (
-            self.within_brain_region_hierarchy_id is not None
-            and self.within_brain_region_brain_region_id is not None
-            and not db.execute(
-                sa.select(
-                    sa.exists().where(
-                        sa.and_(
-                            BrainRegion.id == self.within_brain_region_brain_region_id,
-                            BrainRegion.hierarchy_id == self.within_brain_region_hierarchy_id,
-                        )
-                    )
-                )
-            ).scalar()
-        ):
-            id_ = f"{self.within_brain_region_brain_region_id}"
-            raise ApiError(
-                message=(
-                    "Mismatch between desired `within_brain_region_hierarchy_id` "
-                    "and the `within_brain_region_brain_region_id`: it "
-                    "must belong to the same hierarchy"
-                ),
-                error_code=ApiErrorCode.INVALID_REQUEST,
-                http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-                details={
-                    "within_brain_region_hierarchy_id": f"{self.within_brain_region_hierarchy_id}",
-                    "within_brain_region_brain_region_id": id_,
-                },
-            )
 
         return filter_by_region(
             query=query,

--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -254,18 +254,7 @@ class InBrainRegionQuery(BaseModel):
             query=query,
             model=db_model_class,
             brain_region_id=self.within_brain_region_brain_region_id,
-            direction=self.get_direction(),
-        )
-
-    def get_direction(self) -> WithinBrainRegionDirection:
-        if self.within_brain_region_direction is not None:
-            return self.within_brain_region_direction
-
-        raise ApiError(
-            message=("Need to specify `within_brain_region_direction`"),
-            error_code=ApiErrorCode.INVALID_REQUEST,
-            http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            details={},
+            direction=self.within_brain_region_direction,
         )
 
 

--- a/app/filters/brain_region.py
+++ b/app/filters/brain_region.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 from fastapi_filter import with_prefix
 from sqlalchemy.orm import aliased
 
-from app.db.model import BrainRegion, BrainRegionHierarchy
+from app.db.model import BrainRegion
 from app.dependencies.filter import FilterDepends
 from app.filters.base import CustomFilter
 from app.filters.common import IdFilterMixin, NameFilterMixin
@@ -20,16 +20,12 @@ class WithinBrainRegionDirection(StrEnum):
 
 
 def get_family_query(
-    *, hierarchy_id: uuid.UUID, brain_region_id: uuid.UUID, direction: WithinBrainRegionDirection
+    *, brain_region_id: uuid.UUID, direction: WithinBrainRegionDirection
 ) -> sa.CTE:
     """Create query for BrainRegions that returns ids."""
     cte = (
         sa.select(BrainRegion.id, BrainRegion.parent_structure_id)
-        .join(BrainRegionHierarchy, BrainRegion.hierarchy_id == BrainRegionHierarchy.id)
-        .where(
-            BrainRegion.id == brain_region_id,
-            BrainRegionHierarchy.id == hierarchy_id,
-        )
+        .where(BrainRegion.id == brain_region_id)
         .cte(recursive=True)
     )
 
@@ -44,7 +40,6 @@ def get_family_query(
         return (
             sa.select(
                 get_family_query(
-                    hierarchy_id=hierarchy_id,
                     brain_region_id=brain_region_id,
                     direction=WithinBrainRegionDirection.ascendants,
                 ).c.id
@@ -52,7 +47,6 @@ def get_family_query(
             .union(
                 sa.select(
                     get_family_query(
-                        hierarchy_id=hierarchy_id,
                         brain_region_id=brain_region_id,
                         direction=WithinBrainRegionDirection.descendants,
                     ).c.id
@@ -61,32 +55,21 @@ def get_family_query(
             .cte()
         )
 
-    recurse = (
-        sa.select(br_alias.id, br_alias.parent_structure_id)
-        .join(cte, join_direction)
-        .join(BrainRegionHierarchy, br_alias.hierarchy_id == BrainRegionHierarchy.id)
-        .where(BrainRegionHierarchy.id == hierarchy_id)
-    )
+    recurse = sa.select(br_alias.id, br_alias.parent_structure_id).join(cte, join_direction)
 
     query = cte.union_all(recurse)
 
     return query
 
 
-def filter_by_hierarchy_and_region(
+def filter_by_region(
     *,
     query,
     model,
-    hierarchy_id: uuid.UUID,
     brain_region_id: uuid.UUID,
     direction: WithinBrainRegionDirection,
 ):
-    brain_region_query = get_family_query(
-        hierarchy_id=hierarchy_id,
-        brain_region_id=brain_region_id,
-        direction=direction,
-    )
-
+    brain_region_query = get_family_query(brain_region_id=brain_region_id, direction=direction)
     query = query.join(brain_region_query, model.brain_region_id == brain_region_query.c.id)
     return query
 
@@ -95,7 +78,6 @@ class NestedBrainRegionFilter(IdFilterMixin, NameFilterMixin, CustomFilter):
     acronym: str | None = None
     acronym__in: list[str] | None = None
     annotation_value: int | None = None
-    hierarchy_id: uuid.UUID | None = None
 
     class Constants(CustomFilter.Constants):
         model = BrainRegion

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -327,7 +327,7 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
         filter_query = with_search(filter_query, description_vector)
 
     if with_in_brain_region:
-        filter_query = with_in_brain_region(filter_query, db_model_class)
+        filter_query = with_in_brain_region(db, filter_query, db_model_class)
 
     data_query = (
         filter_model.sort(filter_query, aliases=aliases)

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -327,7 +327,7 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
         filter_query = with_search(filter_query, description_vector)
 
     if with_in_brain_region:
-        filter_query = with_in_brain_region(db, filter_query, db_model_class)
+        filter_query = with_in_brain_region(filter_query, db_model_class)
 
     data_query = (
         filter_model.sort(filter_query, aliases=aliases)

--- a/app/service/entity.py
+++ b/app/service/entity.py
@@ -65,15 +65,13 @@ def count_entities_by_type(
     Returns:
         Dictionary with entity type as key and count as value
     """
-    should_filter_brain_region = (
-        in_brain_region and in_brain_region.within_brain_region_brain_region_id is not None
-    )
+    if (
+        in_brain_region
+        and in_brain_region.within_brain_region_brain_region_id
+        and in_brain_region.within_brain_region_direction
+    ):
+        filter_conditions = []
 
-    filter_conditions = []
-    if should_filter_brain_region:
-        # should be checked by model_validator
-        assert in_brain_region.within_brain_region_brain_region_id  # noqa: S101
-        assert in_brain_region.within_brain_region_direction  # noqa: S101
         brain_region_cte = get_family_query(
             brain_region_id=in_brain_region.within_brain_region_brain_region_id,
             direction=in_brain_region.within_brain_region_direction,

--- a/app/service/entity.py
+++ b/app/service/entity.py
@@ -65,18 +65,13 @@ def count_entities_by_type(
     Returns:
         Dictionary with entity type as key and count as value
     """
-    results = {}
-
     should_filter_brain_region = (
-        in_brain_region
-        and in_brain_region.within_brain_region_hierarchy_id is not None
-        and in_brain_region.within_brain_region_brain_region_id is not None
+        in_brain_region and in_brain_region.within_brain_region_brain_region_id is not None
     )
 
     filter_conditions = []
     if should_filter_brain_region:
         brain_region_cte = get_family_query(
-            hierarchy_id=in_brain_region.within_brain_region_hierarchy_id,  # type: ignore[reportGeneralTypeIssues]
             brain_region_id=in_brain_region.within_brain_region_brain_region_id,  # type: ignore[reportGeneralTypeIssues]
             direction=in_brain_region.get_direction(),
         )

--- a/app/service/entity.py
+++ b/app/service/entity.py
@@ -71,9 +71,12 @@ def count_entities_by_type(
 
     filter_conditions = []
     if should_filter_brain_region:
+        # should be checked by model_validator
+        assert in_brain_region.within_brain_region_brain_region_id  # noqa: S101
+        assert in_brain_region.within_brain_region_direction  # noqa: S101
         brain_region_cte = get_family_query(
-            brain_region_id=in_brain_region.within_brain_region_brain_region_id,  # type: ignore[reportGeneralTypeIssues]
-            direction=in_brain_region.get_direction(),
+            brain_region_id=in_brain_region.within_brain_region_brain_region_id,
+            direction=in_brain_region.within_brain_region_direction,
         )
 
         for et in entity_types:

--- a/docs/API.md
+++ b/docs/API.md
@@ -261,7 +261,6 @@ This is inefficient.
 Instead, one can use the following query parameters:
 
 ```
-    within_brain_region_hierarchy_id: uuid.UUID | None = None
     within_brain_region_brain_region_id: uuid.UUID | None = None
     within_brain_region_direction: [ascendants, descendants, ascendants_and_descendants]
 ```
@@ -280,7 +279,9 @@ For example, in the following, if `RegionA-1` is the target region, all the outl
 ![Tree showing semantics of ascendants and descendants](within-search-ascendants-and-descendants.png)
 
 Only the `within_brain_region_brain_region_id` and `within_brain_region_direction` query parameters are required.
-If `within_brain_region_hierarchy_id` is included, it is checked against the `within_brain_region_brain_region_id` to make sure they refer to the same hierarchy.
+
+Note: If `within_brain_region_hierarchy_id` is included, it is not an error, but it is not checked to be correct against `within_brain_region_brain_region_id`.
+See: https://github.com/openbraininstitute/entitycore/issues/567
 
 # Brain Atlas:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,7 +267,7 @@ Instead, one can use the following query parameters:
 ```
 
 ```
-GET /cell-morphology?within_brain_region_hierarchy_id=3f41b5b5-4b62-40da-a645-eef27c6d07e3&within_brain_region_brain_region_id=ff004978-e3a2-4249-adab-f3d253e4bdd3
+GET /cell-morphology?within_brain_region_direction=ascendants_and_descendants&within_brain_region_brain_region_id=ff004978-e3a2-4249-adab-f3d253e4bdd3
 ```
 
 In other words, the name of the hierarchy, and the id which will be recursively included:
@@ -279,12 +279,8 @@ For example, in the following, if `RegionA-1` is the target region, all the outl
 
 ![Tree showing semantics of ascendants and descendants](within-search-ascendants-and-descendants.png)
 
-
-Originally, there was a boolean: `within_brain_region_ascendants: bool = False`.
-If `within_brain_region_direction` is included, it overrides `within_brain_region_ascendants`.
-Otherwise, `within_brain_region_direction` is used, with the behavior that `within_brain_region_ascendants=True` is equivalent to `within_brain_region_direction=ascendants`, and `within_brain_region_ascendants=True`is equivalent to `within_brain_region_direction=descendants`.
-This will be deprecated.
-
+Only the `within_brain_region_brain_region_id` and `within_brain_region_direction` query parameters are required.
+If `within_brain_region_hierarchy_id` is included, it is checked against the `within_brain_region_brain_region_id` to make sure they refer to the same hierarchy.
 
 # Brain Atlas:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -282,6 +282,7 @@ Only the `within_brain_region_brain_region_id` and `within_brain_region_directio
 
 Note: If `within_brain_region_hierarchy_id` is included, it is not an error, but it is not checked to be correct against `within_brain_region_brain_region_id`.
 See: https://github.com/openbraininstitute/entitycore/issues/567
+It will be deprecated.
 
 # Brain Atlas:
 

--- a/tests/test_brain_region.py
+++ b/tests/test_brain_region.py
@@ -398,6 +398,22 @@ def test_family_queries(db, client, subject_id, person_id, species_id):
         params={"within_brain_region_hierarchy_id": str(hierarchy_name0.id)},
     )
 
+    # only `within_brain_region_brain_region_id`, missing `within_brain_region_direction`
+    utils.assert_request(
+        client.get,
+        url="/cell-morphology",
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        params={"within_brain_region_brain_region_id": str(brain_regions1["RegionA"].id)},
+    )
+
+    # only `within_brain_region_direction`, missing `within_brain_region_brain_region_id`
+    utils.assert_request(
+        client.get,
+        url="/cell-morphology",
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        params={"within_brain_region_direction": "ascendants"},
+    )
+
     # mismatched `within_brain_region_hierarchy_id` and
     utils.assert_request(
         client.get,

--- a/tests/test_brain_region.py
+++ b/tests/test_brain_region.py
@@ -394,8 +394,18 @@ def test_family_queries(db, client, subject_id, person_id, species_id):
     utils.assert_request(
         client.get,
         url="/cell-morphology",
-        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         params={"within_brain_region_hierarchy_id": str(hierarchy_name0.id)},
+    )
+
+    # superfluous `within_brain_region_hierarchy_id` and
+    utils.assert_request(
+        client.get,
+        url="/cell-morphology",
+        params={
+            "within_brain_region_hierarchy_id": str(hierarchy_name0.id),
+            "within_brain_region_direction": "ascendants",
+            "within_brain_region_brain_region_id": str(brain_regions1["RegionA"].id),
+        },
     )
 
     # only `within_brain_region_brain_region_id`, missing `within_brain_region_direction`
@@ -412,18 +422,6 @@ def test_family_queries(db, client, subject_id, person_id, species_id):
         url="/cell-morphology",
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         params={"within_brain_region_direction": "ascendants"},
-    )
-
-    # mismatched `within_brain_region_hierarchy_id` and
-    utils.assert_request(
-        client.get,
-        url="/cell-morphology",
-        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-        params={
-            "within_brain_region_hierarchy_id": str(hierarchy_name0.id),
-            "within_brain_region_direction": "ascendants",
-            "within_brain_region_brain_region_id": str(brain_regions1["RegionA"].id),
-        },
     )
 
 

--- a/tests/test_brain_region.py
+++ b/tests/test_brain_region.py
@@ -1,4 +1,5 @@
 import itertools as it
+from http import HTTPStatus
 from typing import get_type_hints
 from unittest.mock import ANY
 
@@ -304,21 +305,19 @@ def test_family_queries(db, client, subject_id, person_id, species_id):
         )
     assert len(client.get("/cell-morphology").json()["data"]) == 4 + 11
 
-    def get_response(hier, acronym, ascendants=False, direction=None, params=None):  # noqa: FBT002
-        hierarchy_id = hierarchy_name0.id if hier == "hier0" else hierarchy_name1.id
+    def get_response(hier, acronym, direction=None, params=None):
         brain_region_id = (
             brain_regions0[acronym].id if hier == "hier0" else brain_regions1[acronym].id
         )
 
         params = (params or {}) | {
-            "within_brain_region_hierarchy_id": hierarchy_id,
             "within_brain_region_brain_region_id": brain_region_id,
-            "within_brain_region_ascendants": ascendants,
         }
-        if direction is not None:
-            params["within_brain_region_direction"] = direction
+        params["within_brain_region_direction"] = direction
 
-        return client.get("/cell-morphology", params=params).json()["data"]
+        return utils.assert_request(client.get, url="/cell-morphology", params=params).json()[
+            "data"
+        ]
 
     for direction, region, expected in (
         ("descendants", "root", 4),
@@ -336,10 +335,6 @@ def test_family_queries(db, client, subject_id, person_id, species_id):
     ):
         response = get_response("hier0", region, direction=direction)
         assert len(response) == expected
-        if direction != "ascendants_and_descendants":
-            ascendants = direction == "ascendants"
-            legacy = get_response("hier0", region, ascendants=ascendants)
-            assert len(legacy) == expected
 
     for direction, region, expected in (
         ("descendants", "root", 11),
@@ -394,6 +389,26 @@ def test_family_queries(db, client, subject_id, person_id, species_id):
         params={"page_size": "2"},
     )
     assert len(response) == 2
+
+    # only `within_brain_region_hierarchy_id`
+    utils.assert_request(
+        client.get,
+        url="/cell-morphology",
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        params={"within_brain_region_hierarchy_id": str(hierarchy_name0.id)},
+    )
+
+    # mismatched `within_brain_region_hierarchy_id` and
+    utils.assert_request(
+        client.get,
+        url="/cell-morphology",
+        expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        params={
+            "within_brain_region_hierarchy_id": str(hierarchy_name0.id),
+            "within_brain_region_direction": "ascendants",
+            "within_brain_region_brain_region_id": str(brain_regions1["RegionA"].id),
+        },
+    )
 
 
 def test_InBrainRegionDep():

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -205,7 +205,7 @@ def test_count_entities_by_type_with_brain_region_filter(
             "types": "cell_morphology",
             "within_brain_region_hierarchy_id": str(brain_region_hierarchy_id),
             "within_brain_region_brain_region_id": str(region1.id),
-            "within_brain_region_ascendants": False,
+            "within_brain_region_direction": "descendants",
         },
     )
     data = response.json()


### PR DESCRIPTION
* as agreed in: https://github.com/openbraininstitute/entitycore/issues/567
* `within_brain_region_hierarchy_id` isn't required any more; if it's included it is checked to make sure it matches `within_brain_region_brain_region_id`
* remove deprecated `within_brain_region_ascendants`