### PR TITLE
Support filtering circuits by target_simulator__in

### DIFF
--- a/app/filters/circuit.py
+++ b/app/filters/circuit.py
@@ -19,6 +19,7 @@ class CircuitFilterMixin:
     build_category__in: list[CircuitBuildCategory] | None = None
 
     target_simulator: TargetSimulator | None = None
+    target_simulator__in: list[TargetSimulator] | None = None
 
 
 class NestedCircuitFilter(

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -399,6 +399,16 @@ def test_filtering(client, root_circuit, models):
     data = assert_request(
         client.get,
         url=ROUTE,
+        params={
+            "root_circuit_id": str(root_circuit.id),
+            "target_simulator__in": [TargetSimulator.neuron, TargetSimulator.brian2],
+        },
+    ).json()["data"]
+    assert len(data) == 3  # NEURON x2 + Brian2 x1 among the children
+
+    data = assert_request(
+        client.get,
+        url=ROUTE,
         params={"lifecycle_status": "active", "root_circuit_id": str(root_circuit.id)},
     ).json()["data"]
     assert len(data) == len(models)


### PR DESCRIPTION
## What

Adds a `target_simulator__in` list filter to the Circuit API, so clients can filter circuits by multiple target simulators at once:

```
GET /circuit?target_simulator__in=NEURON&target_simulator__in=Brian2
```

This brings `target_simulator` to parity with the sibling enum fields `scale` and `build_category`, which already expose both single-value and `__in` filters. Ordering by `target_simulator` was added previously in #640.

## Changes

- `app/filters/circuit.py` — add `target_simulator__in: list[TargetSimulator] | None` to `CircuitFilterMixin`. The `__in` operator is handled automatically by `CustomFilter` / fastapi-filter, so no service/router/factory wiring is needed. Shared via the mixin, so both `CircuitFilter` and `NestedCircuitFilter` pick it up.
- `tests/test_circuit.py` — add a `target_simulator__in` assertion to `test_filtering`.
