### PR TITLE
Change AdminContextDep to UserContextDep for Person, Organization, Consortium create (#688)

### DIFF
--- a/app/service/consortium.py
+++ b/app/service/consortium.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import aliased, joinedload, raiseload
 
 import app.queries.common
 from app.db.model import Consortium, Person
-from app.dependencies.auth import AdminContextDep
+from app.dependencies.auth import AdminContextDep, UserContextDep
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.filters.consortium import ConsortiumFilterDep
@@ -94,7 +94,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> ConsortiumRead:
 
 
 def create_one(
-    json_model: ConsortiumCreate, db: SessionDep, user_context: AdminContextDep
+    json_model: ConsortiumCreate, db: SessionDep, user_context: UserContextDep
 ) -> ConsortiumRead:
     return app.queries.common.router_create_one(
         db=db,
@@ -108,7 +108,7 @@ def create_one(
 
 def update_one(
     db: SessionDep,
-    user_context: AdminContextDep,
+    user_context: UserContextDep,
     id_: uuid.UUID,
     json_model: ConsortiumAdminUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> ConsortiumRead:

--- a/app/service/consortium.py
+++ b/app/service/consortium.py
@@ -108,7 +108,7 @@ def create_one(
 
 def update_one(
     db: SessionDep,
-    user_context: UserContextDep,
+    user_context: AdminContextDep,
     id_: uuid.UUID,
     json_model: ConsortiumAdminUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> ConsortiumRead:

--- a/app/service/organization.py
+++ b/app/service/organization.py
@@ -108,7 +108,7 @@ def create_one(
 
 def update_one(
     db: SessionDep,
-    user_context: UserContextDep,
+    user_context: AdminContextDep,
     id_: uuid.UUID,
     json_model: OrganizationAdminUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> OrganizationRead:

--- a/app/service/organization.py
+++ b/app/service/organization.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import aliased, joinedload, raiseload
 
 import app.queries.common
 from app.db.model import Organization, Person
-from app.dependencies.auth import AdminContextDep
+from app.dependencies.auth import AdminContextDep, UserContextDep
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.filters.organization import OrganizationFilterDep
@@ -94,7 +94,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> OrganizationRead:
 
 
 def create_one(
-    organization: OrganizationCreate, db: SessionDep, user_context: AdminContextDep
+    organization: OrganizationCreate, db: SessionDep, user_context: UserContextDep
 ) -> OrganizationRead:
     return app.queries.common.router_create_one(
         db=db,
@@ -108,7 +108,7 @@ def create_one(
 
 def update_one(
     db: SessionDep,
-    user_context: AdminContextDep,
+    user_context: UserContextDep,
     id_: uuid.UUID,
     json_model: OrganizationAdminUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> OrganizationRead:

--- a/app/service/person.py
+++ b/app/service/person.py
@@ -117,7 +117,7 @@ def create_one(person: PersonCreate, db: SessionDep, user_context: UserContextDe
 
 def update_one(
     db: SessionDep,
-    user_context: UserContextDep,
+    user_context: AdminContextDep,
     id_: uuid.UUID,
     json_model: PersonAdminUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> PersonRead:

--- a/app/service/person.py
+++ b/app/service/person.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import aliased, joinedload, raiseload
 
 from app.db.model import Person
-from app.dependencies.auth import AdminContextDep
+from app.dependencies.auth import AdminContextDep, UserContextDep
 from app.dependencies.common import PaginationQuery
 from app.dependencies.db import SessionDep
 from app.filters.person import PersonFilterDep
@@ -104,7 +104,7 @@ def admin_read_one(db: SessionDep, id_: uuid.UUID) -> PersonRead:
     )
 
 
-def create_one(person: PersonCreate, db: SessionDep, user_context: AdminContextDep) -> PersonRead:
+def create_one(person: PersonCreate, db: SessionDep, user_context: UserContextDep) -> PersonRead:
     return router_create_one(
         db=db,
         db_model_class=Person,
@@ -117,7 +117,7 @@ def create_one(person: PersonCreate, db: SessionDep, user_context: AdminContextD
 
 def update_one(
     db: SessionDep,
-    user_context: AdminContextDep,
+    user_context: UserContextDep,
     id_: uuid.UUID,
     json_model: PersonAdminUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> PersonRead:

--- a/tests/test_consortium.py
+++ b/tests/test_consortium.py
@@ -23,8 +23,8 @@ def json_data():
     }
 
 
-def test_create(client, client_admin, json_data):
-    response = client_admin.post(ROUTE, json=json_data)
+def test_create(client, json_data):
+    response = client.post(ROUTE, json=json_data)
     assert response.status_code == 200
     data = response.json()
     assert data["pref_label"] == json_data["pref_label"]

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -9,7 +9,6 @@ from tests.utils import (
     add_db,
     assert_request,
     check_global_delete_one,
-    check_global_read_many,
 )
 
 ROUTE = "/organization"
@@ -30,8 +29,8 @@ def _assert_read_response(data, json_data):
     assert "id" in data
 
 
-def test_create_organization(client, client_admin, json_data):
-    response = client_admin.post(
+def test_create_organization(client, json_data):
+    response = client.post(
         ROUTE,
         json=json_data,
     )
@@ -61,7 +60,7 @@ def test_create_organization(client, client_admin, json_data):
 
     for ror_id in valid_ror_ids:
         data = assert_request(
-            client_admin.post,
+            client.post,
             url=ROUTE,
             json=json_data | {"ror_id": ror_id, "pref_label": f"org-{ror_id[-4:]}"},
         ).json()
@@ -78,7 +77,7 @@ def test_create_organization(client, client_admin, json_data):
 
     for ror_id in invalid_ror_ids:
         data = assert_request(
-            client_admin.post,
+            client.post,
             url=ROUTE,
             json=json_data | {"ror_id": ror_id, "pref_label": f"org-{ror_id}"},
             expected_status_code=422,
@@ -87,12 +86,12 @@ def test_create_organization(client, client_admin, json_data):
 
     ror_id = "https://ror.org/03nawhv43"
     assert_request(
-        client_admin.post,
+        client.post,
         url=ROUTE,
         json=json_data | {"ror_id": ror_id, "pref_label": "org-ror-dup-1"},
     ).json()
     data = assert_request(
-        client_admin.post,
+        client.post,
         url=ROUTE,
         json=json_data | {"ror_id": ror_id, "pref_label": "org-ror-dup-2"},
         expected_status_code=409,
@@ -101,13 +100,39 @@ def test_create_organization(client, client_admin, json_data):
 
 
 def test_read_many(clients, json_data):
-    check_global_read_many(
-        route=ROUTE,
-        admin_route=ADMIN_ROUTE,
-        clients=clients,
-        json_data=json_data,
-        validator=_assert_read_response,
-    )
+    model_id = assert_request(clients.user_1.post, url=ROUTE, json=json_data).json()["id"]
+
+    def _req(client, client_route):
+        data = assert_request(client.get, url=client_route).json()["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(model_id)
+        _assert_read_response(data[0], json_data)
+
+    # user that created the resource can read it
+    _req(clients.user_1, ROUTE)
+
+    # but cannot use the admin endpoint
+    data = assert_request(
+        clients.user_1.get,
+        url=ADMIN_ROUTE,
+        expected_status_code=403,
+    ).json()
+    assert data["message"] == "Service admin role required"
+
+    # any other user can read it too because it is global
+    _req(clients.user_2, ROUTE)
+
+    # but cannot use the admin endpoint
+    data = assert_request(
+        clients.user_2.get,
+        url=ADMIN_ROUTE,
+        expected_status_code=403,
+    ).json()
+    assert data["message"] == "Service admin role required"
+
+    # service admins can read from both regular and admin routes
+    _req(clients.admin, ROUTE)
+    _req(clients.admin, ADMIN_ROUTE)
 
 
 def test_delete_one(db, clients, json_data):

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -5,7 +5,6 @@ import pytest
 from app.db.model import Agent, Person
 
 from tests.utils import (
-    ADMIN_SUB_ID,
     MISSING_ID,
     MISSING_ID_COMPACT,
     USER_SUB_ID_1,
@@ -34,8 +33,8 @@ def _assert_read_response(data, json_data):
     assert data["sub_id"] == ANY
 
 
-def test_create_person(client, client_admin, json_data):
-    response = client_admin.post(ROUTE, json=json_data)
+def test_create_person(client, json_data):
+    response = client.post(ROUTE, json=json_data)
     assert response.status_code == 200
     data = response.json()
     _assert_read_response(data, json_data)
@@ -62,11 +61,11 @@ def test_create_person(client, client_admin, json_data):
     assert created_from_data["id"] == id_
     assert created_from_data["sub_id"] is None
 
-    assert created_from_token["pref_label"] == "Admin User"
-    assert created_from_token["sub_id"] == str(ADMIN_SUB_ID)
+    assert created_from_token["pref_label"] == "Regular User With Project Id"
+    assert created_from_token["sub_id"] == str(USER_SUB_ID_1)
 
     # If register again only the data agent added and the token agent is reused
-    response = client_admin.post(
+    response = client.post(
         ROUTE,
         json=json_data,
     )
@@ -86,7 +85,7 @@ def test_create_person(client, client_admin, json_data):
 
     for orcid in valid_orcids:
         data = assert_request(
-            client_admin.post,
+            client.post,
             url=ROUTE,
             json=json_data | {"orcid": orcid, "pref_label": f"person-{orcid[-4:]}"},
         ).json()
@@ -102,7 +101,7 @@ def test_create_person(client, client_admin, json_data):
 
     for orcid in invalid_orcids:
         data = assert_request(
-            client_admin.post,
+            client.post,
             url=ROUTE,
             json=json_data | {"orcid": orcid, "pref_label": f"person-{orcid}"},
             expected_status_code=422,
@@ -111,12 +110,12 @@ def test_create_person(client, client_admin, json_data):
 
     orcid = "https://orcid.org/0000-0004-5678-9012"
     assert_request(
-        client_admin.post,
+        client.post,
         url=ROUTE,
         json=json_data | {"orcid": orcid, "pref_label": "person-orcid-dup-1"},
     ).json()
     data = assert_request(
-        client_admin.post,
+        client.post,
         url=ROUTE,
         json=json_data | {"orcid": orcid, "pref_label": "person-orcid-dup-2"},
         expected_status_code=409,
@@ -129,7 +128,7 @@ def test_read_many(clients, json_data):
     route = ROUTE
     admin_route = ADMIN_ROUTE
 
-    assert_request(clients.admin.post, url=route, json=json_data).json()["id"]
+    assert_request(clients.user_1.post, url=route, json=json_data).json()["id"]
 
     def _req(client, client_route):
         data = assert_request(client.get, url=client_route).json()["data"]


### PR DESCRIPTION
## Summary
- Change `AdminContextDep` to `UserContextDep` for `create_one` in Person, Organization, and Consortium services, allowing regular authenticated users to create these entities.
- Update and delete remain admin-only (`AdminContextDep`).
- Update tests to use regular user client for create operations instead of admin client.

Closes #688

> **Note:** This PR depends on #686 which needs to be merged first.

## Test plan
- [x] Verify regular users can create Person, Organization, and Consortium entities
- [x] Verify update remains restricted to admins
- [x] Verify delete remains restricted to admins (403 for regular users)
- [x] All 14 existing tests pass