### PR TITLE
Ensure unique name in cell_morphology_protocol

### DIFF
--- a/alembic/versions/20260420_182546_2f5c75357494_unique_cell_morpholy_protocol_name.py
+++ b/alembic/versions/20260420_182546_2f5c75357494_unique_cell_morpholy_protocol_name.py
@@ -1,0 +1,37 @@
+"""unique cell_morpholy_protocol name
+
+Revision ID: 2f5c75357494
+Revises: f4744cf2307b
+Create Date: 2026-04-20 18:25:46.370808
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from sqlalchemy import Text
+import app.db.types
+
+# revision identifiers, used by Alembic.
+revision: str = "2f5c75357494"
+down_revision: Union[str, None] = "f4744cf2307b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index(op.f("ix_cell_morphology_protocol_name"), table_name="cell_morphology_protocol")
+    # it can fail if there are multiple protocols with the same name
+    op.create_index(
+        op.f("ix_cell_morphology_protocol_name"), "cell_morphology_protocol", ["name"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_cell_morphology_protocol_name"), table_name="cell_morphology_protocol")
+    op.create_index(
+        op.f("ix_cell_morphology_protocol_name"), "cell_morphology_protocol", ["name"], unique=False
+    )

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -176,6 +176,11 @@ class NameDescriptionVectorMixin(Base):
         return super_table_args
 
 
+class UniqueNameDescriptionVectorMixin(NameDescriptionVectorMixin):
+    __abstract__ = True
+    name: Mapped[str] = mapped_column(index=True, unique=True)
+
+
 class EmbeddingMixin(Base):
     """Mixin class that provides an embedding field for vector similarity search.
 
@@ -801,7 +806,7 @@ class MeasurableEntityMixin:
         )
 
 
-class CellMorphologyProtocol(Entity, NameDescriptionVectorMixin):
+class CellMorphologyProtocol(Entity, UniqueNameDescriptionVectorMixin):
     __tablename__ = EntityType.cell_morphology_protocol.value
     id: Mapped[uuid.UUID] = mapped_column(ForeignKey("entity.id"), primary_key=True)
     protocol_document: Mapped[str | None]

--- a/scripts/export/build_database_archive.sh
+++ b/scripts/export/build_database_archive.sh
@@ -2,7 +2,7 @@
 # Automatically generated, do not edit!
 set -euo pipefail
 SCRIPT_VERSION="1"
-SCRIPT_DB_VERSION="f4744cf2307b"
+SCRIPT_DB_VERSION="2f5c75357494"
 echo "DB dump (version $SCRIPT_VERSION for db version $SCRIPT_DB_VERSION)"
 
 
@@ -269,7 +269,7 @@ install -m 755 /dev/stdin "$WORK_DIR/load.sh" <<'EOF_LOAD_SCRIPT'
 # Automatically generated, do not edit!
 set -euo pipefail
 SCRIPT_VERSION="1"
-SCRIPT_DB_VERSION="f4744cf2307b"
+SCRIPT_DB_VERSION="2f5c75357494"
 echo "DB load (version $SCRIPT_VERSION for db version $SCRIPT_DB_VERSION)"
 
 

--- a/tests/test_cell_morphology_protocol.py
+++ b/tests/test_cell_morphology_protocol.py
@@ -228,7 +228,7 @@ def test_read_many(clients, json_data):
         admin_route=ADMIN_ROUTE,
         clients=clients,
         # ensure that each protocol has a unique name
-        json_data_it=({**json_data, "name": f"{name}_{i}"} for i in itertools.count()),
+        json_data=({**json_data, "name": f"{name}_{i}"} for i in itertools.count()),
     )
 
 

