### PR TITLE
Leverage pydantic unset functionality for update instead of custom NOT_SET

### DIFF
--- a/app/db/utils.py
+++ b/app/db/utils.py
@@ -18,7 +18,6 @@ from app.db.model import (
 )
 from app.db.types import CellMorphologyGenerationType, EntityType, ResourceType
 from app.logger import L
-from app.schemas.utils import NOT_SET
 
 PublishableBaseModel = Activity | Entity | ETypeClassification | MTypeClassification
 
@@ -149,12 +148,9 @@ def update_model[T: DeclarativeBase](model: T, data: dict) -> T:
     """Update a database model from a dict, in-place.
 
     Nested objects are fully replaced, if specified in the given data.
-    Attributes set to the sentinel NOT_SET are ignored.
     Unknown attibutes are ignored.
     """
     model_cls = model.__class__
-    # ignore attributes with NOT_SET sentinel
-    data = {key: value for key, value in data.items() if value != NOT_SET}
     model_kwargs = _model_kwargs(model_cls=model_cls, data=data)
     for key, value in model_kwargs.items():
         setattr(model, key, value)

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -418,7 +418,7 @@ def router_update_one[T: BaseModel, I: Identifiable](
     db_model_instance = update_model(
         model=db_model_instance,
         data=json_model.model_dump(
-            exclude=set(nested_relationships) if nested_relationships else None
+            exclude_unset=True, exclude=set(nested_relationships) if nested_relationships else None
         ),
     )
 
@@ -518,7 +518,7 @@ def router_update_activity_one[T: BaseModel, I: Activity](
         exclude_unset=True,
         exclude_none=True,
         exclude=set(nested_relationships),
-        exclude_defaults=True,  # ignore NOT_SET default values
+        exclude_defaults=True,
     )
 
     for key, value in update_data.items():

--- a/app/queries/utils.py
+++ b/app/queries/utils.py
@@ -12,7 +12,6 @@ from app.db.auth import select_unauthorized_entities
 from app.db.model import Identifiable, Person
 from app.queries.types import NestedRelationships
 from app.schemas.auth import UserContext, UserProfile
-from app.schemas.utils import NOT_SET
 from app.utils.uuid import create_uuid
 
 
@@ -97,13 +96,13 @@ def create_associations_to_entities(
         HTTPException: If any of the associated entities are not public or not in the same project,
             or if trying to update associations when it's not allowed.
     """
-    # map relationship keys to lists of entity IDs to associate, ignoring NOT_SET values
+    # map relationship keys to lists of entity IDs to associate
     nested_relationship_ids: dict[str, list[uuid.UUID]] = cast(
         "dict[str, list[uuid.UUID]]",
         {
             relationship_key: relationship["nested_id_getter"](items=items)  # type: ignore[misc]
             for relationship_key, relationship in nested_relationships.items()
-            if (items := getattr(json_model, relationship_key, NOT_SET)) != NOT_SET
+            if (items := getattr(json_model, relationship_key, None)) is not None
         },
     )
 

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -13,7 +13,6 @@ from app.schemas.base import (
     IdentifiableMixin,
 )
 from app.schemas.entity import NestedEntityRead
-from app.schemas.utils import NOT_SET, NotSet
 
 
 class ActivityBase(BaseModel):
@@ -38,10 +37,10 @@ class ActivityCreate(ActivityBase, AuthorizationOptionalPublicMixin):
 
 
 class ActivityUpdate(BaseModel):
-    start_time: datetime | NotSet | None = NOT_SET
-    end_time: datetime | NotSet | None = NOT_SET
-    generated_ids: list[uuid.UUID] | NotSet | None = NOT_SET
-    status: ActivityStatus | NotSet | None = NOT_SET
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    generated_ids: list[uuid.UUID] | None = None
+    status: ActivityStatus | None = None
 
 
 class ExecutionActivityMixin:

--- a/app/schemas/cell_morphology_protocol.py
+++ b/app/schemas/cell_morphology_protocol.py
@@ -19,7 +19,7 @@ from app.schemas.base import (
     NameDescriptionMixin,
 )
 from app.schemas.types import SerializableHttpUrl
-from app.schemas.utils import NOT_SET, make_update_schema
+from app.schemas.utils import make_update_schema
 
 
 class CommonReadMixin(
@@ -325,5 +325,6 @@ class CellMorphologyProtocolUserUpdateAdapter(BaseModel):
         """Return the correct instance of the protocol."""
         model = cls._adapter.validate_python(obj, *args, **kwargs)
         # generation_type was needed only as a discriminator. It should not be updated.
-        model.generation_type = NOT_SET
+        model.generation_type = None
+        model.model_fields_set.discard("generation_type")  # make it unset
         return model

--- a/app/schemas/utils.py
+++ b/app/schemas/utils.py
@@ -1,12 +1,6 @@
-from typing import Annotated, Literal
+from typing import Annotated
 
 from pydantic import BaseModel, Field, create_model
-
-type NotSet = Literal["<NOT_SET>"]
-
-
-# Attributes set to the sentinel NOT_SET are ignored on model updates by user
-NOT_SET = "<NOT_SET>"
 
 EXCLUDED_FIELDS = {
     "authorized_public",
@@ -22,18 +16,12 @@ def make_update_schema(
 ):
     """Create a new pydantic schema from current schema where all fields are optional.
 
-    In order to differentiate between the user providing a None value and an actual not set by the
-    user field all fields are by default set to a NOT_SET sentinel.
-
     When the api payload instantiates the schema model, the user can explicitly set an update value
     to None.
-
-    All attributes with NOT_SET defaults are then removed in the router logic. This way only the
-    values set by the user, None included, remain in the update schema.
     """
 
     def make_optional(field):
-        return Annotated[field.annotation | Literal["<NOT_SET>"] | None, Field(default=NOT_SET)]
+        return Annotated[field.annotation | None, Field(default=None)]
 
     fields = {}
     for name, field in schema.model_fields.items():


### PR DESCRIPTION
Leverage pydantic's `model_fields_set` that keeps track of the fields that have been set upon instantiation. That allows to differentiate from fields that are not updated by the user from fields that have been update with None.

This PR replaces the custom implementation with NOT_SET sentinels with pydantic's implicit functionality and allows removing NOT_SET from the schemas.

Fixes #497