### PR TITLE
Strict update schemas: forbid extras and merge exclusions

### DIFF
--- a/app/schemas/derivation.py
+++ b/app/schemas/derivation.py
@@ -7,7 +7,7 @@ from app.db.types import DerivationType
 from app.schemas.base import Schema
 from app.schemas.entity import NestedEntityRead
 from app.schemas.identifiable import IdentifiableCreate, IdentifiableRead
-from app.schemas.utils import DEFAULT_EXCLUDED_FIELDS, make_update_schema
+from app.schemas.utils import make_update_schema
 
 # Allowed label values per derivation type.
 # - emodel_circuit: SONATA ``model_template`` entry, by convention ``hoc:<template_name>``.
@@ -65,7 +65,7 @@ DERIVATION_EXCLUDED_FIELDS = {"used_id", "generated_id", "derivation_type"}
 DerivationUserUpdate = make_update_schema(
     DerivationCreate,
     "DerivationUserUpdate",
-    excluded_fields=DEFAULT_EXCLUDED_FIELDS | DERIVATION_EXCLUDED_FIELDS,
+    excluded_fields=DERIVATION_EXCLUDED_FIELDS,
 )  # pyright: ignore [reportInvalidTypeForm]
 DerivationAdminUpdate = make_update_schema(
     DerivationCreate,

--- a/app/schemas/utils.py
+++ b/app/schemas/utils.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import Field, create_model
+from pydantic import ConfigDict, Field, create_model
 
 from app.schemas.base import Schema
 
@@ -10,24 +10,40 @@ DEFAULT_EXCLUDED_FIELDS = {
 DEFAULT_PRESERVED_FIELDS = set()
 
 
+class UpdateSchema(Schema):
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+
+
 def make_update_schema(
     schema: type[Schema],
     new_schema_name: str | None = None,
-    excluded_fields: set = DEFAULT_EXCLUDED_FIELDS,
+    excluded_fields: set | None = None,
     preserved_fields: set = DEFAULT_PRESERVED_FIELDS,
 ):
     """Create a new pydantic schema from current schema where all fields are optional.
 
     When the api payload instantiates the schema model, the user can explicitly set an update value
     to None.
+
+    ``excluded_fields`` semantics:
+    - ``None`` (omitted): use ``DEFAULT_EXCLUDED_FIELDS``
+    - empty set: no exclusions (admin opt-out)
+    - non-empty set: ``DEFAULT_EXCLUDED_FIELDS | excluded_fields``
     """
 
     def make_optional(field):
         return Annotated[field.annotation | None, Field(default=None)]
 
+    if excluded_fields is None:
+        excluded = set(DEFAULT_EXCLUDED_FIELDS)
+    elif not excluded_fields:
+        excluded = set()
+    else:
+        excluded = DEFAULT_EXCLUDED_FIELDS | excluded_fields
+
     fields = {}
     for name, field in schema.model_fields.items():
-        if name in excluded_fields:
+        if name in excluded:
             continue
 
         if name in preserved_fields:
@@ -36,4 +52,4 @@ def make_update_schema(
 
         fields[name] = make_optional(field)
 
-    return create_model(new_schema_name, **fields)  # pyright: ignore reportArgumentType
+    return create_model(new_schema_name, __base__=UpdateSchema, **fields)  # pyright: ignore reportArgumentType

--- a/app/schemas/utils.py
+++ b/app/schemas/utils.py
@@ -29,13 +29,17 @@ def make_update_schema(
     - ``None`` (omitted): use ``DEFAULT_EXCLUDED_FIELDS``
     - empty set: no exclusions (admin opt-out)
     - non-empty set: ``DEFAULT_EXCLUDED_FIELDS | excluded_fields``
+
+    ``preserved_fields``: fields that stay required with their create-schema default instead of
+    becoming optional. Useful when a field must not be omitted from the update payload by mistake
+    (e.g. ``generation_type`` on cell morphology protocols).
     """
 
     def make_optional(field):
         return Annotated[field.annotation | None, Field(default=None)]
 
     if excluded_fields is None:
-        excluded = set(DEFAULT_EXCLUDED_FIELDS)
+        excluded = DEFAULT_EXCLUDED_FIELDS
     elif not excluded_fields:
         excluded = set()
     else:

--- a/tests/test_derivation.py
+++ b/tests/test_derivation.py
@@ -549,19 +549,25 @@ def test_update_one(db, clients, root_circuit, circuit, person_id):
     data = assert_request(
         clients.user_2.patch,
         url=f"{ROUTE}/{did}",
-        json={"derivation_type": DerivationType.unspecified.value},
+        json={"label": "label-u2"},
         expected_status_code=404,
     ).json()
     assert data["error_code"] == "ENTITY_NOT_FOUND"
+
+    # excluded fields are rejected (not silently ignored)
+    assert_request(
+        clients.user_1.patch,
+        url=f"{ROUTE}/{did}",
+        json={"derivation_type": DerivationType.unspecified.value, "label": "label-u1"},
+        expected_status_code=422,
+    )
 
     # user_1 owns the generated entity -> update succeeds
     data = assert_request(
         clients.user_1.patch,
         url=f"{ROUTE}/{did}",
-        json={"derivation_type": DerivationType.unspecified.value, "label": "label-u1"},
+        json={"label": "label-u1"},
     ).json()
-
-    # derivation_type is excluded from updates
     assert data["derivation_type"] == DerivationType.circuit_extraction
     assert data["label"] == "label-u1"
     assert data["updated_by"]["id"] == str(person_id)
@@ -582,18 +588,24 @@ def test_update_one(db, clients, root_circuit, circuit, person_id):
     data = assert_request(clients.user_1.get, url=f"{ROUTE}/{did}").json()
     assert data["label"] == "label-u1"
 
-    # admin on admin route bypasses writable-entity checks
-    data = assert_request(
+    # excluded fields are rejected on admin route too
+    assert_request(
         clients.admin.patch,
         url=f"{ADMIN_ROUTE}/{did}",
         json={
             "label": "label-admin",
             "derivation_type": DerivationType.circuit_rewiring.value,
         },
+        expected_status_code=422,
+    )
+
+    # admin on admin route bypasses writable-entity checks
+    data = assert_request(
+        clients.admin.patch,
+        url=f"{ADMIN_ROUTE}/{did}",
+        json={"label": "label-admin"},
     ).json()
     assert data["label"] == "label-admin"
-
-    # excluded attribute
     assert data["derivation_type"] == DerivationType.circuit_extraction
 
     data = assert_request(clients.user_1.get, url=f"{ROUTE}/{did}").json()

--- a/tests/test_schemas_utils.py
+++ b/tests/test_schemas_utils.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.base import AuthorizationOptionalPublicMixin, Schema
+from app.schemas.utils import make_update_schema
+
+
+class _ExampleCreate(Schema, AuthorizationOptionalPublicMixin):
+    name: str
+    secret: str
+
+
+def test_make_update_schema_default_exclusions():
+    update = make_update_schema(_ExampleCreate, "ExampleUserUpdate")
+    assert "authorized_public" not in update.model_fields
+    assert sorted(update.model_fields) == ["name", "secret"]
+    assert update.model_config.get("extra") == "forbid"
+
+
+def test_make_update_schema_empty_exclusions_opt_out():
+    update = make_update_schema(_ExampleCreate, "ExampleAdminUpdate", excluded_fields=set())
+    assert "authorized_public" in update.model_fields
+    update.model_validate({"authorized_public": True})
+
+
+def test_make_update_schema_merges_default_exclusions():
+    update = make_update_schema(_ExampleCreate, "ExampleMergedUpdate", excluded_fields={"secret"})
+    assert sorted(update.model_fields) == ["name"]
+    assert "authorized_public" not in update.model_fields
+    assert "secret" not in update.model_fields
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"name": "x", "authorized_public": True},
+        {"name": "x", "unknown": 1},
+    ],
+)
+def test_make_update_schema_forbids_excluded_and_unknown(payload):
+    update = make_update_schema(_ExampleCreate, "ExampleForbidUpdate")
+    with pytest.raises(ValidationError) as exc_info:
+        update.model_validate(payload)
+    assert exc_info.value.errors()[0]["type"] == "extra_forbidden"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1175,6 +1175,23 @@ def check_global_read_many(
     _req(clients.admin, admin_route)
 
 
+def _assert_update_rejects_extra_fields(client, url: str, *, extra_payload: dict | None = None):
+    """Update schemas use extra='forbid'; unknown/excluded fields must return 422."""
+    assert_request(
+        client.patch,
+        url=url,
+        json={"__unknown_field__": "x"},
+        expected_status_code=422,
+    )
+    if extra_payload:
+        assert_request(
+            client.patch,
+            url=url,
+            json=extra_payload,
+            expected_status_code=422,
+        )
+
+
 def check_global_update_one(
     *,
     route: str,
@@ -1202,6 +1219,8 @@ def check_global_update_one(
     ).json()
     assert data["message"] == "Service admin role required"
 
+    _assert_update_rejects_extra_fields(clients.admin, f"{route}/{model_id}")
+
     # update using admin client and regular route
     _patch_compare(clients.admin.patch, f"{route}/{model_id}", patch_payload)
 
@@ -1216,6 +1235,8 @@ def check_global_update_one(
         expected_status_code=403,
     ).json()
     assert data["message"] == "Service admin role required"
+
+    _assert_update_rejects_extra_fields(clients.admin, f"{admin_route}/{model_id}")
 
     # update using admin client and admin route
     _patch_compare(clients.admin.patch, f"{admin_route}/{model_id}", patch_payload)
@@ -1406,6 +1427,13 @@ def check_entity_update_one(
         _patch_compare(clients.user_1, f"{route}/{private_1_id}", optional_payload)
         _patch_compare(clients.user_1, f"{route}/{private_1_id}", dict.fromkeys(optional_payload))
 
+    # user update schema forbids unknown fields and default-excluded fields
+    _assert_update_rejects_extra_fields(
+        clients.user_1,
+        f"{route}/{private_1_id}",
+        extra_payload={"authorized_public": True},
+    )
+
     # only admin client can hit admin endpoint
     data = assert_request(
         clients.user_1.patch,
@@ -1415,6 +1443,11 @@ def check_entity_update_one(
     ).json()
     assert data["error_code"] == "NOT_AUTHORIZED"
     assert data["message"] == "Service admin role required"
+
+    # admin update schema forbids unknown fields but allows authorized_public
+    _assert_update_rejects_extra_fields(clients.admin, f"{admin_route}/{private_1_id}")
+    _patch_compare(clients.admin, f"{admin_route}/{private_1_id}", {"authorized_public": True})
+    _patch_compare(clients.admin, f"{admin_route}/{private_1_id}", {"authorized_public": False})
 
     _patch_compare(clients.admin, f"{admin_route}/{private_1_id}", patch_payload)
 


### PR DESCRIPTION
## Summary
- Update `make_update_schema` so non-empty `excluded_fields` merge with `DEFAULT_EXCLUDED_FIELDS`; `set()` still means no exclusions (admin).
- Generated update models use `extra="forbid"`, so unknown or excluded PATCH fields return 422 instead of being dropped.
- Cover the behavior in shared update helpers and derivation/unit tests.

Closes #614

## Test plan
- [x] `tests/test_schemas_utils.py` (merge / empty / forbid)
- [x] `tests/test_derivation.py::test_update_one`
- [x] `check_entity_update_one` / `check_global_update_one` via subject, species, circuit, measurement-label update tests
- [x] Full suite: `make test-docker` (or CI)