### PR TITLE
Expose in openapi the valid values for order_by

### DIFF
--- a/app/dependencies/filter.py
+++ b/app/dependencies/filter.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, get_args, get_origin
 
@@ -10,17 +9,17 @@ from pydantic import ValidationError, create_model
 _ORDER_BY_FIELD_NAME = "order_by"
 
 
-def _order_by_schema_extra(fields: list[str]) -> Callable[[dict[str, Any]], None]:
-    """Return a json_schema_extra callable that injects all valid order_by values as enum.
+def _order_by_schema_extra(fields: list[str]) -> dict[str, Any]:
+    """Return a json_schema_extra dict that injects all valid order_by values as enum.
 
     Each field is expanded to unprefixed (ascending), `+` (ascending), and `-` (descending).
     """
-    enum = [f"{prefix}{f}" for prefix in ("", "+", "-") for f in fields]
-
-    def extra(s: dict) -> None:
-        s.update({"items": {"type": "string", "enum": enum}})
-
-    return extra
+    return {
+        "items": {
+            "type": "string",
+            "enum": [f"{p}{f}" for p in ("", "+", "-") for f in fields],
+        }
+    }
 
 
 def _prepare_filter_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any]:
@@ -41,11 +40,15 @@ def _prepare_filter_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any
             or get_origin(annotation) is list
             or any(get_origin(a) is list for a in get_args(annotation))
         ) and type(field_info.default) is not params.Query:
-            field_info.default = Query(default=field_info.default)
-            if name == _ORDER_BY_FIELD_NAME and ordering_fields:
-                # FastAPI's Query restricts json_schema_extra to dict | None, but Pydantic's
-                # underlying FieldInfo supports callables, so we assign after construction.
-                field_info.default.json_schema_extra = _order_by_schema_extra(ordering_fields)  # type: ignore[method-assign]
+            json_schema_extra = (
+                _order_by_schema_extra(ordering_fields)
+                if name == _ORDER_BY_FIELD_NAME and ordering_fields
+                else None
+            )
+            field_info.default = Query(
+                default=field_info.default,
+                json_schema_extra=json_schema_extra,
+            )
 
         fields[name] = (f.annotation, field_info)
 

--- a/app/dependencies/filter.py
+++ b/app/dependencies/filter.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, get_args, get_origin
 
@@ -6,9 +7,27 @@ from fastapi.exceptions import RequestValidationError
 from fastapi_filter.base.filter import BaseFilterModel
 from pydantic import ValidationError, create_model
 
+_ORDER_BY_FIELD_NAME = "order_by"
 
-def _list_to_query_fields(filter_model: type[BaseFilterModel]):
+
+def _order_by_schema_extra(fields: list[str]) -> Callable[[dict[str, Any]], None]:
+    """Return a json_schema_extra callable that injects all valid order_by values as enum.
+
+    Each field is expanded to unprefixed (ascending), `+` (ascending), and `-` (descending).
+    """
+    enum = [f"{prefix}{f}" for prefix in ("", "+", "-") for f in fields]
+
+    def extra(s: dict) -> None:
+        s.update({"items": {"type": "string", "enum": enum}})
+
+    return extra
+
+
+def _list_to_query_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any]:
     fields = {}
+    ordering_fields: list[str] | None = getattr(
+        getattr(filter_model, "Constants", None), "ordering_model_fields", None
+    )
     for name, f in filter_model.model_fields.items():
         field_info = deepcopy(f)
         annotation = f.annotation
@@ -18,7 +37,14 @@ def _list_to_query_fields(filter_model: type[BaseFilterModel]):
             or get_origin(annotation) is list
             or any(get_origin(a) is list for a in get_args(annotation))
         ) and type(field_info.default) is not params.Query:
-            field_info.default = Query(default=field_info.default)
+            if name == _ORDER_BY_FIELD_NAME and ordering_fields:
+                query = Query(default=field_info.default)
+                # FastAPI's Query restricts json_schema_extra to dict | None, but Pydantic's
+                # underlying FieldInfo supports callables, so we assign after construction.
+                query.json_schema_extra = _order_by_schema_extra(ordering_fields)  # type: ignore[method-assign]
+                field_info.default = query
+            else:
+                field_info.default = Query(default=field_info.default)
 
         fields[name] = (f.annotation, field_info)
 

--- a/app/dependencies/filter.py
+++ b/app/dependencies/filter.py
@@ -60,8 +60,7 @@ def FilterDepends(filter_model: type[BaseFilterModel], *, by_alias: bool = False
 
     FastAPI treats `list` fields as request body unless their default is a `Query` object.
     This builds a `GeneratedFilter` with list fields wrapped in `Query`, used by FastAPI for
-    OpenAPI schema generation and query param parsing. The actual validation and construction
-    of `filter_model` happens inside `FilterWrapper.__new__`.
+    OpenAPI schema generation and query param parsing.
     """
     fields = _prepare_filter_fields(filter_model)
     GeneratedFilter = create_model(filter_model.__class__.__name__, **fields)  # ruff:ignore[non-lowercase-variable-in-function]

--- a/app/dependencies/filter.py
+++ b/app/dependencies/filter.py
@@ -23,7 +23,11 @@ def _order_by_schema_extra(fields: list[str]) -> Callable[[dict[str, Any]], None
     return extra
 
 
-def _list_to_query_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any]:
+def _prepare_filter_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any]:
+    """Convert list fields to Query params and inject the order_by enum for OpenAPI.
+
+    Returns a field definitions dict suitable for passing to `create_model`.
+    """
     fields = {}
     ordering_fields: list[str] | None = getattr(
         getattr(filter_model, "Constants", None), "ordering_model_fields", None
@@ -37,14 +41,11 @@ def _list_to_query_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any]
             or get_origin(annotation) is list
             or any(get_origin(a) is list for a in get_args(annotation))
         ) and type(field_info.default) is not params.Query:
