### PR TITLE
Improve naming consistency in asset uploads

### DIFF
--- a/app/routers/asset.py
+++ b/app/routers/asset.py
@@ -22,10 +22,10 @@ from app.schemas.asset import (
     AssetReadWithUploadMeta,
     AssetRegister,
     DetailedFileList,
-    DirectoryUpload,
-    InitiateUploadRequest,
-    MultipartDirectoryAssetAndPresignedURLS,
-    MultipartDirectoryUpload,
+    DirectoryUploadRequest,
+    MultipartDirectoryUploadRequest,
+    MultipartDirectoryUploadResponse,
+    MultipartUploadInitiateRequest,
 )
 from app.schemas.types import ListResponse
 from app.service import asset as asset_service
@@ -249,12 +249,12 @@ def entity_asset_directory_upload(
     storage_client_factory: StorageClientFactoryDep,
     entity_route: EntityRoute,
     entity_id: uuid.UUID,
-    files: DirectoryUpload,
+    files: DirectoryUploadRequest,
 ) -> AssetAndPresignedURLS:
     """Given a list of full paths, return a dictionary of presigned URLS for uploading."""
     storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
     s3_client = storage_client_factory(storage)
-    model, urls = asset_service.entity_asset_upload_directory(
+    model, urls = asset_service.entity_asset_directory_upload(
         repos=repos,
         user_context=user_context,
         entity_type=entity_route_to_type(entity_route),
@@ -288,13 +288,13 @@ def entity_asset_directory_list(
 
 
 @router.post("/{entity_route}/{entity_id}/assets/multipart-upload/initiate")
-def initiate_entity_asset_upload(
+def entity_asset_multipart_upload_initiate(
     repos: RepoGroupDep,
     storage_client_factory: StorageClientFactoryDep,
     user_context: UserContextWithProjectIdDep,
     entity_route: EntityRoute,
     entity_id: uuid.UUID,
-    json_model: InitiateUploadRequest,
+    json_model: MultipartUploadInitiateRequest,
 ) -> AssetReadWithUploadMeta:
     """Start a multipart upload for a file asset associated with an entity.
 
@@ -372,7 +372,7 @@ def initiate_entity_asset_upload(
     # create presigned urls using the part count hint and filesize
     # asset schemas is updated with the upload metadata
     # Note: User already authorized when creating the asset
-    asset_read = asset_service.entity_asset_upload_initiate(
+    asset_read = asset_service.entity_asset_multipart_upload_initiate(
         repos=repos,
         s3_client=s3_client,
         entity_type=entity_type,
@@ -389,7 +389,7 @@ def initiate_entity_asset_upload(
 
 
 @router.post("/{entity_route}/{entity_id}/assets/{asset_id}/multipart-upload/complete")
-def complete_entity_asset_upload(
+def entity_asset_multipart_upload_complete(
     repos: RepoGroupDep,
     storage_client_factory: StorageClientFactoryDep,
     user_context: UserContextWithProjectIdDep,
@@ -421,7 +421,7 @@ def complete_entity_asset_upload(
     """
     storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
 
-    return asset_service.entity_asset_upload_complete(
+    return asset_service.entity_asset_multipart_upload_complete(
         repos=repos,
         user_context=user_context,
         entity_type=entity_route_to_type(entity_route),
@@ -433,20 +433,20 @@ def complete_entity_asset_upload(
 
 
 @router.post("/{entity_route}/{entity_id}/assets/directory/multipart-upload/initiate")
-def initiate_multipart_entity_asset_directory_upload(
+def entity_asset_directory_multipart_upload_initiate(
     repos: RepoGroupDep,
     storage_client_factory: StorageClientFactoryDep,
     user_context: UserContextWithProjectIdDep,
     entity_route: EntityRoute,
     entity_id: uuid.UUID,
-    json_model: MultipartDirectoryUpload,
-) -> MultipartDirectoryAssetAndPresignedURLS:
+    json_model: MultipartDirectoryUploadRequest,
+) -> MultipartDirectoryUploadResponse:
     """Initiate a multipart upload for directories."""
     storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
     s3_client = storage_client_factory(storage)
     entity_type = entity_route_to_type(entity_route)
 
-    return asset_service.initiate_multipart_entity_asset_directory_upload(
+    return asset_service.entity_asset_directory_multipart_upload_initiate(
         repos=repos,
         user_context=user_context,
         s3_client=s3_client,
@@ -458,7 +458,7 @@ def initiate_multipart_entity_asset_directory_upload(
 
 
 @router.post("/{entity_route}/{entity_id}/assets/{asset_id}/directory/multipart-upload/complete")
-def complete_multipart_entity_asset_directory_upload(
+def entity_asset_directory_multipart_upload_complete(
     repos: RepoGroupDep,
     storage_client_factory: StorageClientFactoryDep,
     user_context: UserContextWithProjectIdDep,
@@ -468,7 +468,7 @@ def complete_multipart_entity_asset_directory_upload(
 ) -> AssetRead:
     storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
 
-    return asset_service.complete_multipart_entity_asset_directory_upload(
+    return asset_service.entity_asset_directory_multipart_upload_complete(
         repos=repos,
         user_context=user_context,
         entity_type=entity_route_to_type(entity_route),

--- a/app/schemas/asset.py
+++ b/app/schemas/asset.py
@@ -225,7 +225,7 @@ class AssetsMixin(BaseModel):
     assets: list[AssetRead]
 
 
-class DirectoryUpload(BaseModel):
+class DirectoryUploadRequest(BaseModel):
     directory_name: Annotated[
         PathComponentStr,
         Field(
@@ -268,7 +268,7 @@ class AssetAndPresignedURLS(BaseModel):
     files: dict[Path, AnyUrl]
 
 
-class InitiateUploadRequest(BaseModel):
+class MultipartUploadInitiateRequest(BaseModel):
     filename: Annotated[
         PathComponentStr,
         Field(description="File name to be uploaded."),
@@ -297,7 +297,7 @@ class InitiateUploadRequest(BaseModel):
     )
 
 
-class NestedInitiateUploadRequest(BaseModel):
+class MultipartDirectoryFileRequest(BaseModel):
     filename: Annotated[
         RelativePathStr,
         Field(description="File name to be uploaded, relative to the base directory."),
@@ -326,10 +326,10 @@ class NestedInitiateUploadRequest(BaseModel):
     )
 
 
-class MultipartDirectoryUpload(BaseModel):
+class MultipartDirectoryUploadRequest(BaseModel):
     """Request schema for initiating a multipart directory upload.
 
-    Similar to DirectoryUpload schema, but with additional information for multipart uploads.
+    Similar to DirectoryUploadRequest schema, but with additional information for multipart uploads.
     """
 
     directory_name: Annotated[
@@ -339,7 +339,7 @@ class MultipartDirectoryUpload(BaseModel):
         ),
     ]
     files: Annotated[
-        list[NestedInitiateUploadRequest],
+        list[MultipartDirectoryFileRequest],
         Field(
             description="List of files to be uploaded inside the directory.",
             min_length=1,
@@ -358,7 +358,7 @@ class MultipartDirectoryUpload(BaseModel):
         return self
 
 
-class MultipartDirectoryAssetAndPresignedURLS(BaseModel):
+class MultipartDirectoryUploadResponse(BaseModel):
     """Response schema after initiating a multipart directory upload.
 
     Similar to AssetAndPresignedURLS schema, but with additional information for multipart uploads.

--- a/app/service/asset.py
+++ b/app/service/asset.py
@@ -25,9 +25,9 @@ from app.schemas.asset import (
     AssetRead,
     AssetReadWithUploadMeta,
     DetailedFileList,
-    DirectoryUpload,
-    MultipartDirectoryAssetAndPresignedURLS,
-    MultipartDirectoryUpload,
+    DirectoryUploadRequest,
+    MultipartDirectoryUploadRequest,
+    MultipartDirectoryUploadResponse,
     ToUploadPart,
     UploadMeta,
     UploadMetaRead,
@@ -399,14 +399,14 @@ def delete_asset_unverified(
     return AssetRead.model_validate(asset)
 
 
-def entity_asset_upload_directory(
+def entity_asset_directory_upload(
     repos: RepositoryGroup,
     user_context: UserContextWithProjectId,
     entity_type: EntityType,
     entity_id: uuid.UUID,
     s3_client: S3Client,
     storage: StorageUnion,
-    files: DirectoryUpload,
+    files: DirectoryUploadRequest,
 ) -> tuple[AssetRead, dict[Path, AnyUrl]]:
     entity = entity_service.get_writable_entity(
         repos,
@@ -491,7 +491,7 @@ def list_directory(
     return DetailedFileList.model_validate({"files": ret})
 
 
-def entity_asset_upload_initiate(
+def entity_asset_multipart_upload_initiate(
     *,
     repos: RepositoryGroup,
     entity_type: EntityType,
@@ -564,7 +564,7 @@ def entity_asset_upload_initiate(
     )
 
 
-def entity_asset_upload_complete(
+def entity_asset_multipart_upload_complete(
     *,
     repos: RepositoryGroup,
     user_context: UserContextWithProjectId,
@@ -726,7 +726,7 @@ def create_asset_download_redirect(
     return RedirectResponse(url=url)
 
 
-def initiate_multipart_entity_asset_directory_upload(
+def entity_asset_directory_multipart_upload_initiate(
     *,
     repos: RepositoryGroup,
     user_context: UserContextWithProjectId,
@@ -734,8 +734,8 @@ def initiate_multipart_entity_asset_directory_upload(
     entity_id: uuid.UUID,
     s3_client: S3Client,
     storage: StorageUnion,
-    json_model: MultipartDirectoryUpload,
-) -> MultipartDirectoryAssetAndPresignedURLS:
+    json_model: MultipartDirectoryUploadRequest,
+) -> MultipartDirectoryUploadResponse:
     """Initiate a multipart upload for each file in a directory asset.
 
     Return presigned urls for all parts.
@@ -788,7 +788,7 @@ def initiate_multipart_entity_asset_directory_upload(
         # create presigned urls using the part count hint and filesize
         # asset schemas is updated with the upload metadata
         # Note: User already authorized when creating the asset
-        asset_read_with_upload_meta = entity_asset_upload_initiate(
+        asset_read_with_upload_meta = entity_asset_multipart_upload_initiate(
             repos=repos,
             s3_client=s3_client,
             entity_type=entity_type,
@@ -801,13 +801,13 @@ def initiate_multipart_entity_asset_directory_upload(
             preferred_part_count=initiate_payload.preferred_part_count,
         )
         asset_read_with_upload_meta_list.append(asset_read_with_upload_meta)
-    return MultipartDirectoryAssetAndPresignedURLS(
+    return MultipartDirectoryUploadResponse(
         asset=parent,
         files=asset_read_with_upload_meta_list,
     )
 
 
-def complete_multipart_entity_asset_directory_upload(
+def entity_asset_directory_multipart_upload_complete(
     *,
     repos: RepositoryGroup,
     user_context: UserContextWithProjectId,
@@ -835,7 +835,7 @@ def complete_multipart_entity_asset_directory_upload(
         if child.status == AssetStatus.CREATED:
             L.debug("Child asset upload already completed, skipping completion for id {}", child.id)
             continue
-        entity_asset_upload_complete(
+        entity_asset_multipart_upload_complete(
             repos=repos,
             user_context=user_context,
             entity_type=entity_type,

--- a/app/utils/files.py
+++ b/app/utils/files.py
@@ -5,11 +5,13 @@ from fastapi import UploadFile
 
 from app.db.types import ContentType
 from app.logger import L
-from app.schemas.asset import InitiateUploadRequest, NestedInitiateUploadRequest
+from app.schemas.asset import MultipartDirectoryFileRequest, MultipartUploadInitiateRequest
 
 
 def get_content_type(
-    file: UploadFile | InitiateUploadRequest | NestedInitiateUploadRequest, *, verbose: bool = True
+    file: UploadFile | MultipartUploadInitiateRequest | MultipartDirectoryFileRequest,
+    *,
+    verbose: bool = True,
 ) -> ContentType:
     """Return the file content-type.
 

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -11,7 +11,7 @@ from app.db.model import Asset, Entity
 from app.db.types import AssetLabel, EntityType, StorageType
 from app.errors import ApiErrorCode
 from app.schemas.api import ErrorResponse
-from app.schemas.asset import AssetRead, MultipartDirectoryAssetAndPresignedURLS
+from app.schemas.asset import AssetRead, MultipartDirectoryUploadResponse
 from app.utils.s3 import build_s3_path
 
 from tests.utils import (
@@ -1385,8 +1385,8 @@ def test_multipart_asset_upload_abort(db, client, entity, s3, s3_internal_bucket
     assert not s3_multipart_upload_exists(s3, upload_id, s3_internal_bucket)
 
 
-def test_initiate_entity_asset_upload_invalid_filesize(client, entity):
-    """Test initiate_entity_asset_upload with invalid filesize."""
+def test_entity_asset_multipart_upload_initiate__invalid_filesize(client, entity):
+    """Test entity_asset_multipart_upload_initiate with invalid filesize."""
     # Test with filesize exceeding max
     max_size = settings.S3_MULTIPART_UPLOAD_MAX_SIZE
     response = assert_request(
@@ -1400,8 +1400,8 @@ def test_initiate_entity_asset_upload_invalid_filesize(client, entity):
     assert error.details[0]["msg"] == f"Input should be less than {max_size}"
 
 
-def test_initiate_entity_asset_upload_invalid_filename(client, entity):
-    """Test initiate_entity_asset_upload with invalid filename."""
+def test_entity_asset_multipart_upload_initiate__invalid_filename(client, entity):
+    """Test entity_asset_multipart_upload_initiate with invalid filename."""
     # Test with invalid filename (path traversal)
 
     response = assert_request(
@@ -1428,8 +1428,8 @@ def test_initiate_entity_asset_upload_invalid_filename(client, entity):
     assert error.details[0]["msg"] == "Value error, Expected a valid file or directory name"
 
 
-def test_initiate_entity_asset_upload_invalid_content_type(client, entity):
-    """Test initiate_entity_asset_upload with invalid content type."""
+def test_entity_asset_multipart_upload_initiate__invalid_content_type(client, entity):
+    """Test entity_asset_multipart_upload_initiate with invalid content type."""
     # Test with invalid content type
     response = assert_request(
         client.post,
@@ -1442,8 +1442,8 @@ def test_initiate_entity_asset_upload_invalid_content_type(client, entity):
     assert "Value error, morphology implies one of the following content-types" in error.details[0]
 
 
-def test_initiate_entity_asset_upload_duplicate(client, entity):
-    """Test initiate_entity_asset_upload with duplicate asset."""
+def test_entity_asset_multipart_upload_initiate__duplicate(client, entity):
+    """Test entity_asset_multipart_upload_initiate with duplicate asset."""
     # Create first upload
     assert_request(
         client.post,
@@ -1462,8 +1462,8 @@ def test_initiate_entity_asset_upload_duplicate(client, entity):
     assert error.error_code == ApiErrorCode.ASSET_DUPLICATED
 
 
-def test_initiate_entity_asset_upload_entity_not_found(client, entity):
-    """Test initiate_entity_asset_upload with non-existent entity."""
+def test_entity_asset_multipart_upload_initiate__entity_not_found(client, entity):
+    """Test entity_asset_multipart_upload_initiate with non-existent entity."""
     response = assert_request(
         client.post,
         url=f"{route(entity.type)}/{MISSING_ID}/assets/multipart-upload/initiate",
@@ -1481,10 +1481,10 @@ def test_initiate_entity_asset_upload_entity_not_found(client, entity):
         ("client_no_project", 403, ApiErrorCode.NOT_AUTHORIZED),
     ],
 )
-def test_initiate_entity_asset_upload_non_authorized(
+def test_entity_asset_multipart_upload_initiate__non_authorized(
     request, client_fixture, expected_status, expected_error, entity
 ):
-    """Test initiate_entity_asset_upload with unauthorized user."""
+    """Test entity_asset_multipart_upload_initiate with unauthorized user."""
     client = request.getfixturevalue(client_fixture)
     response = assert_request(
         client.post,
@@ -1496,8 +1496,8 @@ def test_initiate_entity_asset_upload_non_authorized(
     assert error.error_code == expected_error
 
 
-def test_complete_entity_asset_upload_asset_not_found(client, entity):
-    """Test complete_entity_asset_upload with non-existent asset."""
+def test_entity_asset_multipart_upload_complete__asset_not_found(client, entity):
+    """Test entity_asset_multipart_upload_complete with non-existent asset."""
     response = assert_request(
         client.post,
         url=f"{route(entity.type)}/{entity.id}/assets/{MISSING_ID}/multipart-upload/complete",
@@ -1507,8 +1507,8 @@ def test_complete_entity_asset_upload_asset_not_found(client, entity):
     assert error.error_code == ApiErrorCode.ASSET_NOT_FOUND
 
 
-def test_complete_entity_asset_upload_entity_not_found(client, entity, uploading_asset):
-    """Test complete_entity_asset_upload with non-existent entity."""
+def test_entity_asset_multipart_upload_complete__entity_not_found(client, entity, uploading_asset):
+    """Test entity_asset_multipart_upload_complete with non-existent entity."""
     response = assert_request(
         client.post,
         url=f"{route(entity.type)}/{MISSING_ID}/assets/{uploading_asset.id}/multipart-upload/complete",
@@ -1518,8 +1518,8 @@ def test_complete_entity_asset_upload_entity_not_found(client, entity, uploading
     assert error.error_code == ApiErrorCode.ENTITY_NOT_FOUND
 
 
-def test_complete_entity_asset_upload_not_uploading(client, entity, asset):
-    """Test complete_entity_asset_upload when asset is not in uploading status."""
+def test_entity_asset_multipart_upload_complete__not_uploading(client, entity, asset):
+    """Test entity_asset_multipart_upload_complete when asset is not in uploading status."""
     data = assert_request(
         client.post,
         url=f"{route(entity.type)}/{entity.id}/assets/{asset.id}/multipart-upload/complete",
@@ -1537,10 +1537,10 @@ def test_complete_entity_asset_upload_not_uploading(client, entity, asset):
         ("client_no_project", 403, ApiErrorCode.NOT_AUTHORIZED),
     ],
 )
-def test_complete_entity_asset_upload_non_authorized(
+def test_entity_asset_multipart_upload_complete__non_authorized(
     request, client_fixture, expected_status, expected_error, entity, uploading_asset
 ):
-    """Test complete_entity_asset_upload with unauthorized user."""
+    """Test entity_asset_multipart_upload_complete with unauthorized user."""
     client = request.getfixturevalue(client_fixture)
     data = assert_request(
         client.post,
@@ -1551,8 +1551,10 @@ def test_complete_entity_asset_upload_non_authorized(
     assert error.error_code == expected_error
 
 
-def test_complete_entity_asset_upload_incomplete(db, client, entity, s3, s3_internal_bucket):
-    """Test complete_entity_asset_upload when upload is incomplete."""
+def test_entity_asset_multipart_upload_complete__incomplete(
+    db, client, entity, s3, s3_internal_bucket
+):
+    """Test entity_asset_multipart_upload_complete when upload is incomplete."""
     filesize = 3 * 5 * 1024**2
 
     # Initiate upload
@@ -1604,8 +1606,10 @@ def test_complete_entity_asset_upload_incomplete(db, client, entity, s3, s3_inte
     assert data["status"] == "created"
 
 
-def test_complete_entity_asset_upload_inconsistent_size(db, client, entity, s3, s3_internal_bucket):
-    """Test complete_entity_asset_upload when total uploaded size does not match expected size."""
+def test_entity_asset_multipart_upload_complete__inconsistent_size(
+    db, client, entity, s3, s3_internal_bucket
+):
+    """Test entity_asset_multipart_upload_complete when uploaded size doesn't match expected."""
     # Expected filesize declared during initiation
     declared_filesize = 3 * 5 * 1024**2  # ~75MB
 
@@ -1761,7 +1765,7 @@ def test_multipart_directory_upload(client, root_circuit, s3, s3_internal_bucket
         assert file_asset["upload_meta"] is not None
         assert len(file_asset["upload_meta"]["parts"]) == 3
 
-    initiated = MultipartDirectoryAssetAndPresignedURLS.model_validate(data)
+    initiated = MultipartDirectoryUploadResponse.model_validate(data)
 
     # Upload parts for each file
     for file_asset in initiated.files:


### PR DESCRIPTION
## Naming consistency refactor

Renamed functions, classes, and tests to follow a consistent pattern: `entity_asset` + `[directory]` + `[multipart_upload]` + `{action}`.

### Schemas (`app/schemas/asset.py`)

| Before | After |
|--------|-------|
| `DirectoryUpload` | `DirectoryUploadRequest` |
| `InitiateUploadRequest` | `MultipartUploadInitiateRequest` |
| `NestedInitiateUploadRequest` | `MultipartDirectoryFileRequest` |
| `MultipartDirectoryUpload` | `MultipartDirectoryUploadRequest` |
| `MultipartDirectoryAssetAndPresignedURLS` | `MultipartDirectoryUploadResponse` |

### Service (`app/service/asset.py`)

| Before | After |
|--------|-------|
| `entity_asset_upload_directory` | `entity_asset_directory_upload` |
| `entity_asset_upload_initiate` | `entity_asset_multipart_upload_initiate` |
| `entity_asset_upload_complete` | `entity_asset_multipart_upload_complete` |
| `initiate_multipart_entity_asset_directory_upload` | `entity_asset_directory_multipart_upload_initiate` |
| `complete_multipart_entity_asset_directory_upload` | `entity_asset_directory_multipart_upload_complete` |

### Router (`app/routers/asset.py`)

| Before | After |
|--------|-------|
| `initiate_entity_asset_upload` | `entity_asset_multipart_upload_initiate` |
| `complete_entity_asset_upload` | `entity_asset_multipart_upload_complete` |
| `initiate_multipart_entity_asset_directory_upload` | `entity_asset_directory_multipart_upload_initiate` |
| `complete_multipart_entity_asset_directory_upload` | `entity_asset_directory_multipart_upload_complete` |

### Tests (`tests/routers/test_asset.py`)

| Before | After |
|--------|-------|
| `test_initiate_entity_asset_upload_*` | `test_entity_asset_multipart_upload_initiate__*` |
| `test_complete_entity_asset_upload_*` | `test_entity_asset_multipart_upload_complete__*` |
