### PR TITLE
Remove CreatedByUpdatedByMixin from NestedMEModelCalibrationResultRead

### DIFF
--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -30,11 +30,6 @@ class NestedPersonRead(PersonBase, NestedIdentifiableRead):
     sub_id: uuid.UUID | None
 
 
-class CreatedByUpdatedByMixin:
-    created_by: NestedPersonRead
-    updated_by: NestedPersonRead
-
-
 class PersonRead(PersonBase, IdentifiableRead):
     type: AgentType
     sub_id: uuid.UUID | None

--- a/app/schemas/memodel_calibration_result.py
+++ b/app/schemas/memodel_calibration_result.py
@@ -1,6 +1,5 @@
 import uuid
 
-from app.schemas.agent import CreatedByUpdatedByMixin
 from app.schemas.entity import EntityCreate, EntityReadWoutAssets, NestedEntityRead
 from app.schemas.utils import make_update_schema
 
@@ -16,7 +15,6 @@ class MEModelCalibrationResultBaseMixin:
 
 class NestedMEModelCalibrationResultRead(
     MEModelCalibrationResultBaseMixin,
-    CreatedByUpdatedByMixin,
     NestedEntityRead,
 ):
     pass


### PR DESCRIPTION
Remove CreatedByUpdatedByMixin from NestedMEModelCalibrationResultRead after the confirmation in https://github.com/openbraininstitute/entitycore/pull/638#discussion_r3460112928