--- a/tests/test_cell_morphology_protocol.py
+++ b/tests/test_cell_morphology_protocol.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pytest
 
 from app.db.model import (
@@ -13,6 +15,7 @@ from app.db.types import (
     ModifiedMorphologyMethodType,
     SlicingDirectionType,
 )
+from app.errors import ApiErrorCode
 from app.schemas.cell_morphology_protocol import (
     ComputationallySynthesizedCellMorphologyProtocolCreate,
     DigitalReconstructionCellMorphologyProtocolCreate,
@@ -140,6 +143,21 @@ def test_create_one(request, client, json_data_fixture):
     _assert_read_response(data, expected)
 
 
+@pytest.mark.usefixtures("model_id")  # ensure that the protocol already exists
+def test_create_one_duplicated_fails(client, json_data):
+    del json_data["type"]
+    data = assert_request(
+        client.post,
+        url=ROUTE,
+        json=json_data,
+        expected_status_code=409,
+    ).json()
+    assert data["error_code"] == ApiErrorCode.ENTITY_DUPLICATED
+    assert data["message"] == (
+        "DigitalReconstructionCellMorphologyProtocol already exists or breaks unique constraints"
+    )
+
+
 def test_update_one(clients, json_data_digital_reconstruction):
     def _req_compare(client, route, patch_data):
         data = assert_request(
@@ -204,11 +222,13 @@ def test_read_one(client, model_id, json_data):
 
 
 def test_read_many(clients, json_data):
+    name = json_data["name"]
     check_entity_read_many(
         route=ROUTE,
         admin_route=ADMIN_ROUTE,
         clients=clients,
-        json_data=json_data,
+        # ensure that each protocol has a unique name
+        json_data_it=({**json_data, "name": f"{name}_{i}"} for i in itertools.count()),
     )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1287,28 +1287,23 @@ def check_entity_read_many(
     route: str,
     admin_route: str,
     clients: ClientProxies,
-    json_data: dict | None = None,
-    json_data_it: Iterator[dict] | None = None,
+    json_data: dict | Iterator[dict],
 ):
-    if json_data_it is None:
-        assert json_data is not None
-        json_data_it = itertools.repeat(json_data)
-    else:
-        # json_data cannot be passed with json_data_it
-        assert json_data is None
+    if isinstance(json_data, dict):
+        json_data = itertools.repeat(json_data)
 
     # register entities with users in different projects
     u1_private = assert_request(
-        clients.user_1.post, url=route, json=next(json_data_it) | {"authorized_public": False}
+        clients.user_1.post, url=route, json=next(json_data) | {"authorized_public": False}
     ).json()
     u1_public = assert_request(
-        clients.user_1.post, url=route, json=next(json_data_it) | {"authorized_public": True}
+        clients.user_1.post, url=route, json=next(json_data) | {"authorized_public": True}
     ).json()
     u2_private = assert_request(
-        clients.user_2.post, url=route, json=next(json_data_it) | {"authorized_public": False}
+        clients.user_2.post, url=route, json=next(json_data) | {"authorized_public": False}
     ).json()
     u2_public = assert_request(
-        clients.user_2.post, url=route, json=next(json_data_it) | {"authorized_public": True}
+        clients.user_2.post, url=route, json=next(json_data) | {"authorized_public": True}
     ).json()
 
     def req(client, client_route, expected_status_code=200):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,10 @@
 import functools
+import itertools
 import json
 import operator
 import os
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import NamedTuple
@@ -1286,21 +1287,28 @@ def check_entity_read_many(
     route: str,
     admin_route: str,
     clients: ClientProxies,
-    json_data: dict,
+    json_data: dict | None = None,
+    json_data_it: Iterator[dict] | None = None,
 ):
+    if json_data_it is None:
+        assert json_data is not None
+        json_data_it = itertools.repeat(json_data)
+    else:
+        # json_data cannot be passed with json_data_it
+        assert json_data is None
 
     # register entities with users in different projects
     u1_private = assert_request(
-        clients.user_1.post, url=route, json=json_data | {"authorized_public": False}
+        clients.user_1.post, url=route, json=next(json_data_it) | {"authorized_public": False}
     ).json()
     u1_public = assert_request(
-        clients.user_1.post, url=route, json=json_data | {"authorized_public": True}
+        clients.user_1.post, url=route, json=next(json_data_it) | {"authorized_public": True}
     ).json()
     u2_private = assert_request(
-        clients.user_2.post, url=route, json=json_data | {"authorized_public": False}
+        clients.user_2.post, url=route, json=next(json_data_it) | {"authorized_public": False}
     ).json()
     u2_public = assert_request(
-        clients.user_2.post, url=route, json=json_data | {"authorized_public": True}
+        clients.user_2.post, url=route, json=next(json_data_it) | {"authorized_public": True}
     ).json()
 
     def req(client, client_route, expected_status_code=200):


### PR DESCRIPTION
Implements https://github.com/openbraininstitute/entitycore/issues/570

Since in staging and production there are protocols with the same name, it cannot be deployed until the records are fixed with one of these approaches (cc @dkeller9 for deciding):
- decide which protocol to keep, delete the other ones and potentially update the morphologies using them
- decide which protocol to keep, update the name of the other ones without deleting or updating morphologies
