### PR TITLE
Analysis Notebook Template unique name per project

### DIFF
--- a/app/service/analysis_notebook_template.py
+++ b/app/service/analysis_notebook_template.py
@@ -1,18 +1,21 @@
 import uuid
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy.orm import aliased, joinedload, raiseload, selectinload
+from sqlalchemy.orm import Session, aliased, joinedload, raiseload, selectinload
 
 from app.db.model import (
     Agent,
     AnalysisNotebookTemplate,
     Contribution,
+    Entity,
     PlatformUser,
 )
 from app.dependencies.auth import AdminContextDep, UserContextDep, UserContextWithProjectIdDep
 from app.dependencies.common import ExpandDep, FacetsDep, PaginationQuery, SearchDep
 from app.dependencies.db import SessionDep
+from app.errors import ApiError, ApiErrorCode
 from app.filters.analysis_notebook_template import AnalysisNotebookTemplateFilterDep
 from app.queries.common import (
     router_create_one,
@@ -34,6 +37,24 @@ from app.schemas.types import ListResponse
 
 if TYPE_CHECKING:
     from app.filters.base import Aliases
+
+
+def _check_unique_name(
+    db: Session, name: str, project_id: uuid.UUID, exclude_id: uuid.UUID | None = None
+) -> None:
+    query = sa.select(AnalysisNotebookTemplate.id).where(
+        AnalysisNotebookTemplate.name == name,
+        Entity.authorized_project_id == project_id,
+        AnalysisNotebookTemplate.id == Entity.id,
+    )
+    if exclude_id is not None:
+        query = query.where(AnalysisNotebookTemplate.id != exclude_id)
+    if db.execute(query).first() is not None:
+        raise ApiError(
+            message="AnalysisNotebookTemplate already exists or breaks unique constraints",
+            error_code=ApiErrorCode.ENTITY_DUPLICATED,
+            http_status_code=HTTPStatus.CONFLICT,
+        )
 
 
 def _load(query: sa.Select):
@@ -85,6 +106,7 @@ def create_one(
     json_model: AnalysisNotebookTemplateCreate,
     user_context: UserContextWithProjectIdDep,
 ) -> AnalysisNotebookTemplateRead:
+    _check_unique_name(db, json_model.name, user_context.project_id)
     return router_create_one(
         db=db,
         json_model=json_model,
@@ -101,6 +123,8 @@ def update_one(
     id_: uuid.UUID,
     json_model: AnalysisNotebookTemplateUpdate,  # pyright: ignore [reportInvalidTypeForm]
 ) -> AnalysisNotebookTemplateRead:
+    if json_model.name is not None and user_context.project_id is not None:
+        _check_unique_name(db, json_model.name, user_context.project_id, exclude_id=id_)
     return router_update_one(
         id_=id_,
         db=db,

--- a/tests/test_analysis_notebook_template.py
+++ b/tests/test_analysis_notebook_template.py
@@ -65,10 +65,8 @@ def test_update_one(clients, json_data):
         admin_route=ADMIN_ROUTE,
         clients=clients,
         json_data=json_data,
-        patch_payload={
-            "name": "name",
-            "description": "description",
-        },
+        private_json_data=json_data | {"name": "other name"},
+        patch_payload={"description": "new description"},
         optional_payload=None,
     )
 

--- a/tests/test_analysis_notebook_template.py
+++ b/tests/test_analysis_notebook_template.py
@@ -2,6 +2,7 @@ import pytest
 
 from app.db.model import AnalysisNotebookTemplate
 from app.db.types import EntityType
+from app.errors import ApiErrorCode
 
 from .utils import (
     assert_request,
@@ -72,9 +73,34 @@ def test_update_one(clients, json_data):
     )
 
 
+def test_update_one_duplicate_name_same_project_fails(client, json_data):
+    assert_request(client.post, url=ROUTE, json=json_data)
+    id_2 = assert_request(client.post, url=ROUTE, json=json_data | {"name": "other name"}).json()[
+        "id"
+    ]
+    data = assert_request(
+        client.patch,
+        url=f"{ROUTE}/{id_2}",
+        json={"name": json_data["name"]},
+        expected_status_code=409,
+    ).json()
+    assert data["error_code"] == ApiErrorCode.ENTITY_DUPLICATED
+
+
 def test_create_one(client, json_data):
     data = assert_request(client.post, url=ROUTE, json=json_data).json()
     _assert_read_response(data, json_data)
+
+
+def test_create_one_duplicate_name_same_project_fails(client, json_data):
+    assert_request(client.post, url=ROUTE, json=json_data)
+    data = assert_request(client.post, url=ROUTE, json=json_data, expected_status_code=409).json()
+    assert data["error_code"] == ApiErrorCode.ENTITY_DUPLICATED
+
+
+def test_create_one_duplicate_name_different_project_succeeds(clients, json_data):
+    assert_request(clients.user_1.post, url=ROUTE, json=json_data)
+    assert_request(clients.user_2.post, url=ROUTE, json=json_data)
 
 
 def test_user_read_one(client, model, json_data):

--- a/tests/test_analysis_notebook_template.py
+++ b/tests/test_analysis_notebook_template.py
@@ -71,7 +71,11 @@ def test_update_one(clients, json_data):
     )
 
 
-def test_update_one_duplicate_name_same_project_fails(client, json_data):
+def test_update_one_name_succeeds(client, json_data):
+    id_ = assert_request(client.post, url=ROUTE, json=json_data).json()["id"]
+    data = assert_request(client.patch, url=f"{ROUTE}/{id_}", json={"name": "new name"}).json()
+    assert data["name"] == "new name"
+
     assert_request(client.post, url=ROUTE, json=json_data)
     id_2 = assert_request(client.post, url=ROUTE, json=json_data | {"name": "other name"}).json()[
         "id"


### PR DESCRIPTION
Enforce that two `AnalysisNotebookTemplate` entities within the same project cannot share the same name.

For the Courses feature, each course has a master project and a synchronization mechanism. When a notebook is patched or deleted in the master project, the same operation is applied to the notebook with the same name in all child projects.

The initial suggestion was to use a derivation link from each child notebook to its corresponding master notebook. However, this is not possible because the notebooks are private entities belonging to different projects within the same virtual lab.

Instead, notebooks are matched by name. This requires notebook names to be unique within each project. Uniqueness is currently enforced only by the frontend, so backend validation is being added to enforce this constraint.

See original discussion here: https://github.com/openbraininstitute/prod-launch-notebook/issues/55#issuecomment-4622228788

**No database constraint**
`name` and `authorized_project_id` live in different tables (joined-table inheritance), so a DB-level unique constraint across them is not possible without denormalizing the schema.

## Changes

- `app/service/analysis_notebook_template.py`: `_check_unique_name` called in `create_one` and `update_one`, returns `409 ENTITY_DUPLICATED` on conflict.
- `tests/test_analysis_notebook_template.py`: tests for same-project conflict (create + update), cross-project allowed, and successful rename.
