### PR TITLE
Increase DB_MAX_OVERFLOW

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,7 +85,7 @@ class Settings(BaseSettings):
 
     DB_POOL_SIZE: int = 30
     DB_POOL_PRE_PING: bool = False
-    DB_MAX_OVERFLOW: int = 0
+    DB_MAX_OVERFLOW: int = 10
 
     OPENAI_API_KEY: SecretStr | None = None
 


### PR DESCRIPTION
Increase DB_MAX_OVERFLOW to 10, that is also the sqlalchemy default.
From https://docs.sqlalchemy.org/en/21/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow

> The maximum overflow size of the pool. When the number of checked-out connections reaches the size set in pool_size, additional connections will be returned up to this limit. When those additional connections are returned to the pool, they are disconnected and discarded. It follows then that the total number of simultaneous connections the pool will allow is pool_size + max_overflow, and the total number of “sleeping” connections the pool will allow is pool_size. max_overflow can be set to -1 to indicate no overflow limit; no limit will be placed on the total number of concurrent connections. Defaults to 10.
