### PR TITLE
Fix virtual-lab-manager endpoint to resolve virtual-labs

### DIFF
--- a/app/utils/virtual_lab.py
+++ b/app/utils/virtual_lab.py
@@ -19,7 +19,7 @@ class VirtualLabClient:
 class AdminVirtualLabClient(VirtualLabClient):
     def get_virtual_lab_by_project(self, project_id: UUID) -> ProjectVirtualLabMapping:
         response = make_http_request(
-            url=f"/projects/{project_id}/virtual-lab",
+            url=f"/virtual-labs/projects/{project_id}/virtual-lab",
             http_client=self._http_client,
             method="GET",
         )

--- a/tests/dependencies/test_virtual_lab_api.py
+++ b/tests/dependencies/test_virtual_lab_api.py
@@ -32,7 +32,7 @@ def admin_bearer_credentials():
 
 
 def _virtual_lab_project_url(base_url: str, project_id: UUID | str = PROJECT_ID) -> str:
-    return f"{base_url}/projects/{project_id}/virtual-lab"
+    return f"{base_url}/virtual-labs/projects/{project_id}/virtual-lab"
 
 
 def _mapping_response_json(
@@ -204,7 +204,7 @@ def test_admin_virtual_lab_client_direct_instantiation(
 ):
     project_id = UUID(PROJECT_ID)
     httpx_mock.add_response(
-        url=re.compile(rf"{re.escape(virtual_lab_api_url)}/projects/.+/virtual-lab"),
+        url=re.compile(rf"{re.escape(virtual_lab_api_url)}/virtual-labs/projects/.+/virtual-lab"),
         json=_mapping_response_json(project_id),
     )
 

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -56,7 +56,7 @@ def virtual_lab_api_url(monkeypatch):
 @pytest.fixture
 def mock_virtual_lab_project_mapping(httpx_mock, virtual_lab_api_url):
     httpx_mock.add_response(
-        url=f"{virtual_lab_api_url}/projects/{PROJECT_ID}/virtual-lab",
+        url=f"{virtual_lab_api_url}/virtual-labs/projects/{PROJECT_ID}/virtual-lab",
         json={
             "data": {
                 "project_id": PROJECT_ID,
@@ -600,7 +600,7 @@ def test_upload_entity_asset_admin_virtual_lab_api_failure(
     client_admin, entity, httpx_mock, virtual_lab_api_url
 ):
     httpx_mock.add_response(
-        url=f"{virtual_lab_api_url}/projects/{PROJECT_ID}/virtual-lab",
+        url=f"{virtual_lab_api_url}/virtual-labs/projects/{PROJECT_ID}/virtual-lab",
         status_code=HTTPStatus.NOT_FOUND,
     )
     with FILE_EXAMPLE_PATH.open("rb") as f:


### PR DESCRIPTION
Use `/virtual-labs/projects` instead of `/projects` when calling virtual-lab-manager to resolve vtirtual-labs.

Refs:
- external [PR](https://github.com/openbraininstitute/virtual-lab-api/pull/149)
- openapi [docs](https://staging.openbraininstitute.org/api/virtual-lab-manager/docs#/Project%20Endpoints/get_virtual_lab_by_project)