### PR TITLE
Increase max_pool_connections in s3 client

### DIFF
--- a/app/utils/s3.py
+++ b/app/utils/s3.py
@@ -125,9 +125,14 @@ def get_s3_client(storage: StorageUnion) -> S3Client:
     clients: dict = getattr(_thread_local, "s3_clients", None) or {}
     if storage.type not in clients:
         if storage.is_open:
-            config = botocore.client.Config(signature_version=botocore.UNSIGNED)
+            config = botocore.client.Config(
+                signature_version=botocore.UNSIGNED,
+                max_pool_connections=settings.S3_DIRECTORY_UPLOAD_MAX_WORKERS,
+            )
         else:
-            config = botocore.client.Config()
+            config = botocore.client.Config(
+                max_pool_connections=settings.S3_DIRECTORY_UPLOAD_MAX_WORKERS,
+            )
         clients[storage.type] = boto3.session.Session().client(
             "s3", region_name=storage.region, config=config
         )


### PR DESCRIPTION
Increase max_pool_connections in s3 client to avoid a warning when uploading many files in a directory in the endpoints:
- directory/multipart-upload/initiate
- directory/multipart-upload/complete

Reuse the same value used for S3_DIRECTORY_UPLOAD_MAX_WORKERS, since in this way there should be a s3 worker free for each entitycore worker.

> {"time":"2026-07-20T12:25:44.722759+00:00","level":"WARNING","name":"sentry_sdk.integrations.logging","message":"Connection pool is full, discarding connection: entitycore-data-staging.s3.amazonaws.com. Connection pool size: 10","extra":{},"exception":null}

