### PR TITLE
Add sorting by memodel mtype and etype to single_neuron_synaptome

### DIFF
--- a/app/filters/base.py
+++ b/app/filters/base.py
@@ -187,7 +187,8 @@ class CustomFilter[T: DeclarativeBase](Filter):
             if NESTED_SEPARATOR in field_name:
                 filter_name, *parts, field_name = field_name.split(NESTED_SEPARATOR)  # noqa: PLW2901
 
-                model = getattr(self, filter_name).Constants.model
+                nested_filter = getattr(self, filter_name)
+                model = nested_filter.Constants.model
 
                 if model in aliases:
                     model_or_fields_dict = aliases[model]
@@ -197,7 +198,20 @@ class CustomFilter[T: DeclarativeBase](Filter):
                         model = model_or_fields_dict
 
                 for part in parts:
-                    model = getattr(model, part).property.mapper.class_
+                    # Resolve each intermediate part of the ordering field
+                    # (e.g. "etype" in "me_model__etype__pref_label").
+                    # Prefer the nested filter field name (e.g. NestedMEModelFilter.etype)
+                    # so that ordering and filtering use the same names, even when
+                    # the filter name differs from the DB relationship name
+                    # (e.g. filter "etype" vs relationship "etypes").
+                    # Fall back to the SQLAlchemy relationship for parts that
+                    # don't correspond to any nested filter field.
+                    nested_attr = getattr(nested_filter, part, None)
+                    if isinstance(nested_attr, CustomFilter):
+                        nested_filter = nested_attr
+                        model = nested_filter.Constants.model
+                    else:
+                        model = getattr(model, part).property.mapper.class_
 
             order_by_field = getattr(model, field_name)
 

--- a/app/filters/base.py
+++ b/app/filters/base.py
@@ -165,8 +165,12 @@ class CustomFilter[T: DeclarativeBase](Filter):
     def sort(self, query: Select[tuple[T]], aliases: Aliases | None = None) -> Select[tuple[T]]:  # type:ignore[override]
         """Sort query taking into account nested fields and aliases.
 
-        Sorting in nested field is applied by spliting the nested field name from A__B__name to
-        [A, B, name] and sorting with the respective nested model alias name.
+        Nested ordering fields (e.g. "me_model__etype__pref_label") are split into
+        [filter_name, *intermediate_parts, field_name]. The first element identifies the
+        top-level nested filter, and each intermediate part must correspond to a nested
+        CustomFilter field on the previous filter, so that ordering and filtering use the
+        same names even when the filter name differs from the DB relationship name
+        (e.g. filter "etype" vs relationship "etypes").
 
         Aliases are required here because the ORDER BY section must refer to the correct aliased
         model that is also used in the filtering part of the query.
@@ -174,6 +178,7 @@ class CustomFilter[T: DeclarativeBase](Filter):
         Ordering value examples:
             - creation_date
             - subject__species__name
+            - me_model__etype__pref_label
         """
         if aliases is None:
             aliases = {}
@@ -198,20 +203,13 @@ class CustomFilter[T: DeclarativeBase](Filter):
                         model = model_or_fields_dict
 
                 for part in parts:
-                    # Resolve each intermediate part of the ordering field
-                    # (e.g. "etype" in "me_model__etype__pref_label").
-                    # Prefer the nested filter field name (e.g. NestedMEModelFilter.etype)
-                    # so that ordering and filtering use the same names, even when
-                    # the filter name differs from the DB relationship name
-                    # (e.g. filter "etype" vs relationship "etypes").
-                    # Fall back to the SQLAlchemy relationship for parts that
-                    # don't correspond to any nested filter field.
                     nested_attr = getattr(nested_filter, part, None)
                     if isinstance(nested_attr, CustomFilter):
                         nested_filter = nested_attr
                         model = nested_filter.Constants.model
                     else:
-                        model = getattr(model, part).property.mapper.class_
+                        msg = f"Unsupported ordering part {part!r} in {type(nested_filter).__name__}"
+                        raise ValueError(msg)
 
             order_by_field = getattr(model, field_name)
 

