### PR TITLE
Remove filter by species_id__in

### DIFF
--- a/app/filters/species.py
+++ b/app/filters/species.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Annotated
 
 from fastapi_filter import with_prefix
@@ -49,6 +48,5 @@ NestedStrainFilterDep = FilterDepends(with_prefix("strain", NestedStrainFilter))
 
 
 class SpeciesFilterMixin:
-    species_id__in: list[uuid.UUID] | None = None
     species: Annotated[NestedSpeciesFilter | None, NestedSpeciesFilterDep] = None
     strain: Annotated[NestedStrainFilter | None, NestedStrainFilterDep] = None


### PR DESCRIPTION
The correct parameter is `species__id__in`, already included with the species subfilter, and not `species_id__in`