### PR TITLE
Add missing admin endpoints for assets

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -14,6 +14,12 @@ from app.dependencies.virtual_lab_api import AdminVirtualLabClientDep
 from app.filters.asset import AssetFilterDep
 from app.schemas.asset import (
     AssetRead,
+    AssetReadWithUploadMeta,
+    AssetRegister,
+    DetailedFileList,
+    MultipartDirectoryUploadRequest,
+    MultipartDirectoryUploadResponse,
+    MultipartUploadInitiateRequest,
 )
 from app.schemas.publish import ChangeProjectVisibilityResponse
 from app.schemas.types import ListResponse
@@ -42,6 +48,7 @@ def get_entity_assets(
     pagination_request: PaginationQuery,
     filter_model: AssetFilterDep,
 ) -> ListResponse[AssetRead]:
+    """Retrieve a paginated list of assets associated with a specific entity."""
     return admin_service.get_entity_assets(
         repos=repos,
         entity_route=entity_route,
@@ -80,6 +87,10 @@ def upload_entity_asset(
     label: Annotated[AssetLabel, Form()],
     meta: Annotated[dict | None, Form()] = None,
 ) -> AssetRead:
+    """Upload an asset to be associated with the specified entity.
+
+    To be used only for small files.
+    """
     return admin_service.upload_entity_asset(
         repos=repos,
         user_context=user_context,
@@ -89,6 +100,32 @@ def upload_entity_asset(
         file=file,
         label=label,
         meta=meta,
+        virtual_lab_client=virtual_lab_client,
+    )
+
+
+@router.post("/{entity_route}/{entity_id}/assets/register", status_code=status.HTTP_201_CREATED)
+def register_entity_asset(
+    *,
+    repos: RepoGroupDep,
+    entity_route: EntityRoute,
+    storage_client_factory: StorageClientFactoryDep,
+    user_context: AdminContextDep,
+    virtual_lab_client: AdminVirtualLabClientDep,
+    entity_id: uuid.UUID,
+    asset: AssetRegister,
+) -> AssetRead:
+    """Register an asset already in cloud.
+
+    Only open data storage is supported for now.
+    """
+    return admin_service.register_entity_asset(
+        repos=repos,
+        user_context=user_context,
+        storage_client_factory=storage_client_factory,
+        entity_id=entity_id,
+        entity_type=entity_route_to_type(entity_route),
+        asset=asset,
         virtual_lab_client=virtual_lab_client,
     )
 
@@ -139,8 +176,9 @@ def delete_entity_asset(
 ) -> AssetRead:
     """Delete an assets associated with a specific entity.
 
-    The asset record is not deleted from the database, but its status is changed.
     The file is actually deleted from S3, unless it's stored in open data storage.
+
+    Asset storage object is deleted via `app.db.events`.
     """
     asset = asset_service.delete_asset_unverified(
         repos,
@@ -148,8 +186,107 @@ def delete_entity_asset(
         entity_id=entity_id,
         asset_id=asset_id,
     )
-    # Note: Asset storage object is deleted via app.db.events
     return asset
+
+
+@router.get("/{entity_route}/{entity_id}/assets/{asset_id}/list")
+def list_directory(
+    repos: RepoGroupDep,
+    storage_client_factory: StorageClientFactoryDep,
+    entity_route: EntityRoute,
+    entity_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> DetailedFileList:
+    """Return the list of files in a directory asset."""
+    return admin_service.list_directory(
+        repos=repos,
+        storage_client_factory=storage_client_factory,
+        entity_type=entity_route_to_type(entity_route),
+        entity_id=entity_id,
+        asset_id=asset_id,
+    )
+
+
+@router.post("/{entity_route}/{entity_id}/assets/multipart-upload/initiate")
+def multipart_upload_initiate(
+    *,
+    repos: RepoGroupDep,
+    entity_route: EntityRoute,
+    storage_client_factory: StorageClientFactoryDep,
+    user_context: AdminContextDep,
+    virtual_lab_client: AdminVirtualLabClientDep,
+    entity_id: uuid.UUID,
+    json_model: MultipartUploadInitiateRequest,
+) -> AssetReadWithUploadMeta:
+    """Start a multipart upload for a file asset associated with an entity."""
+    return admin_service.multipart_upload_initiate(
+        repos=repos,
+        user_context=user_context,
+        storage_client_factory=storage_client_factory,
+        entity_id=entity_id,
+        entity_type=entity_route_to_type(entity_route),
+        json_model=json_model,
+        virtual_lab_client=virtual_lab_client,
+    )
+
+
+@router.post("/{entity_route}/{entity_id}/assets/{asset_id}/multipart-upload/complete")
+def multipart_upload_complete(
+    repos: RepoGroupDep,
+    storage_client_factory: StorageClientFactoryDep,
+    entity_route: EntityRoute,
+    entity_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> AssetRead:
+    """Finalize a multipart upload for a file asset associated with an entity."""
+    return admin_service.multipart_upload_complete(
+        repos=repos,
+        storage_client_factory=storage_client_factory,
+        entity_type=entity_route_to_type(entity_route),
+        entity_id=entity_id,
+        asset_id=asset_id,
+    )
+
+
+@router.post("/{entity_route}/{entity_id}/assets/directory/multipart-upload/initiate")
+def directory_multipart_upload_initiate(
+    *,
+    repos: RepoGroupDep,
+    entity_route: EntityRoute,
+    storage_client_factory: StorageClientFactoryDep,
+    user_context: AdminContextDep,
+    virtual_lab_client: AdminVirtualLabClientDep,
+    entity_id: uuid.UUID,
+    json_model: MultipartDirectoryUploadRequest,
+) -> MultipartDirectoryUploadResponse:
+    """Initiate a multipart upload for each file in a directory asset."""
+    return admin_service.directory_multipart_upload_initiate(
+        repos=repos,
+        user_context=user_context,
+        storage_client_factory=storage_client_factory,
+        entity_id=entity_id,
+        entity_type=entity_route_to_type(entity_route),
+        json_model=json_model,
+        virtual_lab_client=virtual_lab_client,
+    )
+
+
+@router.post("/{entity_route}/{entity_id}/assets/{asset_id}/directory/multipart-upload/complete")
+def directory_multipart_upload_complete(
+    repos: RepoGroupDep,
+    storage_client_factory: StorageClientFactoryDep,
+    entity_route: EntityRoute,
+    entity_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> AssetRead:
+    """Finalize a multipart upload for a directory asset associated with an entity."""
+    return admin_service.directory_multipart_upload_complete(
+        repos=repos,
+        storage_client_factory=storage_client_factory,
+        entity_type=entity_route_to_type(entity_route),
+        entity_id=entity_id,
+        asset_id=asset_id,
+    )
 
 
 @router.post("/publish-project/{project_id}")

--- a/app/routers/asset.py
+++ b/app/routers/asset.py
@@ -187,6 +187,8 @@ def delete_entity_asset(
     """Delete an assets associated with a specific entity.
 
     The file is actually deleted from S3, unless it's stored in open data storage.
+
+    Asset storage object is deleted via `app.db.events`.
     """
     asset = asset_service.delete_entity_asset(
         repos,
@@ -195,8 +197,6 @@ def delete_entity_asset(
         entity_id=entity_id,
         asset_id=asset_id,
     )
-
-    # Note: Asset storage object is deleted via app.db.events
 
     return asset
 
@@ -211,7 +211,7 @@ def entity_asset_directory_upload(
     files: DirectoryUploadRequest,
 ) -> AssetAndPresignedURLS:
     """Given a list of full paths, return a dictionary of presigned URLS for uploading."""
-    storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
+    storage = storages[StorageType.aws_s3_internal]
     s3_client = storage_client_factory(storage)
     model, urls = asset_service.entity_asset_directory_upload(
         repos=repos,
@@ -317,16 +317,13 @@ def entity_asset_multipart_upload_complete(
     - If you lose the presigned URLs and wish to cancel the upload, you must
       delete the asset manually using the delete asset endpoint.
     """
-    storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
-
     return asset_service.entity_asset_multipart_upload_complete(
         repos=repos,
         user_context=user_context,
         entity_type=entity_route_to_type(entity_route),
         entity_id=entity_id,
         asset_id=asset_id,
-        storage=storage,
-        s3_client=storage_client_factory(storage),
+        storage_client_factory=storage_client_factory,
     )
 
 
@@ -340,7 +337,7 @@ def entity_asset_directory_multipart_upload_initiate(
     json_model: MultipartDirectoryUploadRequest,
 ) -> MultipartDirectoryUploadResponse:
     """Initiate a multipart upload for directories."""
-    storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
+    storage = storages[StorageType.aws_s3_internal]
     s3_client = storage_client_factory(storage)
     entity_type = entity_route_to_type(entity_route)
 
@@ -364,14 +361,11 @@ def entity_asset_directory_multipart_upload_complete(
     entity_id: uuid.UUID,
     asset_id: uuid.UUID,
 ) -> AssetRead:
-    storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
-
     return asset_service.entity_asset_directory_multipart_upload_complete(
         repos=repos,
         user_context=user_context,
         entity_type=entity_route_to_type(entity_route),
         entity_id=entity_id,
         asset_id=asset_id,
-        storage=storage,
-        s3_client=storage_client_factory(storage),
+        storage_client_factory=storage_client_factory,
     )

--- a/app/service/admin.py
+++ b/app/service/admin.py
@@ -18,6 +18,12 @@ from app.queries.common import router_admin_delete_one, router_read_many
 from app.repository.group import RepositoryGroup
 from app.schemas.asset import (
     AssetRead,
+    AssetReadWithUploadMeta,
+    AssetRegister,
+    DetailedFileList,
+    MultipartDirectoryUploadRequest,
+    MultipartDirectoryUploadResponse,
+    MultipartUploadInitiateRequest,
 )
 from app.schemas.auth import UserContext
 from app.schemas.routers import DeleteResponse
@@ -25,6 +31,12 @@ from app.schemas.types import ListResponse
 from app.service.asset import (
     create_asset_download_redirect,
     create_entity_asset_unverified,
+    directory_multipart_upload_complete_unverified,
+    directory_multipart_upload_initiate_unverified,
+    list_directory_unverified,
+    multipart_upload_complete_unverified,
+    multipart_upload_initiate_unverified,
+    register_entity_asset_unverified,
     validate_uploadfile_for_small_entity_post,
 )
 from app.types import EntityRoute, ResourceRoute
@@ -34,6 +46,23 @@ from app.utils.s3 import (
     StorageClientFactory,
     upload_to_s3,
 )
+
+
+def _get_entity_and_vlab(
+    repos: RepositoryGroup,
+    virtual_lab_client: AdminVirtualLabClient,
+    entity_type: EntityType,
+    entity_id: uuid.UUID,
+) -> tuple[Entity, uuid.UUID]:
+    entity = crud.get_identifiable_one(
+        db=repos.db,
+        db_model_class=ENTITY_TYPE_TO_CLASS[entity_type],
+        id_=entity_id,
+    )
+    vlab_proj_mapping = virtual_lab_client.get_virtual_lab_by_project(
+        project_id=entity.authorized_project_id
+    )
+    return entity, vlab_proj_mapping.virtual_lab_id
 
 
 def delete_one(
@@ -153,14 +182,7 @@ def upload_entity_asset(
     s3_client = storage_client_factory(storage)
     content_type = validate_uploadfile_for_small_entity_post(file)
     sha256_digest = calculate_sha256_digest(file)
-    entity = crud.get_identifiable_one(
-        db=repos.db,
-        db_model_class=ENTITY_TYPE_TO_CLASS[entity_type],
-        id_=entity_id,
-    )
-    vlab_proj_mapping = virtual_lab_client.get_virtual_lab_by_project(
-        project_id=entity.authorized_project_id
-    )
+    entity, virtual_lab_id = _get_entity_and_vlab(repos, virtual_lab_client, entity_type, entity_id)
     asset_db = create_entity_asset_unverified(
         repos,
         entity=entity,
@@ -173,7 +195,7 @@ def upload_entity_asset(
         is_directory=False,
         storage_type=storage.type,
         user_profile=user_context.profile,
-        virtual_lab_id=vlab_proj_mapping.virtual_lab_id,
+        virtual_lab_id=virtual_lab_id,
     )
     if not upload_to_s3(
         s3_client,
@@ -183,3 +205,106 @@ def upload_entity_asset(
     ):
         raise HTTPException(status_code=500, detail="Failed to upload object")
     return AssetRead.model_validate(asset_db)
+
+
+def register_entity_asset(
+    repos: RepositoryGroup,
+    user_context: UserContext,
+    virtual_lab_client: AdminVirtualLabClient,
+    storage_client_factory: StorageClientFactory,
+    entity_id: uuid.UUID,
+    entity_type: EntityType,
+    asset: AssetRegister,
+) -> AssetRead:
+    entity, virtual_lab_id = _get_entity_and_vlab(repos, virtual_lab_client, entity_type, entity_id)
+    return register_entity_asset_unverified(
+        repos,
+        entity=entity,
+        virtual_lab_id=virtual_lab_id,
+        user_profile=user_context.profile,
+        storage_client_factory=storage_client_factory,
+        asset=asset,
+    )
+
+
+def multipart_upload_initiate(
+    repos: RepositoryGroup,
+    user_context: UserContext,
+    virtual_lab_client: AdminVirtualLabClient,
+    storage_client_factory: StorageClientFactory,
+    entity_id: uuid.UUID,
+    entity_type: EntityType,
+    json_model: MultipartUploadInitiateRequest,
+) -> AssetReadWithUploadMeta:
+    entity, virtual_lab_id = _get_entity_and_vlab(repos, virtual_lab_client, entity_type, entity_id)
+    storage = storages[StorageType.aws_s3_internal]
+    return multipart_upload_initiate_unverified(
+        repos,
+        entity=entity,
+        virtual_lab_id=virtual_lab_id,
+        user_profile=user_context.profile,
+        s3_client=storage_client_factory(storage),
+        storage=storage,
+        json_model=json_model,
+    )
+
+
+def list_directory(
+    repos: RepositoryGroup,
+    storage_client_factory: StorageClientFactory,
+    entity_type: EntityType,
+    entity_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> DetailedFileList:
+    asset = get_entity_asset(repos, entity_type=entity_type, entity_id=entity_id, asset_id=asset_id)
+    return list_directory_unverified(asset=asset, storage_client_factory=storage_client_factory)
+
+
+def directory_multipart_upload_initiate(
+    repos: RepositoryGroup,
+    user_context: UserContext,
+    virtual_lab_client: AdminVirtualLabClient,
+    storage_client_factory: StorageClientFactory,
+    entity_id: uuid.UUID,
+    entity_type: EntityType,
+    json_model: MultipartDirectoryUploadRequest,
+) -> MultipartDirectoryUploadResponse:
+    entity, virtual_lab_id = _get_entity_and_vlab(repos, virtual_lab_client, entity_type, entity_id)
+    storage = storages[StorageType.aws_s3_internal]
+    return directory_multipart_upload_initiate_unverified(
+        repos=repos,
+        entity=entity,
+        virtual_lab_id=virtual_lab_id,
+        s3_client=storage_client_factory(storage),
+        storage=storage,
+        json_model=json_model,
+        user_profile=user_context.profile,
+    )
+
+
+def multipart_upload_complete(
+    repos: RepositoryGroup,
+    storage_client_factory: StorageClientFactory,
+    entity_type: EntityType,
+    entity_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> AssetRead:
+    with ensure_result(f"Asset {asset_id} not found", error_code=ApiErrorCode.ASSET_NOT_FOUND):
+        asset_db = repos.asset.get_entity_asset(
+            entity_type=entity_type, entity_id=entity_id, asset_id=asset_id
+        )
+    return multipart_upload_complete_unverified(repos, asset_db, storage_client_factory)
+
+
+def directory_multipart_upload_complete(
+    repos: RepositoryGroup,
+    storage_client_factory: StorageClientFactory,
+    entity_type: EntityType,
+    entity_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> AssetRead:
+    with ensure_result(f"Asset {asset_id} not found", error_code=ApiErrorCode.ASSET_NOT_FOUND):
+        asset_db = repos.asset.get_entity_asset(
+            entity_type=entity_type, entity_id=entity_id, asset_id=asset_id
+        )
+    return directory_multipart_upload_complete_unverified(repos, asset_db, storage_client_factory)

--- a/app/service/asset.py
+++ b/app/service/asset.py
@@ -403,6 +403,7 @@ def delete_asset_unverified(
     """Delete an asset from the db withouth checking authorization.
 
     In case of directory asset with children registered in the db, they are deleted on cascade.
+
     Asset storage object is deleted via `app.db.events`.
     """
     # TODO: Only directories registered with multipart upload have the children in the db, but
@@ -636,7 +637,7 @@ def multipart_upload_initiate(
         entity_id=entity_id,
     )
     virtual_lab_id = resolve_virtual_lab_id(user_context, entity.authorized_project_id)
-    storage = storages[StorageType.aws_s3_internal]  # hardcoded for now
+    storage = storages[StorageType.aws_s3_internal]
     s3_client = storage_client_factory(storage)
     return multipart_upload_initiate_unverified(
         repos,
@@ -738,11 +739,11 @@ def _entity_asset_multipart_upload_initiate(
 def multipart_upload_complete_unverified(
     repos: RepositoryGroup,
     asset_db: Asset,
-    storage: StorageUnion,
-    s3_client: S3Client,
+    storage_client_factory: StorageClientFactory,
 ) -> AssetRead:
     """Complete a multipart upload for an asset, without checking authorization."""
-    complete_asset_s3(asset=asset_db, storage=storage, s3_client=s3_client)
+    storage = storages[asset_db.storage_type]
+    complete_asset_s3(asset=asset_db, storage=storage, s3_client=storage_client_factory(storage))
     asset_db.status = AssetStatus.CREATED
     repos.db.flush()
     return AssetRead.model_validate(asset_db)
@@ -755,8 +756,7 @@ def entity_asset_multipart_upload_complete(
     entity_type: EntityType,
     entity_id: uuid.UUID,
     asset_id: uuid.UUID,
-    storage: StorageUnion,
-    s3_client: S3Client,
+    storage_client_factory: StorageClientFactory,
 ) -> AssetRead:
     """Complete a multipart upload for an existing entity asset."""
     asset_db = get_writable_entity_db_asset(
@@ -766,12 +766,7 @@ def entity_asset_multipart_upload_complete(
         entity_id=entity_id,
         asset_id=asset_id,
     )
-    return multipart_upload_complete_unverified(
-        repos,
-        asset_db=asset_db,
-        storage=storage,
-        s3_client=s3_client,
-    )
+    return multipart_upload_complete_unverified(repos, asset_db, storage_client_factory)
 
 
 def download_entity_asset(
@@ -985,8 +980,7 @@ def entity_asset_directory_multipart_upload_initiate(
 def directory_multipart_upload_complete_unverified(
     repos: RepositoryGroup,
     asset_db: Asset,
-    storage: StorageUnion,
-    s3_client: S3Client,
+    storage_client_factory: StorageClientFactory,
 ) -> AssetRead:
     """Complete a multipart upload for a directory asset, without checking authorization."""
     if asset_db.status != AssetStatus.UPLOADING:
@@ -995,6 +989,8 @@ def directory_multipart_upload_complete_unverified(
             error_code=ApiErrorCode.ASSET_NOT_UPLOADING,
             http_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         )
+    storage = storages[asset_db.storage_type]
+    s3_client = storage_client_factory(storage)
     pending_children = [child for child in asset_db.children if child.status != AssetStatus.CREATED]
     if pending_children:
         max_workers = min(settings.S3_MAX_WORKERS, len(pending_children))
@@ -1024,8 +1020,7 @@ def entity_asset_directory_multipart_upload_complete(
     entity_type: EntityType,
     entity_id: uuid.UUID,
     asset_id: uuid.UUID,
-    storage: StorageUnion,
-    s3_client: S3Client,
+    storage_client_factory: StorageClientFactory,
 ) -> AssetRead:
     """Complete a multipart upload for an existing directory asset."""
     asset_db = get_writable_entity_db_asset(
@@ -1035,4 +1030,4 @@ def entity_asset_directory_multipart_upload_complete(
         entity_id=entity_id,
         asset_id=asset_id,
     )
-    return directory_multipart_upload_complete_unverified(repos, asset_db, storage, s3_client)
+    return directory_multipart_upload_complete_unverified(repos, asset_db, storage_client_factory)

--- a/tests/routers/test_asset.py
+++ b/tests/routers/test_asset.py
@@ -2560,3 +2560,222 @@ def test_multipart_directory_upload_abort(db, client, circuit, s3, s3_internal_b
 
     # Verify multipart upload was aborted
     assert not s3_multipart_upload_exists(s3, upload_id, s3_internal_bucket)
+
+
+@pytest.mark.usefixtures("s3_file", "mock_virtual_lab_project_mapping")
+def test_register_entity_asset_admin(client_admin, entity):
+    response = assert_request(
+        client_admin.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/register",
+        json={
+            "path": "admin-test.swc",
+            "full_path": "path/to/test.swc",
+            "is_directory": False,
+            "content_type": "application/swc",
+            "label": "morphology",
+            "storage_type": "aws_s3_open",
+        },
+        expected_status_code=201,
+    )
+    data = response.json()
+    assert data["path"] == "admin-test.swc"
+    assert data["storage_type"] == "aws_s3_open"
+    assert data["status"] == "created"
+
+
+@pytest.mark.usefixtures("virtual_lab_api_url")
+def test_register_entity_asset_admin_non_authorized(clients, entity):
+    response = assert_request(
+        clients.user_1.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/register",
+        json={
+            "path": "admin-test.swc",
+            "full_path": "path/to/test.swc",
+            "is_directory": False,
+            "content_type": "application/swc",
+            "label": "morphology",
+            "storage_type": "aws_s3_open",
+        },
+        expected_status_code=403,
+    )
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.NOT_AUTHORIZED
+
+
+def test_list_directory_admin(
+    clients, root_circuit, circuit, private_asset_directory, asset_directory
+):
+    entity_type = route(root_circuit.type)
+    fake_files = {
+        "file1.txt": {"name": "file1.txt", "size": 100, "last_modified": "2024-01-01T00:00:00Z"},
+    }
+
+    with patch("app.service.asset.list_directory_with_details", return_value=fake_files):
+        # admin can list any directory regardless of visibility
+        data = assert_request(
+            clients.admin.get,
+            url=f"/admin{entity_type}/{circuit.id}/assets/{private_asset_directory.id}/list",
+        ).json()
+        assert data["files"] == fake_files
+
+    with patch("app.service.asset.list_directory_with_details", return_value=fake_files):
+        data = assert_request(
+            clients.admin.get,
+            url=f"/admin{entity_type}/{root_circuit.id}/assets/{asset_directory.id}/list",
+        ).json()
+        assert data["files"] == fake_files
+
+
+@pytest.mark.usefixtures("virtual_lab_api_url")
+def test_list_directory_admin_non_authorized(clients, root_circuit, asset_directory):
+    entity_type = route(root_circuit.type)
+    response = assert_request(
+        clients.user_1.get,
+        url=f"/admin{entity_type}/{root_circuit.id}/assets/{asset_directory.id}/list",
+        expected_status_code=403,
+    )
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.NOT_AUTHORIZED
+
+
+@pytest.mark.usefixtures("mock_virtual_lab_project_mapping")
+def test_multipart_upload_initiate_admin(client_admin, entity):
+    data = assert_request(
+        client_admin.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/multipart-upload/initiate",
+        json=_multipart_json_data(),
+    ).json()
+    assert data["status"] == "uploading"
+    assert data["upload_meta"] is not None
+    assert len(data["upload_meta"]["parts"]) == 3
+
+
+@pytest.mark.usefixtures("virtual_lab_api_url")
+def test_multipart_upload_initiate_admin_non_authorized(clients, entity):
+    response = assert_request(
+        clients.user_1.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/multipart-upload/initiate",
+        json=_multipart_json_data(),
+        expected_status_code=403,
+    )
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.NOT_AUTHORIZED
+
+
+@pytest.mark.usefixtures("mock_virtual_lab_project_mapping")
+def test_multipart_upload_complete_admin(db, client_admin, entity, s3, s3_internal_bucket):
+    data = assert_request(
+        client_admin.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/multipart-upload/initiate",
+        json=_multipart_json_data(filesize=3 * 5 * 1024**2),
+    ).json()
+
+    upload_id = db.get(Asset, data["id"]).upload_meta["upload_id"]
+    part_size = data["upload_meta"]["part_size"]
+    for part in data["upload_meta"]["parts"]:
+        s3.upload_part(
+            Bucket=s3_internal_bucket,
+            Key=data["full_path"],
+            UploadId=upload_id,
+            PartNumber=part["part_number"],
+            Body=b"x" * part_size,
+        )
+
+    completed = assert_request(
+        client_admin.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/{data['id']}/multipart-upload/complete",
+    ).json()
+    assert completed["status"] == "created"
+
+
+@pytest.mark.usefixtures("virtual_lab_api_url")
+def test_multipart_upload_complete_admin_non_authorized(clients, entity, uploading_asset):
+    response = assert_request(
+        clients.user_1.post,
+        url=f"/admin{route(entity.type)}/{entity.id}/assets/{uploading_asset.id}/multipart-upload/complete",
+        expected_status_code=403,
+    )
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.NOT_AUTHORIZED
+
+
+@pytest.mark.usefixtures("mock_virtual_lab_project_mapping")
+def test_directory_multipart_upload_initiate_admin(client_admin, root_circuit):
+    entity_type = route(root_circuit.type)
+    data = assert_request(
+        client_admin.post,
+        url=f"/admin{entity_type}/{root_circuit.id}/assets/directory/multipart-upload/initiate",
+        json=_multipart_directory_json_data(directory_name="admin-dir"),
+    ).json()
+    assert data["asset"]["is_directory"] is True
+    assert data["asset"]["status"] == "uploading"
+    assert len(data["files"]) == 2
+
+
+@pytest.mark.usefixtures("virtual_lab_api_url")
+def test_directory_multipart_upload_initiate_admin_non_authorized(clients, root_circuit):
+    response = assert_request(
+        clients.user_1.post,
+        url=f"/admin{route(root_circuit.type)}/{root_circuit.id}/assets/directory/multipart-upload/initiate",
+        json=_multipart_directory_json_data(directory_name="admin-dir-unauth"),
+        expected_status_code=403,
+    )
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.NOT_AUTHORIZED
+
+
+@pytest.mark.usefixtures("mock_virtual_lab_project_mapping")
+def test_directory_multipart_upload_complete_admin(
+    client_admin, root_circuit, db, s3, s3_internal_bucket
+):
+    entity_type = route(root_circuit.type)
+    filesize = 3 * 5 * 1024**2
+
+    data = assert_request(
+        client_admin.post,
+        url=f"/admin{entity_type}/{root_circuit.id}/assets/directory/multipart-upload/initiate",
+        json=_multipart_directory_json_data(
+            directory_name="admin-complete-dir",
+            files=[
+                {
+                    "filename": "file.bin",
+                    "filesize": filesize,
+                    "sha256_digest": DUMMY_DIGEST,
+                    "preferred_part_count": 3,
+                }
+            ],
+        ),
+    ).json()
+
+    parent_id = data["asset"]["id"]
+    file_asset = data["files"][0]
+    upload_id = db.get(Asset, file_asset["id"]).upload_meta["upload_id"]
+    part_size = file_asset["upload_meta"]["part_size"]
+    for part in file_asset["upload_meta"]["parts"]:
+        s3.upload_part(
+            Bucket=s3_internal_bucket,
+            Key=file_asset["full_path"],
+            UploadId=upload_id,
+            PartNumber=part["part_number"],
+            Body=b"x" * part_size,
+        )
+
+    completed = assert_request(
+        client_admin.post,
+        url=f"/admin{entity_type}/{root_circuit.id}/assets/{parent_id}/directory/multipart-upload/complete",
+    ).json()
+    assert completed["status"] == "created"
+    assert completed["is_directory"] is True
+
+
+@pytest.mark.usefixtures("virtual_lab_api_url")
+def test_directory_multipart_upload_complete_admin_non_authorized(
+    clients, root_circuit, asset_directory
+):
+    response = assert_request(
+        clients.user_1.post,
+        url=f"/admin{route(root_circuit.type)}/{root_circuit.id}/assets/{asset_directory.id}/directory/multipart-upload/complete",
+        expected_status_code=403,
+    )
+    error = ErrorResponse.model_validate(response.json())
+    assert error.error_code == ApiErrorCode.NOT_AUTHORIZED


### PR DESCRIPTION
Add the following admin endpoints for assets, mirroring the existing user-facing endpoints in `routers/asset.py`:

- `POST /admin/{entity_route}/{entity_id}/assets` — small file upload
- `POST /admin/{entity_route}/{entity_id}/assets/register` — register existing cloud asset
- `GET /admin/{entity_route}/{entity_id}/assets/{asset_id}/list` — list directory contents
- `POST /admin/{entity_route}/{entity_id}/assets/multipart-upload/initiate`
- `POST /admin/{entity_route}/{entity_id}/assets/{asset_id}/multipart-upload/complete`
- `POST /admin/{entity_route}/{entity_id}/assets/directory/multipart-upload/initiate`
- `POST /admin/{entity_route}/{entity_id}/assets/{asset_id}/directory/multipart-upload/complete`

All new endpoints delegate to `_unverified` functions, avoiding code duplication. A `_get_entity_and_vlab` helper in `service/admin.py` handles the auth-bypass entity + virtual lab lookup shared across the write endpoints.