--- a/app/filters/base.py
+++ b/app/filters/base.py
@@ -166,10 +166,9 @@ class CustomFilter[T: DeclarativeBase](Filter):
         """Sort query taking into account nested fields and aliases.
 
         Nested ordering fields (e.g. "me_model__etype__pref_label") are split into
-        [filter_name, *intermediate_parts, field_name]. The first element identifies the
-        top-level nested filter, and each intermediate part must correspond to a nested
-        CustomFilter field on the previous filter, so that ordering and filtering use the
-        same names even when the filter name differs from the DB relationship name
+        [*parts, field_name]. Each part must correspond to a nested CustomFilter field
+        on the previous filter (starting from self), so that ordering and filtering use
+        the same names even when the filter name differs from the DB relationship name
         (e.g. filter "etype" vs relationship "etypes").
 
         Aliases are required here because the ORDER BY section must refer to the correct aliased
@@ -190,28 +189,23 @@ class CustomFilter[T: DeclarativeBase](Filter):
             model = self.Constants.model
 
             if NESTED_SEPARATOR in field_name:
-                filter_name, *parts, field_name = field_name.split(NESTED_SEPARATOR)  # noqa: PLW2901
-
-                nested_filter = getattr(self, filter_name)
-                model = nested_filter.Constants.model
-
-                if model in aliases:
-                    model_or_fields_dict = aliases[model]
-                    if isinstance(model_or_fields_dict, dict):
-                        model = model_or_fields_dict.get(filter_name, model)
-                    else:
-                        model = model_or_fields_dict
+                original_field_name = field_name
+                *parts, field_name = field_name.split(NESTED_SEPARATOR)  # noqa: PLW2901
+                nested_filter = self
 
                 for part in parts:
-                    nested_attr = getattr(nested_filter, part, None)
-                    if isinstance(nested_attr, CustomFilter):
-                        nested_filter = nested_attr
-                        model = nested_filter.Constants.model
-                    else:
-                        msg = (
-                            f"Unsupported ordering part {part!r} in {type(nested_filter).__name__}"
-                        )
+                    nested_filter = getattr(nested_filter, part, None)
+                    if not isinstance(nested_filter, CustomFilter):
+                        msg = f"Unsupported ordering part {part!r} in {original_field_name!r}"
                         raise ValueError(msg)  # noqa: TRY004
+                    model = nested_filter.Constants.model
+
+                    if model in aliases:
+                        model_or_fields_dict = aliases[model]
+                        if isinstance(model_or_fields_dict, dict):
+                            model = model_or_fields_dict.get(part, model)
+                        else:
+                            model = model_or_fields_dict
 
             order_by_field = getattr(model, field_name)
 

--- a/app/filters/base.py
+++ b/app/filters/base.py
@@ -208,8 +208,10 @@ class CustomFilter[T: DeclarativeBase](Filter):
                         nested_filter = nested_attr
                         model = nested_filter.Constants.model
                     else:
-                        msg = f"Unsupported ordering part {part!r} in {type(nested_filter).__name__}"
-                        raise ValueError(msg)
+                        msg = (
+                            f"Unsupported ordering part {part!r} in {type(nested_filter).__name__}"
+                        )
+                        raise ValueError(msg)  # noqa: TRY004
 
             order_by_field = getattr(model, field_name)
 

--- a/app/filters/single_neuron_synaptome.py
+++ b/app/filters/single_neuron_synaptome.py
@@ -54,6 +54,8 @@ class SingleNeuronSynaptomeFilter(
             "brain_region__name",
             "brain_region__acronym",
             "created_by__pref_label",
+            "me_model__etype__pref_label",
+            "me_model__mtype__pref_label",
         ]
 
 

--- a/app/queries/factory.py
+++ b/app/queries/factory.py
@@ -129,6 +129,8 @@ def query_params_factory[I: Identifiable](
         },
         "emodel": {"id": emodel_alias.id, "label": emodel_alias.name},
         "me_model": {"id": me_model_alias.id, "label": me_model_alias.name},
+        "me_model.etype": {"id": ETypeClass.id, "label": ETypeClass.pref_label},
+        "me_model.mtype": {"id": MTypeClass.id, "label": MTypeClass.pref_label},
         "synaptome": {"id": synaptome_alias.id, "label": synaptome_alias.name},
         "created_by": {
             "id": created_by_alias.id,
@@ -186,6 +188,12 @@ def query_params_factory[I: Identifiable](
         "me_model": lambda q: q.join(
             me_model_alias, db_model_class.me_model_id == me_model_alias.id
         ),
+        "me_model.etype": lambda q: q.join(
+            ETypeClassification, ETypeClassification.entity_id == me_model_alias.id
+        ).join(ETypeClass, ETypeClass.id == ETypeClassification.etype_class_id),
+        "me_model.mtype": lambda q: q.join(
+            MTypeClassification, MTypeClassification.entity_id == me_model_alias.id
+        ).join(MTypeClass, MTypeClass.id == MTypeClassification.mtype_class_id),
         "synaptome": lambda q: q.join(
             synaptome_alias, db_model_class.synaptome_id == synaptome_alias.id
         ),

--- a/app/service/single_neuron_synaptome.py
+++ b/app/service/single_neuron_synaptome.py
@@ -152,10 +152,12 @@ def _read_many(
     }
     facet_keys = filter_keys = [
         "brain_region",
-        "me_model",
         "created_by",
         "updated_by",
         "contribution",
+        "me_model",
+        "me_model.etype",  # match NestedMEModelFilter.etype for filtering by me_model__etype__*
+        "me_model.mtype",  # match NestedMEModelFilter.mtype for filtering by me_model__mtype__*
     ]
     name_to_facet_query_params, filter_joins = query_params_factory(
         db_model_class=SingleNeuronSynaptome,

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -92,5 +92,8 @@ def test_sort_unsupported_nested_ordering_part():
         order_by=["subject__bad_part__name"],
         subject=NestedSubjectFilter(),
     )
-    with pytest.raises(ValueError, match="Unsupported ordering part 'bad_part'"):
+    with pytest.raises(
+        ValueError,
+        match="Unsupported ordering part 'bad_part' in 'subject__bad_part__name'",
+    ):
         invalid_filter.sort(sa.select(CellMorphology))

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,4 +1,9 @@
+import pytest
+import sqlalchemy as sa
+
 from app.db.model import CellMorphology, License
+from app.filters.cell_morphology import CellMorphologyFilter
+from app.filters.subject import NestedSubjectFilter
 
 from tests.utils import PROJECT_ID, add_all_db, check_sort_by_field
 
@@ -77,3 +82,15 @@ def test_cell_morphology_ordering(db, client, subject_id, license_id, brain_regi
     data = response.json()["data"]
     assert len(data) == count // 2
     check_sort_by_field(data, "name", how="descending")
+
+
+def test_sort_unsupported_nested_ordering_part():
+    """Test that sorting by a nested field with an unsupported intermediate part raises an error."""
+
+    # Use model_construct to bypass the ordering_model_fields validator
+    invalid_filter = CellMorphologyFilter.model_construct(
+        order_by=["subject__bad_part__name"],
+        subject=NestedSubjectFilter(),
+    )
+    with pytest.raises(ValueError, match="Unsupported ordering part 'bad_part'"):
+        invalid_filter.sort(sa.select(CellMorphology))

--- a/tests/test_single_neuron_synaptome.py
+++ b/tests/test_single_neuron_synaptome.py
@@ -1,4 +1,5 @@
 import itertools as it
+from unittest.mock import ANY
 
 import pytest
 
@@ -346,6 +347,22 @@ def test_facets(db, client, faceted_ids):
         ],
         "updated_by": [
             {"id": str(agent.id), "label": agent.pref_label, "count": 4, "type": agent.type}
+        ],
+        "etype": [
+            {
+                "count": 4,
+                "id": ANY,
+                "label": "etype-emodel-0",
+                "type": "me_model.etype",
+            },
+        ],
+        "mtype": [
+            {
+                "count": 4,
+                "id": ANY,
+                "label": "m1",
+                "type": "me_model.mtype",
+            },
         ],
     }
 


### PR DESCRIPTION
Examples:

```
http://127.0.0.1:8000/single-neuron-synaptome?order_by=me_model__etype__pref_label
http://127.0.0.1:8000/single-neuron-synaptome?me_model__etype__pref_label=AAA&order_by=me_model__etype__pref_label
```