+            field_info.default = Query(default=field_info.default)
             if name == _ORDER_BY_FIELD_NAME and ordering_fields:
-                query = Query(default=field_info.default)
                 # FastAPI's Query restricts json_schema_extra to dict | None, but Pydantic's
                 # underlying FieldInfo supports callables, so we assign after construction.
-                query.json_schema_extra = _order_by_schema_extra(ordering_fields)  # type: ignore[method-assign]
-                field_info.default = query
-            else:
-                field_info.default = Query(default=field_info.default)
+                field_info.default.json_schema_extra = _order_by_schema_extra(ordering_fields)  # type: ignore[method-assign]
 
         fields[name] = (f.annotation, field_info)
 
@@ -52,15 +53,14 @@ def _list_to_query_fields(filter_model: type[BaseFilterModel]) -> dict[str, Any]
 
 
 def FilterDepends(filter_model: type[BaseFilterModel], *, by_alias: bool = False, **_) -> Any:
-    """Use a hack to treat lists as query parameters.
+    """Return a FastAPI dependency that parses query parameters into a filter model instance.
 
-    What we do is loop through the fields of a filter and assign any `list` field a default value of
-    `Query` so that FastAPI knows it should be treated a query parameter and not body.
-
-    When we apply the filter, we build the original filter to properly validate the data (i.e. can
-    the string be parsed and formatted as a list of <type>?)
+    FastAPI treats `list` fields as request body unless their default is a `Query` object.
+    This builds a `GeneratedFilter` with list fields wrapped in `Query`, used by FastAPI for
+    OpenAPI schema generation and query param parsing. The actual validation and construction
+    of `filter_model` happens inside `FilterWrapper.__new__`.
     """
-    fields = _list_to_query_fields(filter_model)
+    fields = _prepare_filter_fields(filter_model)
     GeneratedFilter = create_model(filter_model.__class__.__name__, **fields)  # ruff:ignore[non-lowercase-variable-in-function]
 
     class FilterWrapper(GeneratedFilter):  # type: ignore[misc,valid-type]

--- a/app/filters/base.py
+++ b/app/filters/base.py
@@ -35,7 +35,7 @@ class CustomFilter[T: DeclarativeBase](Filter):
     @field_validator("order_by", check_fields=False)
     @classmethod
     def restrict_sortable_fields(cls, value: list[str]):
-        """Restrict sorting to specific fields."""
+        """Restrict sorting to fields in Constants.ordering_model_fields, stripping +/- prefix."""
         allowed_field_names = getattr(cls.Constants, "ordering_model_fields", None)
         if not allowed_field_names:
             msg = "You cannot sort by any field"

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,6 +1,9 @@
+from unittest.mock import ANY
+
 import pytest
 import sqlalchemy as sa
 
+from app.application import app
 from app.db.model import CellMorphology, License
 from app.filters.cell_morphology import CellMorphologyFilter
 from app.filters.subject import NestedSubjectFilter
@@ -85,6 +88,29 @@ def test_cell_morphology_ordering(
     data = response.json()["data"]
     assert len(data) == count // 2
     check_sort_by_field(data, "name", how="descending")
+
+
+def test_order_by_openapi_schema():
+    """Test the full OpenAPI schema shape for order_by, including enum expansion and description."""
+    schema = app.openapi()
+    params = {p["name"]: p for p in schema["paths"]["/cell-morphology"]["get"]["parameters"]}
+
+    assert params["order_by"] == {
+        "name": "order_by",
+        "in": "query",
+        "required": False,
+        "schema": {
+            "type": "array",
+            "items": {"type": "string", "enum": ANY},
+            "default": ["-creation_date"],
+            "title": "Order By",
+        },
+    }
+    assert params["order_by"]["schema"]["items"]["enum"] == [
+        f"{prefix}{f}"
+        for prefix in ("", "+", "-")
+        for f in CellMorphologyFilter.Constants.ordering_model_fields
+    ]
 
 
 def test_sort_unsupported_nested_ordering_part():


### PR DESCRIPTION
Expose in openapi the valid values for order_by.

Fixes https://github.com/openbraininstitute/entitycore/issues/411 without changing the models defined for fastapi-filter.

The resulting openapi contains for example:
```json
          {
            "name": "order_by",
            "in": "query",
            "required": false,
            "schema": {
              "type": "array",
              "items": {
                "type": "string",
                "enum": [
                  "creation_date",
                  "update_date",
                  "+creation_date",
                  "+update_date",
                  "-creation_date",
                  "-update_date"
                ]
              },
              "default": [
                "-creation_date"
              ],
              "title": "Order By"
            }
          },
```

or the order of the values can be changed if clearer for human and/or LLM:
```json
          {
            "name": "order_by",
            "in": "query",
            "required": false,
            "schema": {
              "type": "array",
              "items": {
                "type": "string",
                "enum": [
                  "creation_date",
                  "+creation_date",
                  "-creation_date",
                  "update_date",
                  "+update_date",
                  "-update_date"
                ]
              },
              "default": [
                "-creation_date"
              ],
              "title": "Order By"
            }
          }
```

Alternatively, it can be discussed to expose only the unique values without +/- prefix.
In this way the list is shorter, but the schema cannot be used as is for validation, and the default value is not consistent with the values.

```json
          {
            "name": "order_by",
            "in": "query",
            "required": false,
            "schema": {
              "type": "array",
              "items": {
                "type": "string",
                "enum": [
                  "creation_date",
                  "update_date"
                ]
              },
              "default": [
                "-creation_date"
              ],
              "title": "Order By"
            }
          },
```

cc @jankrepl @bilalesi 