### PR TITLE
Fix logger name misattributed to sentry_sdk.integrations.logging

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -32,9 +32,14 @@ class InterceptHandler(logging.Handler):
         except ValueError:
             level = record.levelno
 
-        # Find caller from where originated the logged message.
+        # Find caller from where originated the logged message, skipping also the frames
+        # injected by Sentry's LoggingIntegration, which patches logging.Logger.callHandlers.
         frame, depth = inspect.currentframe(), 0
-        while frame and (depth == 0 or frame.f_code.co_filename == logging.__file__):
+        while frame and (
+            depth == 0
+            or frame.f_code.co_filename == logging.__file__
+            or frame.f_globals.get("__name__", "").startswith("sentry_sdk.")
+        ):
             frame = frame.f_back
             depth += 1
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,30 @@
+import logging
+
+import sentry_sdk
+from loguru import logger
+
+from app.logger import InterceptHandler
+
+
+def test_intercept_handler_reports_caller_module():
+    sentry_sdk.init(dsn=None)
+    assert logging.Logger.callHandlers.__module__ == "sentry_sdk.integrations.logging"
+
+    messages = []
+    handler_id = logger.add(messages.append, level="INFO")
+    handler = InterceptHandler()
+    stdlib_logger = logging.getLogger("test_intercept_handler")
+    stdlib_logger.setLevel(logging.INFO)
+    stdlib_logger.propagate = False
+    stdlib_logger.addHandler(handler)
+    try:
+        stdlib_logger.info("intercepted message")
+    finally:
+        stdlib_logger.removeHandler(handler)
+        logger.remove(handler_id)
+
+    assert len(messages) == 1
+    record = messages[0].record
+    assert record["message"] == "intercepted message"
+    assert record["name"] == __name__
+    assert record["function"] == "test_intercept_handler_reports_caller_module"


### PR DESCRIPTION
## Problem

Since the Sentry integration (#667), every log emitted by third-party libraries through stdlib `logging` is reported with `"name":"sentry_sdk.integrations.logging"` instead of the originating module:

```
{"time":"...","level":"INFO","name":"sentry_sdk.integrations.logging","message":"HTTP Request: GET https://.../userinfo \"HTTP/1.1 200 OK\"",...}
```

## Cause

Sentry's default `LoggingIntegration` monkeypatches `logging.Logger.callHandlers`, inserting a `sentry_sdk` frame into the call stack between the stdlib `logging` frames. `InterceptHandler.emit` locates the original caller by walking frames and skipping only frames from the `logging` module, so the walk now stops at Sentry's wrapper. Loguru then derives `record["name"]` (and `function`/`line`) from that frame instead of the real caller. Known issue with the loguru intercept recipe: Delgan/loguru#509.

## Fix

Extend the frame walk to also skip frames whose module is `sentry_sdk.*`. Checked via the frame's `__name__` so `app/logger.py` doesn't need to import `sentry_sdk`, preserving the init ordering documented in `app/sentry.py`.

## Testing

- New regression test in `tests/test_logger.py`: initializes sentry (asserting `Logger.callHandlers` is actually patched), routes a stdlib log through `InterceptHandler`, and asserts the loguru record is attributed to the calling module/function. Fails with `'sentry_sdk.integrations.logging' == 'tests.test_logger'` without the fix.
- Full suite passes (1068 tests).