### PR TITLE
Add release_version facet and release_version__in filter to EM cell mesh

### DIFF
--- a/app/dependencies/common.py
+++ b/app/dependencies/common.py
@@ -66,7 +66,8 @@ def forbid_extra_query_params(
 
 class FacetQueryParams(TypedDict):
     id: InstrumentedAttribute[uuid.UUID] | InstrumentedAttribute[int]
-    label: InstrumentedAttribute[str]
+    # ColumnElement covers cast() expressions for facets on scalar base-table columns
+    label: InstrumentedAttribute[str] | sa.ColumnElement[str]
     type: NotRequired[InstrumentedAttribute[str]]
 
 

--- a/app/filters/em_cell_mesh.py
+++ b/app/filters/em_cell_mesh.py
@@ -19,6 +19,7 @@ class EMCellMeshFilter(
     MeasurableFilterMixin,
 ):
     release_version: int | None = None
+    release_version__in: list[int] | None = None
     dense_reconstruction_cell_id: int | None = None
     level_of_detail: int | None = None
     mesh_type: EMCellMeshType | None = None

--- a/app/queries/factory.py
+++ b/app/queries/factory.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
 
+import sqlalchemy as sa
 from sqlalchemy.orm import DeclarativeBase
 
 from app.db.model import (
@@ -9,6 +10,7 @@ from app.db.model import (
     CellMorphologyProtocol,
     Circuit,
     Contribution,
+    EMCellMesh,
     EMDenseReconstructionDataset,
     EModel,
     Entity,
@@ -153,6 +155,10 @@ def query_params_factory[I: Identifiable](
             "id": em_dense_reconstruction_dataset_alias.id,
             "label": em_dense_reconstruction_dataset_alias.name,
         },
+        "release_version": {
+            "id": EMCellMesh.release_version,
+            "label": sa.cast(EMCellMesh.release_version, sa.String),
+        },
         "ion_channel_model": {
             "id": ion_channel_model_alias.id,
             "label": ion_channel_model_alias.name,
@@ -282,6 +288,8 @@ def query_params_factory[I: Identifiable](
             em_dense_reconstruction_dataset_alias.id
             == db_model_class.em_dense_reconstruction_dataset_id,
         ),
+        # release_version is a scalar column on the base table; no join needed.
+        "release_version": lambda q: q,
         "ion_channel_model": lambda q: q.outerjoin(
             IonChannelModelToEModel,
             db_model_class.id == IonChannelModelToEModel.emodel_id,

--- a/app/service/em_cell_mesh.py
+++ b/app/service/em_cell_mesh.py
@@ -112,6 +112,7 @@ def _read_many(
         "updated_by",
         "em_dense_reconstruction_dataset",
         "mtype",
+        "release_version",
     ]
     filter_keys = [
         "subject",

--- a/tests/test_em_cell_mesh.py
+++ b/tests/test_em_cell_mesh.py
@@ -99,6 +99,7 @@ def models(db, json_data, person_id):
                     "name": f"mesh-{i}",
                     "description": f"desc-{i}",
                     "level_of_detail": i,
+                    "release_version": i,
                     "dense_reconstruction_cell_id": i,
                     "mesh_type": ["static", "dynamic"][i % 2],
                     "created_by_id": person_id,
@@ -185,7 +186,22 @@ def test_filtering(client, models, brain_region_id, species_id, strain_id):
             },
         ],
         "mtype": [],
+        "release_version": [
+            {
+                "count": 1,
+                "id": 0,
+                "label": "0",
+                "type": "release_version",
+            },
+        ],
     }
+
+    data = assert_request(
+        client.get,
+        url=ROUTE,
+        params={"release_version__in": [1, 2]},
+    ).json()["data"]
+    assert sorted(d["release_version"] for d in data) == [1, 2]
 
     data = assert_request(
         client.get,


### PR DESCRIPTION
## Summary

Adds two capabilities to the EM-cell-mesh list endpoint:

- **(a)** aggregates `release_version` into the `facets` response, so clients can see the distribution of versions and their counts
- **(b)** accepts a `release_version__in` query filter, so clients can list meshes for several versions at once

The exact-match `release_version` filter already existed; this only adds the `__in` variant and the facet.

## Implementation notes

`release_version` is the first facet on a **scalar base-table column** rather than a joined entity, which required two non-obvious touches:

- **`app/queries/factory.py`** — registered the facet with `id = EMCellMesh.release_version` and `label = sa.cast(EMCellMesh.release_version, sa.String)` (`Facet.label` is typed `str` and Pydantic v2 will not coerce an `int`), plus a no-op `filter_joins` entry (`lambda q: q`) since `_get_facets` forces a join on each facet key.
- **`app/dependencies/common.py`** — widened `FacetQueryParams.label` to `InstrumentedAttribute[str] | sa.ColumnElement[str]` so the cast type-checks.
- **`app/service/em_cell_mesh.py`** — added `"release_version"` to `facet_keys` (flows into `filter_keys` via the existing `*facet_keys` splat).
- **`app/filters/em_cell_mesh.py`** — one-line `release_version__in: list[int] | None`; fastapi-filter auto-wires the `IN` operator.

### Facet ordering

Facet entries sort by the **string** `label` (`orderby_keys=["label"]` is hardcoded in `_get_facets`), so `release_version` entries sort lexicographically (`1, 10, 2`). This is accepted as-is — no change to shared facet code. It only affects the order of entries inside the `facets.release_version` array; it does **not** affect the paginated `data` rows, the counts, or `release_version__in` filtering. The frontend re-sorts that small array numerically.

## Testing

- `tests/test_em_cell_mesh.py` — fixture rows now have distinct `release_version` values; `test_filtering` asserts the new facet entry and the `release_version__in=[1, 2]` result.
- Full suite: 1041 passed, total coverage 97.58% (gate 90%). `ruff` + `pyright` clean.

## Related issue

[Add column "version" to browsing of EMCellMeshes. Add filter for version](openbraininstitute/prod-explore-functionality#504)