### PR TITLE
Fix brain-region filter, add additional filters to brain-atlas and brain-atlas-region

### DIFF
--- a/app/filters/brain_atlas.py
+++ b/app/filters/brain_atlas.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Annotated
 
 from app.db.model import BrainAtlas, BrainAtlasRegion
@@ -15,6 +16,7 @@ class BrainAtlasFilter(
     ILikeSearchFilterMixin,
     CustomFilter,
 ):
+    hierarchy_id: uuid.UUID | None = None
     order_by: list[str] = ["name"]  # noqa: RUF012
 
     class Constants(CustomFilter.Constants):
@@ -23,6 +25,10 @@ class BrainAtlasFilter(
 
 
 class BrainAtlasRegionFilter(EntityFilterMixin, CustomFilter):
+    is_leaf_region: bool | None = None
+    brain_atlas_id: uuid.UUID | None = None
+    brain_region_id: uuid.UUID | None = None
+
     order_by: list[str] = ["-creation_date"]  # noqa: RUF012
 
     class Constants(CustomFilter.Constants):

--- a/app/service/brain_atlas.py
+++ b/app/service/brain_atlas.py
@@ -47,7 +47,8 @@ def _read_many(
     check_authorized_project: bool,
 ) -> ListResponse[BrainAtlasRead]:
     aliases: Aliases = {}
-    facet_keys = filter_keys = [
+    facet_keys = []
+    filter_keys = [
         "species",
         "strain",
     ]
@@ -65,7 +66,7 @@ def _read_many(
         with_search=None,
         with_in_brain_region=None,
         facets=None,
-        aliases=None,
+        aliases=aliases,
         apply_filter_query_operations=None,
         apply_data_query_operations=_load_brain_atlas,
         pagination_request=pagination_request,

--- a/app/service/brain_atlas.py
+++ b/app/service/brain_atlas.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.orm import joinedload, raiseload, selectinload
@@ -11,6 +12,7 @@ from app.dependencies.common import (
 )
 from app.dependencies.db import SessionDep
 from app.filters.brain_atlas import BrainAtlasFilterDep, BrainAtlasRegionFilterDep
+from app.queries.factory import query_params_factory
 from app.schemas.brain_atlas import (
     BrainAtlasAdminUpdate,
     BrainAtlasCreate,
@@ -20,6 +22,9 @@ from app.schemas.brain_atlas import (
 from app.schemas.brain_atlas_region import BrainAtlasRegionRead
 from app.schemas.routers import DeleteResponse
 from app.schemas.types import ListResponse
+
+if TYPE_CHECKING:
+    from app.filters.base import Aliases
 
 
 def _load_brain_atlas(query: sa.Select):
@@ -41,6 +46,18 @@ def _read_many(
     filter_model: BrainAtlasFilterDep,
     check_authorized_project: bool,
 ) -> ListResponse[BrainAtlasRead]:
+    aliases: Aliases = {}
+    facet_keys = filter_keys = [
+        "species",
+        "strain",
+    ]
+    name_to_facet_query_params, filter_joins = query_params_factory(
+        db_model_class=BrainAtlas,
+        facet_keys=facet_keys,
+        filter_keys=filter_keys,
+        aliases=aliases,
+    )
+
     return app.queries.common.router_read_many(
         db=db,
         db_model_class=BrainAtlas,
@@ -53,8 +70,9 @@ def _read_many(
         apply_data_query_operations=_load_brain_atlas,
         pagination_request=pagination_request,
         response_schema_class=BrainAtlasRead,
-        name_to_facet_query_params=None,
+        name_to_facet_query_params=name_to_facet_query_params,
         filter_model=filter_model,
+        filter_joins=filter_joins,
         check_authorized_project=check_authorized_project,
     )
 

--- a/app/service/brain_region.py
+++ b/app/service/brain_region.py
@@ -1,7 +1,8 @@
 import uuid
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy.orm import joinedload, raiseload
+from sqlalchemy.orm import aliased, joinedload, raiseload
 
 import app.queries.common
 from app.db.model import BrainRegion, BrainRegionHierarchy, Species, Strain
@@ -14,6 +15,9 @@ from app.schemas.brain_region import BrainRegionAdminUpdate, BrainRegionCreate, 
 from app.schemas.routers import DeleteResponse
 from app.schemas.types import ListResponse
 from app.utils.embedding import generate_embedding
+
+if TYPE_CHECKING:
+    from app.filters.base import Aliases
 
 
 def _load(select: sa.Select):
@@ -32,13 +36,21 @@ def read_many(
     semantic_search: str | None = None,
 ) -> ListResponse[BrainRegionRead]:
     db_model_class = BrainRegion
+    brh_species_alias = aliased(BrainRegionHierarchy, flat=True, name="brh_species")
+    brh_strain_alias = aliased(BrainRegionHierarchy, flat=True, name="brh_strain")
+    aliases: Aliases = {
+        BrainRegionHierarchy: {
+            "species": brh_species_alias,
+            "strain": brh_strain_alias,
+        },
+    }
     filter_joins = {
         "species": lambda q: q.join(
-            BrainRegionHierarchy, db_model_class.hierarchy_id == BrainRegionHierarchy.id
-        ).join(Species, BrainRegionHierarchy.species_id == Species.id),
+            brh_species_alias, db_model_class.hierarchy_id == brh_species_alias.id
+        ).join(Species, brh_species_alias.species_id == Species.id),
         "strain": lambda q: q.join(
-            BrainRegionHierarchy, db_model_class.hierarchy_id == BrainRegionHierarchy.id
-        ).join(Strain, BrainRegionHierarchy.strain_id == Species.id),
+            brh_strain_alias, db_model_class.hierarchy_id == brh_strain_alias.id
+        ).join(Strain, brh_strain_alias.strain_id == Strain.id),
     }
 
     return app.queries.common.router_read_many(
@@ -48,7 +60,7 @@ def read_many(
         with_search=None,
         with_in_brain_region=None,
         facets=None,
-        aliases=None,
+        aliases=aliases,
         apply_filter_query_operations=None,
         apply_data_query_operations=_load,
         pagination_request=pagination_request,

--- a/tests/test_brain_atlas.py
+++ b/tests/test_brain_atlas.py
@@ -7,7 +7,7 @@ from app.db.model import BrainAtlas, BrainAtlasRegion
 from app.db.types import EntityType, StorageType
 
 from . import utils
-from .utils import assert_request, check_entity_read_many
+from .utils import MISSING_ID, assert_request, check_entity_read_many
 
 ROUTE = "/brain-atlas"
 ADMIN_ROUTE = "/admin/brain-atlas"
@@ -372,7 +372,7 @@ def test_pagination(client, create_id):
 
 
 @pytest.mark.usefixtures("model")
-def test_filtering(client, brain_region_hierarchy_id):
+def test_filtering(client, brain_region_hierarchy_id, species_id):
     data = assert_request(
         client.get, url=f"{ROUTE}", params={"hierarchy_id": brain_region_hierarchy_id}
     ).json()
@@ -382,3 +382,19 @@ def test_filtering(client, brain_region_hierarchy_id):
         client.get, url=f"{ROUTE}", params={"species__name": "Test Species"}
     ).json()
     assert len(data["data"]) == 1
+
+    data = assert_request(client.get, url=f"{ROUTE}", params={"species__id": species_id}).json()
+    assert len(data["data"]) == 1
+
+    data = assert_request(client.get, url=f"{ROUTE}", params={"strain__id": MISSING_ID}).json()
+    assert len(data["data"]) == 0
+
+    data = assert_request(
+        client.get,
+        url=f"{ROUTE}",
+        params={
+            "species__id": species_id,
+            "strain__id": MISSING_ID,
+        },
+    ).json()
+    assert len(data["data"]) == 0

--- a/tests/test_brain_atlas.py
+++ b/tests/test_brain_atlas.py
@@ -7,7 +7,7 @@ from app.db.model import BrainAtlas, BrainAtlasRegion
 from app.db.types import EntityType, StorageType
 
 from . import utils
-from .utils import check_entity_read_many
+from .utils import assert_request, check_entity_read_many
 
 ROUTE = "/brain-atlas"
 ADMIN_ROUTE = "/admin/brain-atlas"
@@ -369,3 +369,16 @@ def test_authorization(client_user_1, client_user_2, client_no_project, json_dat
 
 def test_pagination(client, create_id):
     utils.check_pagination(ROUTE, client, create_id)
+
+
+@pytest.mark.usefixtures("model")
+def test_filtering(client, brain_region_hierarchy_id):
+    data = assert_request(
+        client.get, url=f"{ROUTE}", params={"hierarchy_id": brain_region_hierarchy_id}
+    ).json()
+    assert len(data["data"]) == 1
+
+    data = assert_request(
+        client.get, url=f"{ROUTE}", params={"species__name": "Test Species"}
+    ).json()
+    assert len(data["data"]) == 1

--- a/tests/test_brain_atlas_region.py
+++ b/tests/test_brain_atlas_region.py
@@ -129,3 +129,16 @@ def test_authorization(client_user_1, client_user_2, client_no_project, json_dat
 
 def test_pagination(client, create_id):
     check_pagination(ROUTE, client, create_id)
+
+
+@pytest.mark.usefixtures("model")
+def test_filtering(client, brain_atlas_id, brain_region_id):
+    data = assert_request(
+        client.get, url=f"{ROUTE}", params={"brain_atlas_id": brain_atlas_id}
+    ).json()
+    assert len(data["data"]) == 1
+
+    data = assert_request(
+        client.get, url=f"{ROUTE}", params={"brain_region_id": brain_region_id}
+    ).json()
+    assert len(data["data"]) == 1

--- a/tests/test_brain_region.py
+++ b/tests/test_brain_region.py
@@ -468,3 +468,27 @@ def test_InBrainRegionDep():
             endpoints.add(route.path)
 
     assert endpoints == set()
+
+
+def test_filtering(client, client_admin, json_data, species_id):
+    utils.assert_request(client_admin.post, url=ROUTE, json=json_data).json()
+
+    data = utils.assert_request(
+        client.get, url=f"{ROUTE}", params={"species__id": species_id}
+    ).json()
+    assert len(data["data"]) == 1
+
+    data = utils.assert_request(
+        client.get, url=f"{ROUTE}", params={"strain__id": utils.MISSING_ID}
+    ).json()
+    assert len(data["data"]) == 0
+
+    data = utils.assert_request(
+        client.get,
+        url=f"{ROUTE}",
+        params={
+            "species__id": species_id,
+            "strain__id": utils.MISSING_ID,
+        },
+    ).json()
+    assert len(data["data"]) == 0


### PR DESCRIPTION
- Fix brain region filter in https://github.com/openbraininstitute/entitycore/issues/571 for species/strain (DuplicateAlias and missing FROM-clause)
- Fix brain-atlas filter for species/strain (cartesian product)
- Add filters to:
  - BrainAtlas:
    - hierarchy_id
    - species (fixed)
    - strain (fixed)
  - BrainAtlasRegion:
    - is_leaf_region
    - brain_atlas_id
    - brain_region_id

Note: an alternative to adding the *id filters is to add full nested filters, so that the filters would have the double underscore separator and become:
- brain_atlas_id -> brain_atlas__id, brain_atlas__name, ...
- brain_region_id -> brain_region__id, brain_region__name, ...

However, they would require additional joins and it seems unnecessary for the moment, also considering that the returned payload doesn't contain those nested entities but just the ids.

Filtering by `brain_atlas_id` would have been useful in https://github.com/openbraininstitute/migration-scripts/pull/19
