### PR TITLE
Optimize brain-region filter queries with a materialized CTE

### DIFF
--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -5,7 +5,7 @@ from typing import Annotated, NotRequired, TypedDict
 import sqlalchemy as sa
 from fastapi import Depends, Query
 from fastapi.dependencies.models import Dependant
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 from sqlalchemy.orm import DeclarativeBase, InstrumentedAttribute, Session
 from starlette.requests import Request
 
@@ -164,6 +164,12 @@ class InBrainRegionQuery(BaseModel):
     # Not using Annotated syntax because apparently not showing the deprecated flag in openapi
     within_brain_region_hierarchy_id: uuid.UUID | None = Field(Query(None, deprecated=True))
 
+    _candidate_cte: sa.CTE | None = PrivateAttr(default=None)
+
+    @property
+    def candidate_cte(self) -> sa.CTE | None:
+        return self._candidate_cte
+
     @model_validator(mode="after")
     def check_brain_region_id_and_direction(self):
         """Check within_brain_region_direction and within_brain_region_brain_region_id.
@@ -213,12 +219,13 @@ class InBrainRegionQuery(BaseModel):
         assert self.within_brain_region_brain_region_id  # noqa: S101
         assert self.within_brain_region_direction  # noqa: S101
 
-        return filter_by_region(
+        query, self._candidate_cte = filter_by_region(
             query=query,
             model=db_model_class,
             brain_region_id=self.within_brain_region_brain_region_id,
             direction=self.within_brain_region_direction,
         )
+        return query
 
 
 class DerivationQuery(BaseModel):

--- a/app/filters/brain_region.py
+++ b/app/filters/brain_region.py
@@ -68,10 +68,18 @@ def filter_by_region(
     model,
     brain_region_id: uuid.UUID,
     direction: WithinBrainRegionDirection,
-):
-    brain_region_query = get_family_query(brain_region_id=brain_region_id, direction=direction)
-    query = query.join(brain_region_query, model.brain_region_id == brain_region_query.c.id)
-    return query
+) -> tuple[sa.Select, sa.CTE]:
+    region_ids_cte = get_family_query(brain_region_id=brain_region_id, direction=direction)
+    candidate_artifacts = (
+        sa.select(model.id, model.creation_date)
+        .join(region_ids_cte, model.brain_region_id == region_ids_cte.c.id)
+        .cte("candidate_artifacts")
+        .prefix_with("MATERIALIZED")
+    )
+    return (
+        query.join(candidate_artifacts, model.id == candidate_artifacts.c.id),
+        candidate_artifacts,
+    )
 
 
 class NestedBrainRegionFilter(IdFilterMixin, NameFilterMixin, CustomFilter):

--- a/app/queries/common.py
+++ b/app/queries/common.py
@@ -220,6 +220,13 @@ def router_create_one[T: BaseModel, I: Identifiable](
     return response_schema_class.model_validate(db_model_instance)
 
 
+def _sort_is_creation_date_first(filter_model: CustomFilter) -> bool:
+    """Return True if the primary sort is creation_date DESC (or no explicit sort)."""
+    if not filter_model.ordering_values:
+        return True
+    return filter_model.ordering_values[0].lstrip("+") == "-creation_date"
+
+
 def _with_subquery[I: Identifiable](
     data_query: sa.Select[tuple[I]],
     db_model_class: type[I],
@@ -338,15 +345,29 @@ def router_read_many[T: BaseModel, I: Identifiable](  # noqa: PLR0913
     if with_in_brain_region:
         filter_query = with_in_brain_region(filter_query, db_model_class)
 
+    candidate_cte = with_in_brain_region.candidate_cte if with_in_brain_region else None
     ensure_stable_sorting = [db_model_class.creation_date.desc(), db_model_class.id]
 
-    data_query = (
-        filter_model.sort(filter_query, aliases=aliases)
-        .order_by(*ensure_stable_sorting)
-        .with_only_columns(db_model_class)
-        .offset(pagination_request.offset)
-        .limit(pagination_request.page_size)
-    )
+    sorted_filter_query = filter_model.sort(filter_query, aliases=aliases)
+
+    if candidate_cte is not None and _sort_is_creation_date_first(filter_model):
+        # Primary sort is creation_date: drive ordering from the small materialized CTE
+        # instead of the entity creation_date index, forcing the planner to start from
+        # the filtered set rather than scanning all public entities.
+        data_query = (
+            sorted_filter_query.order_by(None)
+            .order_by(candidate_cte.c.creation_date.desc(), candidate_cte.c.id)
+            .with_only_columns(db_model_class)
+            .offset(pagination_request.offset)
+            .limit(pagination_request.page_size)
+        )
+    else:
+        data_query = (
+            sorted_filter_query.order_by(*ensure_stable_sorting)
+            .with_only_columns(db_model_class)
+            .offset(pagination_request.offset)
+            .limit(pagination_request.page_size)
+        )
 
     # Add semantic similarity ordering if embedding is provided and model has embedding field
     if embedding is not None and hasattr(db_model_class, "embedding"):

--- a/tests/test_queries_common.py
+++ b/tests/test_queries_common.py
@@ -7,13 +7,38 @@ from pydantic import BaseModel
 
 from app.db.model import Derivation, TaskActivity
 from app.errors import ApiError, ApiErrorCode
-from app.queries.common import router_update_activity_one, router_update_one
+from app.filters.cell_morphology import CellMorphologyFilter
+from app.queries.common import (
+    _sort_is_creation_date_first,
+    router_update_activity_one,
+    router_update_one,
+)
 from app.schemas.activity import ActivityUpdate
 from app.schemas.derivation import DerivationRead
 
 
 class _DerivationLabelPatch(BaseModel):
     label: str | None = None
+
+
+@pytest.mark.parametrize(
+    ("order_by", "expected"),
+    [
+        (None, True),  # no ordering_values → default behaviour
+        (["-creation_date"], True),  # explicit descending creation_date
+        (["creation_date"], False),  # ascending creation_date is a different sort
+        (["+creation_date"], False),  # explicitly ascending creation_date
+        (["name"], False),  # non-creation_date primary sort
+        (["-name"], False),  # non-creation_date primary sort (descending)
+        (["-creation_date", "name"], True),  # creation_date DESC is still the primary sort
+        (["name", "-creation_date"], False),  # name is the primary sort
+    ],
+)
+def test_sort_is_creation_date_first(order_by, expected):
+    filter_model = (
+        CellMorphologyFilter(order_by=order_by) if order_by is not None else CellMorphologyFilter()
+    )
+    assert _sort_is_creation_date_first(filter_model) is expected
 
 
 def test_router_update_raises_without_authorized_project_column(db, user_context_user_1):


### PR DESCRIPTION
When filtering by within_brain_region, the PostgreSQL planner previously chose to scan all public entities via the ix_entity_public_creation_date_id partial index (driven by the ORDER BY creation_date DESC + LIMIT), then join into the brain-region recursive CTE — resulting in O(all_public_entities × CTE_rows) comparisons.

The fix introduces a MATERIALIZED CTE (candidate_artifacts) that pre-computes the set of matching entity IDs and their creation_date values before the outer query runs. Because a materialized CTE acts as an optimization fence, the planner cannot inline it and is forced to evaluate it first.

When the primary sort is creation_date DESC (the default for all affected endpoints), the ORDER BY is redirected to reference candidate_artifacts.creation_date instead of entity.creation_date. This makes the planner start from the small pre-filtered CTE rather than from the full entity index.

Changes:
- filter_by_region now builds and returns the MATERIALIZED CTE alongside the updated query (was a bare recursive-CTE join before).
- InBrainRegionQuery stores the returned CTE via PrivateAttr and exposes it as candidate_cte so callers can reference it after the filter is applied.
- router_read_many always applies filter_model.sort() first, then replaces the ORDER BY with CTE-based columns only when the primary sort is creation_date DESC.

https://github.com/openbraininstitute/prod-platform-architecture/issues/216
