### PR TITLE
fix: change AnalysisNotebookTemplate exercise_id from UUID to string

### DIFF
--- a/alembic/versions/20260616_134302_209ed0ccfbd1_change_analysis_notebook_template_.py
+++ b/alembic/versions/20260616_134302_209ed0ccfbd1_change_analysis_notebook_template_.py
@@ -12,9 +12,6 @@ from alembic import op
 import sqlalchemy as sa
 
 
-from sqlalchemy import Text
-import app.db.types
-
 # revision identifiers, used by Alembic.
 revision: str = "209ed0ccfbd1"
 down_revision: Union[str, None] = "c9d905433b3e"
@@ -34,6 +31,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    conn = op.get_bind()
+    bad = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM analysis_notebook_template "
+            "WHERE exercise_id IS NOT NULL AND exercise_id !~* "
+            "'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'"
+        )
+    ).scalar()
+    if bad:
+        raise RuntimeError(f"Cannot downgrade: {bad} exercise_id value(s) are not valid UUIDs")
     op.alter_column(
         "analysis_notebook_template",
         "exercise_id",

--- a/alembic/versions/20260616_134302_209ed0ccfbd1_change_analysis_notebook_template_.py
+++ b/alembic/versions/20260616_134302_209ed0ccfbd1_change_analysis_notebook_template_.py
@@ -1,0 +1,44 @@
+"""change analysis notebook template exercise_id to string
+
+Revision ID: 209ed0ccfbd1
+Revises: c9d905433b3e
+Create Date: 2026-06-16 13:43:02.280256
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+from sqlalchemy import Text
+import app.db.types
+
+# revision identifiers, used by Alembic.
+revision: str = "209ed0ccfbd1"
+down_revision: Union[str, None] = "c9d905433b3e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "analysis_notebook_template",
+        "exercise_id",
+        existing_type=sa.Uuid(),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+        postgresql_using="exercise_id::text",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "analysis_notebook_template",
+        "exercise_id",
+        existing_type=sa.String(length=255),
+        type_=sa.Uuid(),
+        existing_nullable=True,
+        postgresql_using="exercise_id::uuid",
+    )

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -2163,7 +2163,7 @@ class AnalysisNotebookTemplate(Entity, NameDescriptionVectorMixin):
     id: Mapped[uuid.UUID] = mapped_column(ForeignKey("entity.id"), primary_key=True)
     scale: Mapped[AnalysisScale]
     specifications: Mapped[JSON_DICT | None]
-    exercise_id: Mapped[uuid.UUID | None] = mapped_column(index=True)
+    exercise_id: Mapped[str | None] = mapped_column(String(255), index=True)
 
     __mapper_args__ = {"polymorphic_identity": __tablename__}  # noqa: RUF012
 

--- a/app/filters/analysis_notebook_template.py
+++ b/app/filters/analysis_notebook_template.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Annotated
 
 from app.db.model import AnalysisNotebookTemplate
@@ -20,8 +19,8 @@ class NestedAnalysisNotebookTemplateFilter(IdFilterMixin, NameFilterMixin, Custo
 class AnalysisNotebookTemplateFilter(
     EntityFilterMixin, NameFilterMixin, ILikeSearchFilterMixin, CustomFilter
 ):
-    exercise_id: uuid.UUID | None = None
-    exercise_id__in: list[uuid.UUID] | None = None
+    exercise_id: str | None = None
+    exercise_id__in: list[str] | None = None
     order_by: list[str] = ["-creation_date"]  # noqa: RUF012
 
     class Constants(CustomFilter.Constants):

--- a/app/schemas/analysis_notebook_template.py
+++ b/app/schemas/analysis_notebook_template.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -42,7 +41,7 @@ class AnalysisNotebookTemplateBase(BaseModel, NameDescriptionMixin):
     model_config = ConfigDict(from_attributes=True)
     specifications: AnalysisNotebookTemplateSpecifications | None = None
     scale: AnalysisScale
-    exercise_id: uuid.UUID | None = None
+    exercise_id: Annotated[str | None, Field(min_length=1, max_length=255)] = None
 
 
 class AnalysisNotebookTemplateCreate(

--- a/scripts/export/build_database_archive.sh
+++ b/scripts/export/build_database_archive.sh
@@ -2,7 +2,7 @@
 # Automatically generated, do not edit!
 set -euo pipefail
 SCRIPT_VERSION="1"
-SCRIPT_DB_VERSION="c9d905433b3e"
+SCRIPT_DB_VERSION="209ed0ccfbd1"
 echo "DB dump (version $SCRIPT_VERSION for db version $SCRIPT_DB_VERSION)"
 
 
@@ -273,7 +273,7 @@ install -m 755 /dev/stdin "$WORK_DIR/load.sh" <<'EOF_LOAD_SCRIPT'
 # Automatically generated, do not edit!
 set -euo pipefail
 SCRIPT_VERSION="1"
-SCRIPT_DB_VERSION="c9d905433b3e"
+SCRIPT_DB_VERSION="209ed0ccfbd1"
 echo "DB load (version $SCRIPT_VERSION for db version $SCRIPT_DB_VERSION)"
 
 

--- a/tests/test_analysis_notebook_template.py
+++ b/tests/test_analysis_notebook_template.py
@@ -1,5 +1,3 @@
-import uuid
-
 import pytest
 
 from app.db.model import AnalysisNotebookTemplate
@@ -108,9 +106,9 @@ def test_read_many_2(clients, json_data):
 
 
 def test_filter_by_exercise_id(client, json_data):
-    exercise_a = str(uuid.uuid4())
-    exercise_b = str(uuid.uuid4())
-    exercise_c = str(uuid.uuid4())
+    exercise_a = "exercise-101"
+    exercise_b = "physiology_basics"
+    exercise_c = "no-such-exercise"
 
     id_a1 = assert_request(
         client.post, url=ROUTE, json=json_data | {"name": "a1", "exercise_id": exercise_a}
@@ -135,6 +133,16 @@ def test_filter_by_exercise_id(client, json_data):
         "data"
     ]
     assert data == []
+
+
+@pytest.mark.parametrize("exercise_id", ["", "x" * 256])
+def test_exercise_id_invalid(client, json_data, exercise_id):
+    assert_request(
+        client.post,
+        url=ROUTE,
+        json=json_data | {"exercise_id": exercise_id},
+        expected_status_code=422,
+    )
 
 
 def test_delete_one(db, clients, json_data):


### PR DESCRIPTION
## Why

The OBI Grading service identifies exercises with **free-form text ids, not UUIDs**. The original `exercise_id` implementation (#623) typed the column as `UUID`, which is incorrect — this fixes it.

## What

Switch `AnalysisNotebookTemplate.exercise_id` from `UUID` to a bounded string (`VARCHAR(255)`, non-empty, max 255), keeping it **nullable** and **indexed**.

| Layer | Change |
|---|---|
| ORM (`app/db/model.py`) | `Mapped[str \| None] = mapped_column(String(255), index=True)` |
| Schema (`app/schemas/analysis_notebook_template.py`) | `Annotated[str \| None, Field(min_length=1, max_length=255)]` |
| Filter (`app/filters/analysis_notebook_template.py`) | `exercise_id` / `exercise_id__in` → `str` / `list[str]` |
| Migration | new revision `209ed0ccfbd1`, casts `uuid -> varchar` via `exercise_id::text` (downgrade casts back with `::uuid`) |
