### PR TITLE
Add creation_date to stable sorting

### DIFF
--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -329,9 +329,11 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
     if with_in_brain_region:
         filter_query = with_in_brain_region(filter_query, db_model_class)
 
+    ensure_stable_sorting = [db_model_class.creation_date.desc(), db_model_class.id]
+
     data_query = (
         filter_model.sort(filter_query, aliases=aliases)
-        .order_by(db_model_class.id)
+        .order_by(*ensure_stable_sorting)
         .with_only_columns(db_model_class)
         .offset(pagination_request.offset)
         .limit(pagination_request.page_size)
@@ -345,7 +347,7 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
         # Order by L2 distance first, then by ID to guarantee uniqueness
         data_query = data_query.order_by(
             db_model_class.embedding.l2_distance(embedding),  # type: ignore[attr-defined]
-            db_model_class.id,
+            *ensure_stable_sorting,
         )
 
     if apply_data_query_operations:


### PR DESCRIPTION
Stable sorting in read_many endpoints is already ensured by adding the `id` to the order by clause.
This PR adds `creation_date` because it's more meaningful for the user in most cases.
However, sorting by id is preserved since creation_date isn't granted to be unique.

I didn't notice significant changes in the execution time of the query: around 50-55 ms after the first execution in staging with the queries below, resulting from a call to `cell-morphology?page=100&page_size=30&order_by=name`

Before:
```sql
SELECT entity.type, entity.authorized_project_id, entity.authorized_public, entity.legacy_id, entity.legacy_self, cell_morphology.id, scientific_artifact.id AS id_1, entity.id AS id_2, entity.created_by_id, entity.updated_by_id, entity.creation_date, entity.update_date, scientific_artifact.experiment_date, scientific_artifact.contact_email, scientific_artifact.published_in, scientific_artifact.notice_text, scientific_artifact.subject_id, scientific_artifact.brain_region_id, scientific_artifact.license_id, cell_morphology.location, cell_morphology.repair_pipeline_state, cell_morphology.cell_morphology_protocol_id, cell_morphology.has_segmented_spines, cell_morphology.name, cell_morphology.description, cell_morphology.description_vector, entity_1.type AS type_1, entity_1.authorized_project_id AS authorized_project_id_1, entity_1.authorized_public AS authorized_public_1, entity_1.legacy_id AS legacy_id_1, entity_1.legacy_self AS legacy_self_1, cell_morphology_protocol_1.id AS id_3, entity_1.id AS id_4, entity_1.created_by_id AS created_by_id_1, entity_1.updated_by_id AS updated_by_id_1, entity_1.creation_date AS creation_date_1, entity_1.update_date AS update_date_1, cell_morphology_protocol_1.protocol_document, cell_morphology_protocol_1.protocol_design, cell_morphology_protocol_1.generation_type, cell_morphology_protocol_1.name AS name_1, cell_morphology_protocol_1.description AS description_1, cell_morphology_protocol_1.description_vector AS description_vector_1, cell_morphology_protocol_1.staining_type, cell_morphology_protocol_1.slicing_thickness, cell_morphology_protocol_1.slicing_direction, cell_morphology_protocol_1.magnification, cell_morphology_protocol_1.tissue_shrinkage, cell_morphology_protocol_1.corrected_for_shrinkage, cell_morphology_protocol_1.method_type, mtype_class_1.pref_label, mtype_class_1.definition, mtype_class_1.alt_label, mtype_class_1.legacy_id AS legacy_id_2, mtype_class_1.legacy_self AS legacy_self_2, mtype_class_1.id AS id_5, mtype_class_1.created_by_id AS created_by_id_2, mtype_class_1.updated_by_id AS updated_by_id_2, mtype_class_1.creation_date AS creation_date_2, mtype_class_1.update_date AS update_date_2, species_1.name AS name_2, species_1.taxonomy_id, species_1.id AS id_6, species_1.created_by_id AS created_by_id_3, species_1.updated_by_id AS updated_by_id_3, species_1.creation_date AS creation_date_3, species_1.update_date AS update_date_3, strain_1.name AS name_3, strain_1.taxonomy_id AS taxonomy_id_1, strain_1.species_id, strain_1.id AS id_7, strain_1.created_by_id AS created_by_id_4, strain_1.updated_by_id AS updated_by_id_4, strain_1.creation_date AS creation_date_4, strain_1.update_date AS update_date_4, entity_2.type AS type_2, entity_2.authorized_project_id AS authorized_project_id_2, entity_2.authorized_public AS authorized_public_2, entity_2.legacy_id AS legacy_id_3, entity_2.legacy_self AS legacy_self_3, subject_1.id AS id_8, entity_2.id AS id_9, entity_2.created_by_id AS created_by_id_5, entity_2.updated_by_id AS updated_by_id_5, entity_2.creation_date AS creation_date_5, entity_2.update_date AS update_date_5, subject_1.age_value, subject_1.age_min, subject_1.age_max, subject_1.age_period, subject_1.sex, subject_1.weight, subject_1.name AS name_4, subject_1.description AS description_2, subject_1.description_vector AS description_vector_2, subject_1.species_id AS species_id_1, subject_1.strain_id, brain_region_1.annotation_value, brain_region_1.name AS name_5, brain_region_1.acronym, brain_region_1.color_hex_triplet, brain_region_1.parent_structure_id, brain_region_1.hierarchy_id, brain_region_1.id AS id_10, brain_region_1.created_by_id AS created_by_id_6, brain_region_1.updated_by_id AS updated_by_id_6, brain_region_1.creation_date AS creation_date_6, brain_region_1.update_date AS update_date_6, license_1.name AS name_6, license_1.label, license_1.legacy_id AS legacy_id_4, license_1.legacy_self AS legacy_self_4, license_1.id AS id_11, license_1.created_by_id AS created_by_id_7, license_1.updated_by_id AS updated_by_id_7, license_1.creation_date AS creation_date_7, license_1.update_date AS update_date_7, license_1.description AS description_3, license_1.description_vector AS description_vector_3, agent_1.type AS type_3, agent_1.pref_label AS pref_label_1, agent_1.legacy_id AS legacy_id_5, agent_1.legacy_self AS legacy_self_5, agent_1.id AS id_12, agent_1.created_by_id AS created_by_id_8, agent_1.updated_by_id AS updated_by_id_8, agent_1.creation_date AS creation_date_8, agent_1.update_date AS update_date_8, agent_2.type AS type_4, agent_2.pref_label AS pref_label_2, agent_2.legacy_id AS legacy_id_6, agent_2.legacy_self AS legacy_self_6, agent_2.id AS id_13, agent_2.created_by_id AS created_by_id_9, agent_2.updated_by_id AS updated_by_id_9, agent_2.creation_date AS creation_date_9, agent_2.update_date AS update_date_9 
	FROM entity JOIN scientific_artifact ON entity.id = scientific_artifact.id JOIN cell_morphology ON scientific_artifact.id = cell_morphology.id JOIN (SELECT cell_morphology.id AS id, cell_morphology.name AS _s0, cell_morphology.id AS _s1 
	FROM entity JOIN scientific_artifact ON entity.id = scientific_artifact.id JOIN cell_morphology ON scientific_artifact.id = cell_morphology.id 
	WHERE entity.authorized_public = true ORDER BY cell_morphology.name ASC, cell_morphology.id 
	 LIMIT 30 OFFSET 2970) AS anon_1 ON anon_1.id = cell_morphology.id LEFT OUTER JOIN (entity AS entity_1 JOIN cell_morphology_protocol AS cell_morphology_protocol_1 ON entity_1.id = cell_morphology_protocol_1.id) ON cell_morphology_protocol_1.id = cell_morphology.cell_morphology_protocol_id LEFT OUTER JOIN (mtype_classification AS mtype_classification_1 JOIN mtype_class AS mtype_class_1 ON mtype_class_1.id = mtype_classification_1.mtype_class_id) ON cell_morphology.id = mtype_classification_1.entity_id LEFT OUTER JOIN (entity AS entity_2 JOIN subject AS subject_1 ON entity_2.id = subject_1.id) ON subject_1.id = scientific_artifact.subject_id LEFT OUTER JOIN species AS species_1 ON species_1.id = subject_1.species_id LEFT OUTER JOIN strain AS strain_1 ON subject_1.strain_id = strain_1.id JOIN brain_region AS brain_region_1 ON brain_region_1.id = scientific_artifact.brain_region_id LEFT OUTER JOIN license AS license_1 ON license_1.id = scientific_artifact.license_id JOIN agent AS agent_1 ON entity.created_by_id = agent_1.id JOIN agent AS agent_2 ON entity.updated_by_id = agent_2.id ORDER BY anon_1._s0 ASC, anon_1._s1, mtype_class_1.pref_label
```

After
```sql
SELECT entity.type, entity.authorized_project_id, entity.authorized_public, entity.legacy_id, entity.legacy_self, cell_morphology.id, scientific_artifact.id AS id_1, entity.id AS id_2, entity.created_by_id, entity.updated_by_id, entity.creation_date, entity.update_date, scientific_artifact.experiment_date, scientific_artifact.contact_email, scientific_artifact.published_in, scientific_artifact.notice_text, scientific_artifact.subject_id, scientific_artifact.brain_region_id, scientific_artifact.license_id, cell_morphology.location, cell_morphology.repair_pipeline_state, cell_morphology.cell_morphology_protocol_id, cell_morphology.has_segmented_spines, cell_morphology.name, cell_morphology.description, cell_morphology.description_vector, entity_1.type AS type_1, entity_1.authorized_project_id AS authorized_project_id_1, entity_1.authorized_public AS authorized_public_1, entity_1.legacy_id AS legacy_id_1, entity_1.legacy_self AS legacy_self_1, cell_morphology_protocol_1.id AS id_3, entity_1.id AS id_4, entity_1.created_by_id AS created_by_id_1, entity_1.updated_by_id AS updated_by_id_1, entity_1.creation_date AS creation_date_1, entity_1.update_date AS update_date_1, cell_morphology_protocol_1.protocol_document, cell_morphology_protocol_1.protocol_design, cell_morphology_protocol_1.generation_type, cell_morphology_protocol_1.name AS name_1, cell_morphology_protocol_1.description AS description_1, cell_morphology_protocol_1.description_vector AS description_vector_1, cell_morphology_protocol_1.staining_type, cell_morphology_protocol_1.slicing_thickness, cell_morphology_protocol_1.slicing_direction, cell_morphology_protocol_1.magnification, cell_morphology_protocol_1.tissue_shrinkage, cell_morphology_protocol_1.corrected_for_shrinkage, cell_morphology_protocol_1.method_type, mtype_class_1.pref_label, mtype_class_1.definition, mtype_class_1.alt_label, mtype_class_1.legacy_id AS legacy_id_2, mtype_class_1.legacy_self AS legacy_self_2, mtype_class_1.id AS id_5, mtype_class_1.created_by_id AS created_by_id_2, mtype_class_1.updated_by_id AS updated_by_id_2, mtype_class_1.creation_date AS creation_date_2, mtype_class_1.update_date AS update_date_2, species_1.name AS name_2, species_1.taxonomy_id, species_1.id AS id_6, species_1.created_by_id AS created_by_id_3, species_1.updated_by_id AS updated_by_id_3, species_1.creation_date AS creation_date_3, species_1.update_date AS update_date_3, strain_1.name AS name_3, strain_1.taxonomy_id AS taxonomy_id_1, strain_1.species_id, strain_1.id AS id_7, strain_1.created_by_id AS created_by_id_4, strain_1.updated_by_id AS updated_by_id_4, strain_1.creation_date AS creation_date_4, strain_1.update_date AS update_date_4, entity_2.type AS type_2, entity_2.authorized_project_id AS authorized_project_id_2, entity_2.authorized_public AS authorized_public_2, entity_2.legacy_id AS legacy_id_3, entity_2.legacy_self AS legacy_self_3, subject_1.id AS id_8, entity_2.id AS id_9, entity_2.created_by_id AS created_by_id_5, entity_2.updated_by_id AS updated_by_id_5, entity_2.creation_date AS creation_date_5, entity_2.update_date AS update_date_5, subject_1.age_value, subject_1.age_min, subject_1.age_max, subject_1.age_period, subject_1.sex, subject_1.weight, subject_1.name AS name_4, subject_1.description AS description_2, subject_1.description_vector AS description_vector_2, subject_1.species_id AS species_id_1, subject_1.strain_id, brain_region_1.annotation_value, brain_region_1.name AS name_5, brain_region_1.acronym, brain_region_1.color_hex_triplet, brain_region_1.parent_structure_id, brain_region_1.hierarchy_id, brain_region_1.id AS id_10, brain_region_1.created_by_id AS created_by_id_6, brain_region_1.updated_by_id AS updated_by_id_6, brain_region_1.creation_date AS creation_date_6, brain_region_1.update_date AS update_date_6, license_1.name AS name_6, license_1.label, license_1.legacy_id AS legacy_id_4, license_1.legacy_self AS legacy_self_4, license_1.id AS id_11, license_1.created_by_id AS created_by_id_7, license_1.updated_by_id AS updated_by_id_7, license_1.creation_date AS creation_date_7, license_1.update_date AS update_date_7, license_1.description AS description_3, license_1.description_vector AS description_vector_3, agent_1.type AS type_3, agent_1.pref_label AS pref_label_1, agent_1.legacy_id AS legacy_id_5, agent_1.legacy_self AS legacy_self_5, agent_1.id AS id_12, agent_1.created_by_id AS created_by_id_8, agent_1.updated_by_id AS updated_by_id_8, agent_1.creation_date AS creation_date_8, agent_1.update_date AS update_date_8, agent_2.type AS type_4, agent_2.pref_label AS pref_label_2, agent_2.legacy_id AS legacy_id_6, agent_2.legacy_self AS legacy_self_6, agent_2.id AS id_13, agent_2.created_by_id AS created_by_id_9, agent_2.updated_by_id AS updated_by_id_9, agent_2.creation_date AS creation_date_9, agent_2.update_date AS update_date_9 
	FROM entity JOIN scientific_artifact ON entity.id = scientific_artifact.id JOIN cell_morphology ON scientific_artifact.id = cell_morphology.id JOIN (SELECT cell_morphology.id AS id, cell_morphology.name AS _s0, entity.creation_date AS _s1, cell_morphology.id AS _s2 
	FROM entity JOIN scientific_artifact ON entity.id = scientific_artifact.id JOIN cell_morphology ON scientific_artifact.id = cell_morphology.id 
	WHERE entity.authorized_public = true ORDER BY cell_morphology.name ASC, entity.creation_date DESC, cell_morphology.id 
	 LIMIT 30 OFFSET 2970) AS anon_1 ON anon_1.id = cell_morphology.id LEFT OUTER JOIN (entity AS entity_1 JOIN cell_morphology_protocol AS cell_morphology_protocol_1 ON entity_1.id = cell_morphology_protocol_1.id) ON cell_morphology_protocol_1.id = cell_morphology.cell_morphology_protocol_id LEFT OUTER JOIN (mtype_classification AS mtype_classification_1 JOIN mtype_class AS mtype_class_1 ON mtype_class_1.id = mtype_classification_1.mtype_class_id) ON cell_morphology.id = mtype_classification_1.entity_id LEFT OUTER JOIN (entity AS entity_2 JOIN subject AS subject_1 ON entity_2.id = subject_1.id) ON subject_1.id = scientific_artifact.subject_id LEFT OUTER JOIN species AS species_1 ON species_1.id = subject_1.species_id LEFT OUTER JOIN strain AS strain_1 ON subject_1.strain_id = strain_1.id JOIN brain_region AS brain_region_1 ON brain_region_1.id = scientific_artifact.brain_region_id LEFT OUTER JOIN license AS license_1 ON license_1.id = scientific_artifact.license_id JOIN agent AS agent_1 ON entity.created_by_id = agent_1.id JOIN agent AS agent_2 ON entity.updated_by_id = agent_2.id ORDER BY anon_1._s0 ASC, anon_1._s1 DESC, anon_1._s2, mtype_class_1.pref_label
````

cc @darshanmandge 