### PR TITLE
Add Sentry integration

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -3,6 +3,7 @@
 import click
 
 from app.logger import configure_logging, configure_warnings
+from app.sentry import init_sentry
 from app.utils.uvicorn import run_server
 
 
@@ -22,4 +23,5 @@ def run(*, host: str, port: int, reload: bool) -> None:
 
 configure_logging()
 configure_warnings()
+init_sentry()
 cli()

--- a/app/config.py
+++ b/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
 
     SENTRY_DSN: str | None = None
     SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
-    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1.0
 
     ROOT_PATH: str = ""
     CORS_ORIGINS: list[str] = ["*"]

--- a/app/config.py
+++ b/app/config.py
@@ -33,8 +33,8 @@ class Settings(BaseSettings):
     DEPLOYMENT_ENV: Literal["local", "staging", "production"] = "local"
 
     SENTRY_DSN: str | None = None
-    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
-    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
 
     ROOT_PATH: str = ""
     CORS_ORIGINS: list[str] = ["*"]

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
-from typing import Literal
+from typing import Annotated, Literal
 from urllib.parse import quote
 
-from pydantic import PostgresDsn, SecretStr, field_validator, model_validator
+from pydantic import Field, PostgresDsn, SecretStr, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
     COMMIT_SHA: str | None = None
 
     ENVIRONMENT: str | None = None
+    DEPLOYMENT_ENV: Literal["local", "staging", "production"] = "local"
+
+    SENTRY_DSN: str | None = None
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
+
     ROOT_PATH: str = ""
     CORS_ORIGINS: list[str] = ["*"]
     CORS_ORIGIN_REGEX: str | None = None

--- a/app/config.py
+++ b/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
 
     SENTRY_DSN: str | None = None
     SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
-    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1
 
     ROOT_PATH: str = ""
     CORS_ORIGINS: list[str] = ["*"]

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,0 +1,21 @@
+"""Sentry integration."""
+
+import sentry_sdk
+
+from app.config import settings
+
+
+def init_sentry() -> None:
+    """Initialize the Sentry SDK.
+
+    Must be called after ``configure_logging``, which removes all the loguru handlers,
+    including the ones registered by the Sentry loguru integration.
+    """
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.DEPLOYMENT_ENV,
+        release=settings.APP_VERSION,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        profile_session_sample_rate=settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
+        profile_lifecycle="trace",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "python-multipart>=0.0.20",       # needed by fastapi to handle uploaded files
     "pgvector>=0.4.1",
     "openai>=1.101.0",
+    "sentry-sdk>=2.65.0",
 ]
 requires-python = "==3.12.*"
 readme = "README.md"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from app.config import Settings
 
@@ -22,3 +23,13 @@ def test_multipart_upload_size_invalid(monkeypatch):
 
     with pytest.raises(ValueError, match="S3 multipart upload max size outside allowed limits"):
         Settings()
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["SENTRY_TRACES_SAMPLE_RATE", "SENTRY_PROFILE_SESSION_SAMPLE_RATE"],
+)
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_configs_invalid_sentry_sample_rate(name, value):
+    with pytest.raises(ValidationError, match=name):
+        Settings(**{name: value})

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,19 @@
+import sentry_sdk
+
+from app import sentry as test_module
+from app.config import settings
+
+
+def test_init_sentry():
+    test_module.init_sentry()
+
+    client = sentry_sdk.get_client()
+    assert client.is_active()
+    assert client.transport is None  # without a DSN nothing is sent
+    assert client.options["environment"] == settings.DEPLOYMENT_ENV
+    assert client.options["release"] == settings.APP_VERSION
+    assert client.options["traces_sample_rate"] == settings.SENTRY_TRACES_SAMPLE_RATE
+    assert (
+        client.options["profile_session_sample_rate"] == settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE
+    )
+    assert client.options["profile_lifecycle"] == "trace"

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "sentry-sdk" },
     { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
@@ -335,6 +336,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.7.1" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "sentry-sdk", specifier = ">=2.65.0" },
     { name = "sqlalchemy" },
     { name = "starlette", specifier = ">=1.0.1" },
     { name = "uvicorn", extras = ["standard"] },
@@ -416,9 +418,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -969,6 +969,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.65.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/1f/ed17a390348156ca99fe622b97cd7d2f1969b5f49df89084b0f28e7953e9/sentry_sdk-2.65.0.tar.gz", hash = "sha256:c94dc945d54bad49d4f20448b1e6b217ca2f92f46d05c3e83d41764af685c3d1", size = 932133, upload-time = "2026-07-13T11:33:19.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/3b/326ad4c03b5da89b5124c8890af66e8119c4d2e10abc0619e0d67d9f7c7f/sentry_sdk-2.65.0-py3-none-any.whl", hash = "sha256:3595169677a808e4d0e1ea6ffb89443459549c7a98392ed71c77c847182ab6bf", size = 503869, upload-time = "2026-07-13T11:33:17.71Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a Sentry integration to entitycore, mirroring [openbraininstitute/accounting-service#53](https://github.com/openbraininstitute/accounting-service/pull/53) with entitycore's conventions. Uses `sentry-sdk>=2.65.0` (latest release).

## Changes

- **`app/sentry.py`** (new): `init_sentry()` calls `sentry_sdk.init(...)` with the DSN, environment, release (`APP_VERSION`), tracing + profiling sample rates, and `profile_lifecycle="trace"`.
- **`app/config.py`**: new settings, all env-var driven with defaults —
  - `DEPLOYMENT_ENV: Literal["local", "staging", "production"] = "local"` → Sentry `environment`
  - `SENTRY_DSN: str | None = None` (unset → nothing is sent)
  - `SENTRY_TRACES_SAMPLE_RATE` / `SENTRY_PROFILE_SESSION_SAMPLE_RATE` — both `Annotated[float, Field(ge=0, le=1)] = 1`
- **`app/__main__.py`**: calls `init_sentry()` after `configure_logging()` (so the loguru handler isn't stripped) and before the app is imported (so the FastAPI/Starlette auto-integrations attach).
- **`pyproject.toml` + `uv.lock`**: add `sentry-sdk>=2.65.0`.
- **Tests**: `tests/test_config.py` asserts out-of-range sample rates raise `ValidationError`; `tests/test_sentry.py` asserts `init_sentry()` produces an active client with `transport is None` (no DSN) and options matching settings.

With `SENTRY_DSN` unset (local dev, tests, CI) the SDK initializes as a no-op. Production supplies `SENTRY_DSN` / `DEPLOYMENT_ENV` / sample rates as runtime env vars; the DSN is deliberately kept out of the Docker build ARGs.
