### PR TITLE
Rename AnalysisNotebookTemplate exercise_id to assignment_id

### DIFF
--- a/alembic/versions/20260703_135010_11529d64c39f_rename_analysis_notebook_template_.py
+++ b/alembic/versions/20260703_135010_11529d64c39f_rename_analysis_notebook_template_.py
@@ -1,0 +1,47 @@
+"""rename analysis notebook template exercise_id to assignment_id
+
+Revision ID: 11529d64c39f
+Revises: b26853460669
+Create Date: 2026-07-03 13:50:10.326074
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "11529d64c39f"
+down_revision: Union[str, None] = "b26853460669"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "analysis_notebook_template",
+        "exercise_id",
+        new_column_name="assignment_id",
+        existing_type=sa.String(length=255),
+        existing_nullable=True,
+    )
+    op.execute(
+        "ALTER INDEX ix_analysis_notebook_template_exercise_id "
+        "RENAME TO ix_analysis_notebook_template_assignment_id"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER INDEX ix_analysis_notebook_template_assignment_id "
+        "RENAME TO ix_analysis_notebook_template_exercise_id"
+    )
+    op.alter_column(
+        "analysis_notebook_template",
+        "assignment_id",
+        new_column_name="exercise_id",
+        existing_type=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/app/db/model.py
+++ b/app/db/model.py
@@ -2208,7 +2208,7 @@ class AnalysisNotebookTemplate(Entity, NameDescriptionVectorMixin):
         scale: The overall scale of the analysis in the notebook. Used for filtering.
         specifications: Definitions of required python version and inputs,
             with schema AnalysisNotebookTemplateSpecifications.
-        exercise_id: Maps the notebook to an exercise in OBI Grading service.
+        assignment_id: Maps the notebook to an assignment in OBI Grading service.
 
     Assets:
         - a .ipynb file.
@@ -2221,7 +2221,7 @@ class AnalysisNotebookTemplate(Entity, NameDescriptionVectorMixin):
     id: Mapped[uuid.UUID] = mapped_column(ForeignKey("entity.id"), primary_key=True)
     scale: Mapped[AnalysisScale]
     specifications: Mapped[JSON_DICT | None]
-    exercise_id: Mapped[str | None] = mapped_column(String(255), index=True)
+    assignment_id: Mapped[str | None] = mapped_column(String(255), index=True)
 
     __mapper_args__ = {"polymorphic_identity": __tablename__}  # noqa: RUF012
 

--- a/app/filters/analysis_notebook_template.py
+++ b/app/filters/analysis_notebook_template.py
@@ -19,8 +19,8 @@ class NestedAnalysisNotebookTemplateFilter(IdFilterMixin, NameFilterMixin, Custo
 class AnalysisNotebookTemplateFilter(
     EntityFilterMixin, NameFilterMixin, ILikeSearchFilterMixin, CustomFilter
 ):
-    exercise_id: str | None = None
-    exercise_id__in: list[str] | None = None
+    assignment_id: str | None = None
+    assignment_id__in: list[str] | None = None
     order_by: list[str] = ["-creation_date"]  # noqa: RUF012
 
     class Constants(CustomFilter.Constants):

--- a/app/schemas/analysis_notebook_template.py
+++ b/app/schemas/analysis_notebook_template.py
@@ -34,7 +34,7 @@ class AnalysisNotebookTemplateSpecifications(Schema):
 class AnalysisNotebookTemplateBaseMixin(NameDescriptionMixin):
     specifications: AnalysisNotebookTemplateSpecifications | None = None
     scale: AnalysisScale
-    exercise_id: Annotated[str | None, Field(min_length=1, max_length=255)] = None
+    assignment_id: Annotated[str | None, Field(min_length=1, max_length=255)] = None
 
 
 class AnalysisNotebookTemplateCreate(

--- a/scripts/export/build_database_archive.sh
+++ b/scripts/export/build_database_archive.sh
@@ -2,7 +2,7 @@
 # Automatically generated, do not edit!
 set -euo pipefail
 SCRIPT_VERSION="1"
-SCRIPT_DB_VERSION="b26853460669"
+SCRIPT_DB_VERSION="11529d64c39f"
 echo "DB dump (version $SCRIPT_VERSION for db version $SCRIPT_DB_VERSION)"
 
 
@@ -273,7 +273,7 @@ install -m 755 /dev/stdin "$WORK_DIR/load.sh" <<'EOF_LOAD_SCRIPT'
 # Automatically generated, do not edit!
 set -euo pipefail
 SCRIPT_VERSION="1"
-SCRIPT_DB_VERSION="b26853460669"
+SCRIPT_DB_VERSION="11529d64c39f"
 echo "DB load (version $SCRIPT_VERSION for db version $SCRIPT_DB_VERSION)"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1763,7 +1763,7 @@ def analysis_notebook_template_json_data():
         "name": "analysis-notebook-template",
         "description": "analysis-notebook-template-description",
         "scale": "cellular",
-        "exercise_id": str(uuid.uuid4()),
+        "assignment_id": str(uuid.uuid4()),
         "specifications": {
             "python": {"version": ">=3.10"},
             "docker": {

--- a/tests/test_analysis_notebook_template.py
+++ b/tests/test_analysis_notebook_template.py
@@ -52,7 +52,7 @@ def _assert_read_response(data, json_data):
         data["specifications"]["docker"]["image_repository"]
         == json_data["specifications"]["docker"]["image_repository"]
     )
-    assert data["exercise_id"] == json_data["exercise_id"]
+    assert data["assignment_id"] == json_data["assignment_id"]
     assert "contributions" in data
 
     check_creation_fields(data)
@@ -105,33 +105,35 @@ def test_read_many_2(clients, json_data):
     )
 
 
-def test_filter_by_exercise_id(client, json_data):
-    exercise_a = "exercise-101"
-    exercise_b = "physiology_basics"
-    exercise_c = "no-such-exercise"
+def test_filter_by_assignment_id(client, json_data):
+    assignment_a = "assignment-101"
+    assignment_b = "physiology_basics"
+    assignment_c = "no-such-assignment"
 
     id_a1 = assert_request(
-        client.post, url=ROUTE, json=json_data | {"name": "a1", "exercise_id": exercise_a}
+        client.post, url=ROUTE, json=json_data | {"name": "a1", "assignment_id": assignment_a}
     ).json()["id"]
     id_a2 = assert_request(
-        client.post, url=ROUTE, json=json_data | {"name": "a2", "exercise_id": exercise_a}
+        client.post, url=ROUTE, json=json_data | {"name": "a2", "assignment_id": assignment_a}
     ).json()["id"]
     id_b = assert_request(
-        client.post, url=ROUTE, json=json_data | {"name": "b", "exercise_id": exercise_b}
+        client.post, url=ROUTE, json=json_data | {"name": "b", "assignment_id": assignment_b}
     ).json()["id"]
-    assert_request(client.post, url=ROUTE, json=json_data | {"name": "none", "exercise_id": None})
+    assert_request(client.post, url=ROUTE, json=json_data | {"name": "none", "assignment_id": None})
 
-    data = assert_request(client.get, url=ROUTE, params={"exercise_id": exercise_a}).json()["data"]
+    data = assert_request(client.get, url=ROUTE, params={"assignment_id": assignment_a}).json()[
+        "data"
+    ]
     assert {d["id"] for d in data} == {id_a1, id_a2}
 
     data = assert_request(
-        client.get, url=ROUTE, params={"exercise_id__in": [exercise_a, exercise_b]}
+        client.get, url=ROUTE, params={"assignment_id__in": [assignment_a, assignment_b]}
     ).json()["data"]
     assert {d["id"] for d in data} == {id_a1, id_a2, id_b}
 
-    data = assert_request(client.get, url=ROUTE, params={"exercise_id__in": [exercise_c]}).json()[
-        "data"
-    ]
+    data = assert_request(
+        client.get, url=ROUTE, params={"assignment_id__in": [assignment_c]}
+    ).json()["data"]
     assert data == []
 
     data = assert_request(client.get, url=ROUTE, params={"lifecycle_status": "active"}).json()[
@@ -140,12 +142,12 @@ def test_filter_by_exercise_id(client, json_data):
     assert len(data) == 4
 
 
-@pytest.mark.parametrize("exercise_id", ["", "x" * 256])
-def test_exercise_id_invalid(client, json_data, exercise_id):
+@pytest.mark.parametrize("assignment_id", ["", "x" * 256])
+def test_assignment_id_invalid(client, json_data, assignment_id):
     assert_request(
         client.post,
         url=ROUTE,
-        json=json_data | {"exercise_id": exercise_id},
+        json=json_data | {"assignment_id": assignment_id},
         expected_status_code=422,
     )
 


### PR DESCRIPTION
## Summary

The way (analysis) graded notebooks work changed: the concept mapping an `AnalysisNotebookTemplate` to the external OBI Grading service was renamed from **"exercise"** to **"assignment"**. This renames `exercise_id` → `assignment_id`.

This is a **hard rename** — no backward-compatible alias. The old JSON field and query params (`exercise_id`, `exercise_id__in`) are fully replaced; clients update in lockstep. The route slug (`analysis-notebook-template`) is unchanged.

Same category of change as #633 (which altered this same column's type).

## Changes

- **ORM** (`app/db/model.py`): column `assignment_id: Mapped[str | None] = mapped_column(String(255), index=True)` + docstring.
- **Schema** (`app/schemas/analysis_notebook_template.py`): renamed field on `AnalysisNotebookTemplateBaseMixin` (propagates to Create/Update/AdminUpdate/NestedRead/Read).
- **Filter** (`app/filters/analysis_notebook_template.py`): `assignment_id` and `assignment_id__in`.
- **Migration**: data-preserving `alter_column(new_column_name=...)` plus index rename (`ix_..._exercise_id` → `ix_..._assignment_id`) — not a drop/re-add.
- **Tests** + regenerated export script (`build_database_archive.sh` head-version bump).

## Verification

- `make format` + `make lint` (ruff format, ruff check, pyright): clean.
- Migration exercised from **base** on a fresh `db-test`.
- Full suite: **1097 passed**, coverage **97.65%** (≥ 90 gate).
