### PR TITLE
Fix content_type not being None for directory label requirements

### DIFF
--- a/app/db/types.py
+++ b/app/db/types.py
@@ -3,7 +3,7 @@
 from enum import StrEnum, auto
 from typing import Annotated, Any, TypedDict
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from sqlalchemy import ARRAY, BigInteger
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import mapped_column
@@ -526,6 +526,13 @@ class LabelRequirements(BaseModel):
     content_type: ContentType | None
     is_directory: bool
     description: str = ""
+
+    @model_validator(mode="after")
+    def validate_directory_content_type(self):
+        if self.is_directory and self.content_type is not None:
+            msg = "content_type must be None when is_directory is True"
+            raise ValueError(msg)
+        return self
 
 
 CONTENT_TYPE_TO_SUFFIX: dict[ContentType, tuple[str, ...]] = {
@@ -1112,7 +1119,7 @@ ALLOWED_ASSET_LABELS_PER_TASK_RESULT = {
         ],
         AssetLabel.efeature_extraction_figures: [
             LabelRequirements(
-                content_type=ContentType.directory,
+                content_type=None,
                 is_directory=True,
                 description=(
                     "Directory of per-protocol/per-feature PDF extraction"
@@ -1145,7 +1152,7 @@ ALLOWED_ASSET_LABELS_PER_TASK_RESULT = {
         ],
         AssetLabel.emodel_analysis_figures: [
             LabelRequirements(
-                content_type=ContentType.directory,
+                content_type=None,
                 is_directory=True,
                 description="EModel analysis generated figures.",
             )

--- a/tests/db/test_types.py
+++ b/tests/db/test_types.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from app.db.types import (
     ALLOWED_ASSET_LABELS_PER_ENTITY,
     ALLOWED_ASSET_LABELS_PER_TASK_RESULT,
@@ -6,6 +9,7 @@ from app.db.types import (
     ContentType,
     EntityType,
     ExternalSource,
+    LabelRequirements,
     TaskResultType,
 )
 
@@ -24,3 +28,18 @@ def test_allowed_asset_labels_per_task_result_type():
 
 def test_external_source_info():
     assert set(ExternalSource) == set(EXTERNAL_SOURCE_INFO)
+
+
+def test_label_requirements_directory_content_type():
+    LabelRequirements(content_type=None, is_directory=True)
+    LabelRequirements(content_type=ContentType.json, is_directory=False)
+
+    with pytest.raises(
+        ValidationError, match="content_type must be None when is_directory is True"
+    ):
+        LabelRequirements(content_type=ContentType.json, is_directory=True)
+
+    with pytest.raises(
+        ValidationError, match="content_type must be None when is_directory is True"
+    ):
+        LabelRequirements(content_type=ContentType.directory, is_directory=True)


### PR DESCRIPTION
Suffix validation was triggered because content_type was not None in directory asset label requirements.
```
{"error_code":"ASSET_INVALID_SCHEMA","message":"Asset schema is invalid","details":["Value error, Suffix for content-type () does not match "]} 
```

Added a schema validator to prevent this mistake in the future.