### PR TITLE
Move agent rules source to AGENTS.md

### DIFF
--- a/.amazonq/rules/project.md
+++ b/.amazonq/rules/project.md
@@ -1,3 +1,5 @@
+<!-- AUTO-GENERATED from AGENTS.md — do not edit directly, run: make sync-rules -->
+
 # Entitycore — Agent Rules
 
 ## Stack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-<!-- AUTO-GENERATED from AGENTS.md — do not edit directly, run: make sync-rules -->
-
 # Entitycore — Agent Rules
 
 ## Stack

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,11 @@ extract-traces:  ## Extract response payloads generated in unit tests
 update-asset-labels:  ## Update asset-labels.md
 	uv run ./scripts/generate_asset_labels_table.py -o ./docs/asset-labels.md
 
-sync-rules:  ## Sync .amazonq/rules into CLAUDE.md
-	echo '<!-- AUTO-GENERATED from .amazonq/rules/*.md — do not edit directly, run: make sync-rules -->' > CLAUDE.md
+sync-rules:  ## Sync AGENTS.md into .amazonq/rules and CLAUDE.md
+	mkdir -p .amazonq/rules
+	echo '<!-- AUTO-GENERATED from AGENTS.md — do not edit directly, run: make sync-rules -->' > .amazonq/rules/project.md
+	echo '' >> .amazonq/rules/project.md
+	cat AGENTS.md >> .amazonq/rules/project.md
+	echo '<!-- AUTO-GENERATED from AGENTS.md — do not edit directly, run: make sync-rules -->' > CLAUDE.md
 	echo '' >> CLAUDE.md
-	cat .amazonq/rules/*.md >> CLAUDE.md
+	cat AGENTS.md >> CLAUDE.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` as the canonical source for agent rules
- Update `make sync-rules` to generate `.amazonq/rules/project.md` and `CLAUDE.md` from `AGENTS.md`
- Add auto-generated headers to both synced outputs

## Test plan
- [x] Run `make sync-rules` and verify `.amazonq/rules/project.md` and `CLAUDE.md` match `AGENTS.md` (with headers)
- [ ] Confirm Amazon Q and Claude pick up the synced rules as expected